### PR TITLE
refactor(portfolio): deduplicate and consolidate repeated idioms across the codebase

### DIFF
--- a/build/_csvout.py
+++ b/build/_csvout.py
@@ -16,3 +16,11 @@ def write_csv(path, fieldnames, rows, extrasaction="raise"):
         w = csv.DictWriter(fh, fieldnames=fieldnames, extrasaction=extrasaction)
         w.writeheader()
         w.writerows(rows)
+
+
+def write_rows(path, header, rows):
+    """Write list `rows` to `path` as a CSV led by a `header` row (csv.writer)."""
+    with open(path, "w", newline="") as fh:
+        w = csv.writer(fh)
+        w.writerow(header)
+        w.writerows(rows)

--- a/build/_csvout.py
+++ b/build/_csvout.py
@@ -1,0 +1,18 @@
+"""Shared CSV output helper for the build/ data-prep scripts.
+
+Sibling scripts run with their own directory as sys.path[0] (see build/_pdf.py),
+so `from _csv import write_csv` resolves in all Makefile invocation modes.
+"""
+import csv
+
+
+def write_csv(path, fieldnames, rows, extrasaction="raise"):
+    """Write dict `rows` to `path` as a CSV with a header row.
+
+    `extrasaction="ignore"` drops dict keys not in `fieldnames` (passed through
+    to csv.DictWriter).
+    """
+    with open(path, "w", newline="") as fh:
+        w = csv.DictWriter(fh, fieldnames=fieldnames, extrasaction=extrasaction)
+        w.writeheader()
+        w.writerows(rows)

--- a/build/_dates.py
+++ b/build/_dates.py
@@ -1,0 +1,19 @@
+"""Shared date parsing for the build/ statement scripts.
+
+try_date(s, formats) is the common "try each strptime format, first that parses
+wins, else None" loop that every statement parser reimplemented inline. Callers
+keep their own pre-processing (Excel-serial checks, line splitting) and decide
+the output shape (date object vs .isoformat(), None vs raw-string fallback).
+"""
+from datetime import datetime
+
+
+def try_date(s, formats):
+    """Return the date parsed by the first matching format in `formats`, else None."""
+    s = (s or "").strip()
+    for fmt in formats:
+        try:
+            return datetime.strptime(s, fmt).date()
+        except ValueError:
+            pass
+    return None

--- a/build/_ledgercommon.py
+++ b/build/_ledgercommon.py
@@ -1,0 +1,14 @@
+"""Shared ledger conventions used by build_ledger.py and build_viewer.py."""
+
+# Holdings.md label -> canonical SGX/exchange code used in transaction data.
+# CWBU->SET: SGX counter renamed (Cromwell->Stoneweg).
+ALIAS = {"QAF": "Q01", "CWBU": "SET", "C": "C52"}
+
+
+def canon(t):
+    return ALIAS.get(t, t)
+
+
+# transfer-leg action predicates (both underscore and space spellings occur)
+def is_transfer_out(a): return "transfer_out" in a or "transfer out" in a
+def is_transfer_in(a):  return "transfer in" in a or a == "transfer_in"

--- a/build/_pdf.py
+++ b/build/_pdf.py
@@ -1,0 +1,9 @@
+"""Shared PDF text extraction for the statement parsers."""
+import subprocess
+
+
+def raw_text(path):
+    """Return the layout-preserving text of a PDF via poppler's pdftotext."""
+    return subprocess.run(
+        ["pdftotext", "-layout", path, "-"], capture_output=True, text=True
+    ).stdout

--- a/build/build_ledger.py
+++ b/build/build_ledger.py
@@ -13,6 +13,7 @@ import csv, glob, os, re
 from collections import defaultdict
 from datetime import datetime
 from _csvout import write_csv
+from _ledgercommon import canon, is_transfer_in, is_transfer_out
 
 DATA = os.path.join(os.path.dirname(__file__), "..", "data")
 ROOT = os.path.join(os.path.dirname(__file__), "..")
@@ -27,11 +28,6 @@ def num(s):
     try: v = float(s)
     except ValueError: return 0.0
     return -v if neg else v
-
-# Holdings.md label  ->  canonical SGX/exchange code used in transaction data
-ALIAS = {"QAF": "Q01", "CWBU": "SET", "C": "C52"}  # CWBU->SET: SGX counter renamed (Cromwell->Stoneweg)
-def canon(t):
-    return ALIAS.get(t, t)
 
 def norm_ticker(sym, market):
     if not sym: return ""
@@ -49,10 +45,6 @@ def parse_date(s):
         try: return datetime.strptime(s, fmt).date().isoformat()
         except ValueError: pass
     return s  # leave raw if unknown
-
-# transfer-leg action predicates (both underscore and space spellings occur)
-def is_transfer_out(a): return "transfer_out" in a or "transfer out" in a
-def is_transfer_in(a):  return "transfer in" in a or a == "transfer_in"
 
 LEDGER = []
 MARKET_CCY = {"SG": "SGD", "US": "USD", "HK": "HKD", "MY": "MYR"}

--- a/build/build_ledger.py
+++ b/build/build_ledger.py
@@ -12,6 +12,7 @@ Normalized row schema:
 import csv, glob, os, re
 from collections import defaultdict
 from datetime import datetime
+from _csvout import write_csv
 
 DATA = os.path.join(os.path.dirname(__file__), "..", "data")
 ROOT = os.path.join(os.path.dirname(__file__), "..")
@@ -328,10 +329,7 @@ LEDGER.sort(key=lambda r: (str(r["date"]), r["account"], r["ticker"]))
 cols = ["date","account","market","ticker","asset_type","action","qty_signed",
         "price","amount","currency","fees","source","raw"]
 out = os.path.join(os.path.dirname(__file__), "ledger.csv")
-with open(out, "w", newline="") as fh:
-    w = csv.DictWriter(fh, fieldnames=cols, extrasaction="ignore")
-    w.writeheader()
-    for r in LEDGER: w.writerow(r)
+write_csv(out, cols, LEDGER, extrasaction="ignore")
 print(f"ledger rows: {len(LEDGER)} -> {out}")
 
 # coverage / file inventory

--- a/build/build_ledger.py
+++ b/build/build_ledger.py
@@ -11,8 +11,8 @@ Normalized row schema:
 """
 import csv, glob, os, re
 from collections import defaultdict
-from datetime import datetime
 from _csvout import write_csv
+from _dates import try_date
 from _ledgercommon import canon, is_transfer_in, is_transfer_out
 
 DATA = os.path.join(os.path.dirname(__file__), "..", "data")
@@ -41,10 +41,8 @@ def norm_ticker(sym, market):
 
 def parse_date(s):
     s = (s or "").strip().split("\n")[0].split(",")[0].strip()
-    for fmt in ("%Y-%m-%d", "%d-%b-%y", "%d %b %Y", "%d/%m/%Y", "%Y%m%d"):
-        try: return datetime.strptime(s, fmt).date().isoformat()
-        except ValueError: pass
-    return s  # leave raw if unknown
+    d = try_date(s, ("%Y-%m-%d", "%d-%b-%y", "%d %b %Y", "%d/%m/%Y", "%Y%m%d"))
+    return d.isoformat() if d else s  # leave raw if unknown
 
 LEDGER = []
 MARKET_CCY = {"SG": "SGD", "US": "USD", "HK": "HKD", "MY": "MYR"}

--- a/build/build_ledger.py
+++ b/build/build_ledger.py
@@ -50,6 +50,10 @@ def parse_date(s):
         except ValueError: pass
     return s  # leave raw if unknown
 
+# transfer-leg action predicates (both underscore and space spellings occur)
+def is_transfer_out(a): return "transfer_out" in a or "transfer out" in a
+def is_transfer_in(a):  return "transfer in" in a or a == "transfer_in"
+
 LEDGER = []
 MARKET_CCY = {"SG": "SGD", "US": "USD", "HK": "HKD", "MY": "MYR"}
 def add(**k):
@@ -277,8 +281,7 @@ def synthesize_transfer_ins():
     for r in LEDGER:
         if r["asset_type"] in ("stock", "fund") and r["ticker"]:
             net[(r["account"], canon(r["ticker"]))] += float(r["qty_signed"] or 0)
-    def is_out(a): return "transfer_out" in a or "transfer out" in a
-    outs = [r for r in LEDGER if r["asset_type"] == "stock" and r["ticker"] and is_out(r["action"])]
+    outs = [r for r in LEDGER if r["asset_type"] == "stock" and r["ticker"] and is_transfer_out(r["action"])]
     used = [False] * len(outs)
     for (acct, tk), q in sorted(net.items()):
         if q >= -1e-6 or acct not in REAL_ACCTS:
@@ -303,12 +306,10 @@ def reconcile_transfer_amounts():
     disagrees with the sending record's cost basis. Carry cost basis across so both
     legs show the same amount. Stock legs only — FX cash transfers (no ticker) are
     genuine currency conversions and keep their differing amounts."""
-    def is_in(a):  return "transfer in" in a or a == "transfer_in"
-    def is_out(a): return "transfer_out" in a or "transfer out" in a
     outs = [r for r in LEDGER if r["asset_type"] == "stock" and r["ticker"]
-            and is_out(r["action"]) and str(r["amount"]).strip()]
+            and is_transfer_out(r["action"]) and str(r["amount"]).strip()]
     for i in LEDGER:
-        if not (i["asset_type"] == "stock" and i["ticker"] and is_in(i["action"])):
+        if not (i["asset_type"] == "stock" and i["ticker"] and is_transfer_in(i["action"])):
             continue
         qi = abs(float(i["qty_signed"] or 0))
         m = next((o for o in outs

--- a/build/build_ledger.py
+++ b/build/build_ledger.py
@@ -9,7 +9,7 @@ Normalized row schema:
   date, account, market, ticker, asset_type, action, qty_signed,
   price, amount, currency, fees, source, raw
 """
-import csv, glob, os, re, sys
+import csv, glob, os, re
 from collections import defaultdict
 from datetime import datetime
 

--- a/build/build_ledger.py
+++ b/build/build_ledger.py
@@ -213,17 +213,6 @@ def load_fsm():
             currency=(r.get("Product Currency") or "").strip(),
             source="fsm/ifast_historical.csv", raw=pn)
 
-# ---------- IBKR (legacy, NAV/MTM only — no trades) ----------
-def load_ibkr_positions():
-    """IBKR yearly files hold no Trades; capture MTM position rows for context."""
-    out = []
-    for f in sorted(glob.glob(os.path.join(DATA, "ibkr/*.csv"))):
-        yr = re.search(r"(\d{4})", f).group(1)
-        for row in csv.reader(open(f, encoding="utf-8-sig")):
-            if row and row[0] == "Mark-to-Market Performance Summary" and len(row) > 3 and row[2] == "Data":
-                out.append((yr, row))
-    return out
-
 # ---------- Moomoo (from parse_moomoo.py snapshot-diff) ----------
 def load_moomoo():
     p = os.path.join(os.path.dirname(__file__), "moomoo_events.csv")

--- a/build/build_viewer.py
+++ b/build/build_viewer.py
@@ -7,6 +7,7 @@ a filterable transaction table + reconciliation badges. No server needed.
 """
 import csv, json, os, re
 from collections import defaultdict
+from _ledgercommon import canon, is_transfer_in as is_in, is_transfer_out as is_out
 
 HTML_TEMPLATE = r"""<!doctype html>
 <html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
@@ -107,9 +108,6 @@ renderSide();
 
 HERE = os.path.dirname(__file__)
 ROOT = os.path.join(HERE, "..")
-
-ALIAS = {"QAF": "Q01", "CWBU": "SET", "C": "C52"}  # CWBU->SET: SGX counter renamed (Cromwell->Stoneweg)
-def canon(t): return ALIAS.get(t, t)
 
 # ---- canonical code -> display name (from symbols.csv) ----
 DROP = ("Cash Dividend", "Scrip Dividend", "Cash in Lieu", "NRO")
@@ -215,9 +213,6 @@ btarget = defaultdict(float)
 for (acct, tk), q in hold.items():
     bk = BUCKET.get(acct)
     if bk: btarget[(bk, tk)] += q
-
-def is_in(a):  return "transfer in" in a or a == "transfer_in"
-def is_out(a): return "transfer_out" in a or "transfer out" in a
 
 def net_transfers(evs):
     """An inter-broker custody move within a bucket gets logged on both sides and

--- a/build/classify_cash.py
+++ b/build/classify_cash.py
@@ -123,6 +123,21 @@ def _apply_correction(o, target):
     return o
 
 
+def _assign_spend_category(o, r, hay, og, ol, groups, unmatched):
+    """Set category/subcategory on a spend row: a manual override (og/ol) wins, else the
+    keyword category from categories.yaml, else Uncategorized (recording the merchant in
+    `unmatched` for the LLM fallback report)."""
+    if og:
+        o["category"], o["subcategory"] = og, ol or ""
+        return
+    group, leaf = category_for(hay, groups)
+    if group:
+        o["category"], o["subcategory"] = group, leaf
+    else:
+        o["category"], o["subcategory"] = "Uncategorized", ""
+        unmatched[r["merchant"][:60]] = unmatched.get(r["merchant"][:60], 0) + 1
+
+
 def classify(rows, cats, excl, overrides, oexcl, corrections=None):
     corrections = corrections or {}
     groups = cats.get("groups", {})
@@ -145,15 +160,8 @@ def classify(rows, cats, excl, overrides, oexcl, corrections=None):
             if og == "EXCLUDE":
                 o["is_spend"] = "false"
                 o["exclude_reason"], o["category"], o["subcategory"] = "manual", "Excluded", "manual"
-            elif og:
-                o["category"], o["subcategory"] = og, ol or ""
             else:
-                group, leaf = category_for(hay, groups)
-                if group:
-                    o["category"], o["subcategory"] = group, leaf
-                else:
-                    o["category"], o["subcategory"] = "Uncategorized", ""
-                    unmatched[r["merchant"][:60]] = unmatched.get(r["merchant"][:60], 0) + 1
+                _assign_spend_category(o, r, hay, og, ol, groups, unmatched)
             out.append(o)
             continue
         if amt >= 0:  # inflow
@@ -182,15 +190,7 @@ def classify(rows, cats, excl, overrides, oexcl, corrections=None):
             out.append(o)
             continue
         o["is_spend"] = "true"
-        if og:
-            o["category"], o["subcategory"] = og, ol or ""
-        else:
-            group, leaf = category_for(hay, groups)
-            if group:
-                o["category"], o["subcategory"] = group, leaf
-            else:
-                o["category"], o["subcategory"] = "Uncategorized", ""
-                unmatched[r["merchant"][:60]] = unmatched.get(r["merchant"][:60], 0) + 1
+        _assign_spend_category(o, r, hay, og, ol, groups, unmatched)
         out.append(o)
     return out, unmatched
 

--- a/build/classify_cash.py
+++ b/build/classify_cash.py
@@ -23,6 +23,7 @@ import os
 import yaml
 
 from _csvout import write_csv
+from _dates import try_date
 
 ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 RAW = os.path.join(ROOT, "build", "cash_ledger_raw.csv")
@@ -87,14 +88,8 @@ def override_for(merchant, overrides, oexcl):
 
 def _iso(s):
     """Spreadsheet apps rewrite ISO dates to D/M/YY on save — normalise back to ISO."""
-    import datetime as _dt
-    s = (s or "").strip()
-    for f in ("%Y-%m-%d", "%d/%m/%y", "%d/%m/%Y"):
-        try:
-            return _dt.datetime.strptime(s, f).date().isoformat()
-        except ValueError:
-            pass
-    return s
+    d = try_date(s, ("%Y-%m-%d", "%d/%m/%y", "%d/%m/%Y"))
+    return d.isoformat() if d else (s or "").strip()
 
 
 def load_record_corrections():

--- a/build/classify_cash.py
+++ b/build/classify_cash.py
@@ -22,6 +22,8 @@ import os
 
 import yaml
 
+from _csvout import write_csv
+
 ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 RAW = os.path.join(ROOT, "build", "cash_ledger_raw.csv")
 OUT = os.path.join(ROOT, "build", "cash_ledger.csv")
@@ -218,10 +220,7 @@ def main():
     watchlist = _load(WATCHLIST, {}) or {}
     corrections = load_record_corrections()
     out, unmatched = classify(rows, cats, excl, overrides, oexcl, corrections)
-    with open(OUT, "w", newline="") as f:
-        w = csv.DictWriter(f, fieldnames=OUT_COLS)
-        w.writeheader()
-        w.writerows(out)
+    write_csv(OUT, OUT_COLS, out)
 
     for d, amt, m, note in watch_alerts(out, watchlist):
         print(f"  ⚠ WATCH {d}  S${amt:,.2f}  {m}  — {note}")

--- a/build/export_dividends_master.py
+++ b/build/export_dividends_master.py
@@ -25,7 +25,10 @@ import os
 
 from sqlalchemy import text
 
-from _csvout import write_csv
+try:
+    from _csvout import write_csv          # script mode: build/ is sys.path[0]
+except ModuleNotFoundError:
+    from build._csvout import write_csv     # package mode: imported as build.export_...
 
 from portfolio.db import SessionLocal
 

--- a/build/export_dividends_master.py
+++ b/build/export_dividends_master.py
@@ -25,6 +25,8 @@ import os
 
 from sqlalchemy import text
 
+from _csvout import write_csv
+
 from portfolio.db import SessionLocal
 
 OUT = os.path.join(os.path.dirname(os.path.dirname(__file__)), "data", "dividends-master.csv")
@@ -117,10 +119,7 @@ def main():
     withex = sum(1 for x in out if x["ex_date"])
     assert_no_ex_date_loss(OUT, withex)
 
-    with open(OUT, "w", newline="") as fh:
-        w = csv.DictWriter(fh, fieldnames=COLS)
-        w.writeheader()
-        w.writerows(out)
+    write_csv(OUT, COLS, out)
     tickers = len({x["ticker"] for x in out})
     print(f"dividend-rate master: {len(out)} rows, {tickers} tickers, {withex} with ex_date -> {OUT}")
 

--- a/build/fetch_cpf_srs_dividends.py
+++ b/build/fetch_cpf_srs_dividends.py
@@ -25,6 +25,7 @@ import csv, os, re, time, json, urllib.request, urllib.parse, datetime as dt
 from collections import defaultdict
 
 from _csvout import write_csv
+from _dates import try_date
 
 HERE = os.path.dirname(__file__)
 ROOT = os.path.join(HERE, "..")
@@ -55,12 +56,7 @@ def epoch_date(ms):
 
 
 def pdate(s):
-    for f in ("%Y-%m-%d", "%d-%b-%y", "%d %b %Y", "%d/%m/%Y", "%Y-%m"):
-        try:
-            return dt.datetime.strptime((s or "").strip(), f).date()
-        except ValueError:
-            pass
-    return None
+    return try_date(s, ("%Y-%m-%d", "%d-%b-%y", "%d %b %Y", "%d/%m/%Y", "%Y-%m"))
 
 
 def nearest(d, pool, days):

--- a/build/fetch_cpf_srs_dividends.py
+++ b/build/fetch_cpf_srs_dividends.py
@@ -24,6 +24,8 @@ SGX supplies the authoritative currency per distribution (e.g. IREIT switched SG
 import csv, os, re, time, json, urllib.request, urllib.parse, datetime as dt
 from collections import defaultdict
 
+from _csvout import write_csv
+
 HERE = os.path.dirname(__file__)
 ROOT = os.path.join(HERE, "..")
 DATA = os.path.join(ROOT, "data")
@@ -224,11 +226,7 @@ def main():
                 ))
     rows.sort(key=lambda r: (r["account"], r["ticker"], r["date"]))
     cols = ["date", "account", "market", "ticker", "name", "kind", "gross", "units", "rate", "currency", "source"]
-    with open(OUT, "w", newline="") as fh:
-        w = csv.DictWriter(fh, fieldnames=cols)
-        w.writeheader()
-        for r in rows:
-            w.writerow(r)
+    write_csv(OUT, cols, rows)
     print(f"{len(rows)} CPF/SRS dividend rows -> {OUT}")
     tot, bysrc = defaultdict(lambda: defaultdict(float)), defaultdict(int)
     for r in rows:

--- a/build/parse_cash.py
+++ b/build/parse_cash.py
@@ -26,6 +26,7 @@ import unicodedata
 
 from _pdf import raw_text
 from _csvout import write_csv
+from _dates import try_date
 
 ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 OUT = os.path.join(ROOT, "build", "cash_ledger_raw.csv")
@@ -55,12 +56,7 @@ def _num(s):
 
 
 def _pdate(s):
-    for f in ("%d %b %Y", "%Y-%m-%d", "%d/%m/%Y"):
-        try:
-            return dt.datetime.strptime((s or "").strip(), f).date()
-        except ValueError:
-            pass
-    return None
+    return try_date(s, ("%d %b %Y", "%Y-%m-%d", "%d/%m/%Y"))
 
 
 def pdftext(path):

--- a/build/parse_cash.py
+++ b/build/parse_cash.py
@@ -22,8 +22,9 @@ import datetime as dt
 import glob
 import os
 import re
-import subprocess
 import unicodedata
+
+from _pdf import raw_text
 
 ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 OUT = os.path.join(ROOT, "build", "cash_ledger_raw.csv")
@@ -62,10 +63,8 @@ def _pdate(s):
 
 
 def pdftext(path):
-    out = subprocess.run(["pdftotext", "-layout", path, "-"],
-                         capture_output=True, text=True).stdout
     # NFKC folds typographic ligatures (Netﬂix -> Netflix) so keyword matching works
-    return unicodedata.normalize("NFKC", out)
+    return unicodedata.normalize("NFKC", raw_text(path))
 
 
 def row(**kw):

--- a/build/parse_cash.py
+++ b/build/parse_cash.py
@@ -25,6 +25,7 @@ import re
 import unicodedata
 
 from _pdf import raw_text
+from _csvout import write_csv
 
 ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 OUT = os.path.join(ROOT, "build", "cash_ledger_raw.csv")
@@ -375,10 +376,7 @@ def main():
     rows = [r for r in rows if not _is_suppressed_cc_bill(r, windows)]
     rows = [r for r in rows if r["txn_date"] >= START.isoformat()]
     rows.sort(key=lambda r: (r["txn_date"], r["source"]))
-    with open(OUT, "w", newline="") as f:
-        w = csv.DictWriter(f, fieldnames=COLS)
-        w.writeheader()
-        w.writerows(rows)
+    write_csv(OUT, COLS, rows)
     by_src = {}
     for r in rows:
         by_src[r["source"]] = by_src.get(r["source"], 0) + 1

--- a/build/parse_cdp.py
+++ b/build/parse_cdp.py
@@ -7,7 +7,9 @@ CDP statements are the authoritative custody record (no fees). Two layouts:
 Both have a NAME then Free, (NIL|qty), Balance, price, mktval. Snapshot-diff the
 Balance per security across months to recover every buy/sell/transfer.
 """
-import glob, os, re, subprocess, csv
+import glob, os, re, csv
+
+from _pdf import raw_text
 
 DATA = os.path.join(os.path.dirname(__file__), "..", "data", "cdp-statements")
 
@@ -38,7 +40,7 @@ def f(s): return float(s.replace(",", ""))
 def parse(path):
     mo = re.search(r"(\d{6})", path).group(1)
     ym = f"{mo[:4]}-{mo[4:]}"
-    txt = subprocess.run(["pdftotext", "-layout", path, "-"], capture_output=True, text=True).stdout
+    txt = raw_text(path)
     out = {}
     inhold = False
     for ln in txt.splitlines():

--- a/build/parse_cdp.py
+++ b/build/parse_cdp.py
@@ -7,9 +7,10 @@ CDP statements are the authoritative custody record (no fees). Two layouts:
 Both have a NAME then Free, (NIL|qty), Balance, price, mktval. Snapshot-diff the
 Balance per security across months to recover every buy/sell/transfer.
 """
-import glob, os, re, csv
+import glob, os, re
 
 from _pdf import raw_text
+from _csvout import write_rows
 
 DATA = os.path.join(os.path.dirname(__file__), "..", "data", "cdp-statements")
 
@@ -100,10 +101,8 @@ def main():
         h, v = HOLD.get(c), snaps[last].get(c)
         print(f"  {c:8} statement={v!s:>8}  Holdings={h}  {'OK' if h==v else ('—' if h is None else 'CHECK')}")
     out = os.path.join(os.path.dirname(__file__), "cdp_events.csv")
-    with open(out, "w", newline="") as fh:
-        w = csv.writer(fh); w.writerow(["date","name","code","action","qty_signed"])
-        for mo, c, act, q in ev:
-            w.writerow([mo + "-28", label.get(c, ""), c, act, q])
+    write_rows(out, ["date", "name", "code", "action", "qty_signed"],
+               [[mo + "-28", label.get(c, ""), c, act, q] for mo, c, act, q in ev])
     print(f"\nwrote {out}")
 
 if __name__ == "__main__":

--- a/build/parse_dividends.py
+++ b/build/parse_dividends.py
@@ -10,8 +10,10 @@ Endowus Amundi fund is accumulating -> no distributions.
 
 Schema: date, account, market, ticker, name, kind, gross, currency, source
 """
-import csv, glob, os, re, subprocess
+import csv, glob, os, re
 from collections import defaultdict
+
+from _pdf import raw_text
 
 HERE = os.path.dirname(__file__)
 DATA = os.path.join(HERE, "..", "data")
@@ -168,7 +170,7 @@ def moomoo():
     rx = re.compile(r"([A-Z0-9]{2,6})\s+CASH DIVIDEND\s+@\s+([A-Z]{3})\s*([\d.]+)?")
     for f in sorted(glob.glob(os.path.join(DATA, "moomoo/moomoo_*.pdf"))):
         mo = re.search(r"(\d{6})", f).group(1); ym = f"{mo[:4]}-{mo[4:]}"
-        txt = subprocess.run(["pdftotext", "-layout", f, "-"], capture_output=True, text=True).stdout
+        txt = raw_text(f)
         lines = txt.splitlines()
         for i, ln in enumerate(lines):
             m = rx.search(ln)

--- a/build/parse_dividends.py
+++ b/build/parse_dividends.py
@@ -15,6 +15,7 @@ from collections import defaultdict
 
 from _pdf import raw_text
 from _csvout import write_csv
+from _dates import try_date
 
 HERE = os.path.dirname(__file__)
 DATA = os.path.join(HERE, "..", "data")
@@ -116,12 +117,8 @@ def _cdp_date(d):
     d = (d or "").strip()
     if re.fullmatch(r"\d{4,6}", d):                       # Excel serial
         return (_XL_EPOCH + _dt.timedelta(days=int(d))).isoformat()
-    for f in ("%Y-%m-%d", "%d-%b-%y", "%d %b %Y", "%d-%b-%Y", "%d/%m/%Y"):
-        try:
-            return _dt.datetime.strptime(d, f).date().isoformat()
-        except ValueError:
-            pass
-    return None
+    dd = try_date(d, ("%Y-%m-%d", "%d-%b-%y", "%d %b %Y", "%d-%b-%Y", "%d/%m/%Y"))
+    return dd.isoformat() if dd else None
 
 def cdp():
     """CDP cash dividends from the maintained tracker. The sheet is broader than CDP —

--- a/build/parse_dividends.py
+++ b/build/parse_dividends.py
@@ -14,6 +14,7 @@ import csv, glob, os, re
 from collections import defaultdict
 
 from _pdf import raw_text
+from _csvout import write_csv
 
 HERE = os.path.dirname(__file__)
 DATA = os.path.join(HERE, "..", "data")
@@ -239,9 +240,7 @@ def apply_corrections():
 tiger(); fsm(); moomoo(); cpf_srs(); cdp(); apply_corrections()   # cdp() last: dedups vs the rest
 out = os.path.join(HERE, "dividends.csv")
 cols = ["date", "account", "market", "ticker", "name", "kind", "gross", "units", "rate", "currency", "source"]
-with open(out, "w", newline="") as fh:
-    w = csv.DictWriter(fh, fieldnames=cols, extrasaction="ignore"); w.writeheader()
-    for d in DIV: w.writerow(d)
+write_csv(out, cols, DIV, extrasaction="ignore")
 
 # ---------- summary ----------
 by_ccy = defaultdict(lambda: defaultdict(float))

--- a/build/parse_endowus.py
+++ b/build/parse_endowus.py
@@ -20,10 +20,11 @@ price/amount: it is internal, not new capital. Its cost carries from the predece
 the `switch` corporate_action (see performance.py / seed.py), so booking it here would
 double-count. Infinity itself stays in cpf-stocks/transactions.csv (authoritative cost).
 """
-import glob, os, re, csv
+import glob, os, re
 from datetime import datetime
 
 from _pdf import raw_text
+from _csvout import write_rows
 
 DATA = os.path.join(os.path.dirname(__file__), "..", "data", "endowus statement")
 FUND = "Amundi"                     # the fund Endowus is authoritative for (others come from cpf-stocks)
@@ -115,11 +116,8 @@ def main():
     print(f"external cash booked (buys only): S${invested:,.2f}  (switch-in excluded)")
 
     out = os.path.join(os.path.dirname(__file__), "endowus_events.csv")
-    with open(out, "w", newline="") as fh:
-        w = csv.writer(fh)
-        w.writerow(["date", "src", "fund", "action", "qty_signed", "price", "amount"])
-        for date, fund, act, q, price, amt in ev:
-            w.writerow([date, "CPF OA", fund, act, q, price, amt])
+    write_rows(out, ["date", "src", "fund", "action", "qty_signed", "price", "amount"],
+               [[date, "CPF OA", fund, act, q, price, amt] for date, fund, act, q, price, amt in ev])
     print(f"\nwrote {out}")
 
 if __name__ == "__main__":

--- a/build/parse_endowus.py
+++ b/build/parse_endowus.py
@@ -43,13 +43,10 @@ def f(s): return float(s.replace(",", ""))
 def isoA(d): return datetime.strptime(d, "%d %b %Y").date().isoformat()
 def isoB(d): return datetime.strptime(d, "%d/%m/%Y").date().isoformat()
 
-def text_of(path):
-    return raw_text(path)
-
 def holdings(path):
     """fund unit snapshot from the asset-allocation table — used only to sanity-check units."""
     out = {}
-    for m in re.finditer(r"(.+?Fund)\s+Equity(?:\s+Fund)?\s+(CPF OA|CPF SA|SRS|Cash)\s+([\d,]+\.\d+)\s+S\$", text_of(path)):
+    for m in re.finditer(r"(.+?Fund)\s+Equity(?:\s+Fund)?\s+(CPF OA|CPF SA|SRS|Cash)\s+([\d,]+\.\d+)\s+S\$", raw_text(path)):
         out[(re.sub(r"\s+", " ", m.group(1)).strip(), m.group(2))] = f(m.group(3))
     return out
 
@@ -71,7 +68,7 @@ def main():
     files = sorted(glob.glob(os.path.join(DATA, "endowus_*.pdf")))
     allrows, snaps = [], {}
     for path in files:
-        txt = text_of(path)
+        txt = raw_text(path)
         allrows += parse_txns(txt)
         h = holdings(path)
         if h:

--- a/build/parse_endowus.py
+++ b/build/parse_endowus.py
@@ -20,8 +20,10 @@ price/amount: it is internal, not new capital. Its cost carries from the predece
 the `switch` corporate_action (see performance.py / seed.py), so booking it here would
 double-count. Infinity itself stays in cpf-stocks/transactions.csv (authoritative cost).
 """
-import glob, os, re, subprocess, csv
+import glob, os, re, csv
 from datetime import datetime
+
+from _pdf import raw_text
 
 DATA = os.path.join(os.path.dirname(__file__), "..", "data", "endowus statement")
 FUND = "Amundi"                     # the fund Endowus is authoritative for (others come from cpf-stocks)
@@ -41,7 +43,7 @@ def isoA(d): return datetime.strptime(d, "%d %b %Y").date().isoformat()
 def isoB(d): return datetime.strptime(d, "%d/%m/%Y").date().isoformat()
 
 def text_of(path):
-    return subprocess.run(["pdftotext", "-layout", path, "-"], capture_output=True, text=True).stdout
+    return raw_text(path)
 
 def holdings(path):
     """fund unit snapshot from the asset-allocation table — used only to sanity-check units."""

--- a/build/parse_moomoo.py
+++ b/build/parse_moomoo.py
@@ -8,9 +8,10 @@ Each statement has a per-symbol table:
 We emit buy/sell/transfer events from BuyQ/SellQ/TransferIn/TransferOut and also
 record the ending quantity per symbol per month (to confirm current positions).
 """
-import glob, os, re, csv
+import glob, os, re
 
 from _pdf import raw_text
+from _csvout import write_csv
 
 DATA = os.path.join(os.path.dirname(__file__), "..", "data")
 NUM = r"[+\-]?[\d,]+(?:\.\d+)?"
@@ -132,9 +133,7 @@ def main():
         print(f"  {t:5} last-stmt({last})={end!s:>10}  Holdings={h}{flag}")
     out = os.path.join(os.path.dirname(__file__), "moomoo_events.csv")
     cols = ["date","account","market","ticker","asset_type","action","qty_signed","price","amount","source","raw"]
-    with open(out, "w", newline="") as fh:
-        w = csv.DictWriter(fh, fieldnames=cols, extrasaction="ignore"); w.writeheader()
-        for e in ev: w.writerow(e)
+    write_csv(out, cols, ev, extrasaction="ignore")
     print(f"\nwrote {out}")
 
 if __name__ == "__main__":

--- a/build/parse_moomoo.py
+++ b/build/parse_moomoo.py
@@ -8,7 +8,9 @@ Each statement has a per-symbol table:
 We emit buy/sell/transfer events from BuyQ/SellQ/TransferIn/TransferOut and also
 record the ending quantity per symbol per month (to confirm current positions).
 """
-import glob, os, re, csv, subprocess
+import glob, os, re, csv
+
+from _pdf import raw_text
 
 DATA = os.path.join(os.path.dirname(__file__), "..", "data")
 NUM = r"[+\-]?[\d,]+(?:\.\d+)?"
@@ -24,8 +26,7 @@ def parse(path):
     """Return list of (month, ticker, market, endQ) snapshots."""
     month = re.search(r"(\d{6})", path).group(1)
     ym = f"{month[:4]}-{month[4:]}"
-    txt = subprocess.run(["pdftotext", "-layout", path, "-"],
-                         capture_output=True, text=True).stdout
+    txt = raw_text(path)
     lines = txt.splitlines()
     out = []
     for i, ln in enumerate(lines):
@@ -54,7 +55,7 @@ TRADE = re.compile(
 
 def trades(path):
     """priced trades from the Moomoo 'Transaction Details' section -> per (ym,ticker) totals."""
-    txt = subprocess.run(["pdftotext", "-layout", path, "-"], capture_output=True, text=True).stdout
+    txt = raw_text(path)
     lines = txt.splitlines()
     out = []
     for i, ln in enumerate(lines):

--- a/build/parse_moomoo.py
+++ b/build/parse_moomoo.py
@@ -61,7 +61,7 @@ def trades(path):
         m = TRADE.match(ln)
         if not m:
             continue
-        direction, exch, ccy, price, qty, amount = m.groups()
+        direction, _, _, price, qty, amount = m.groups()
         tk = ""
         for j in range(i - 2, i + 4):                 # ticker = first token of the time-bearing line
             if 0 <= j < len(lines) and re.search(r"\d\d:\d\d:\d\d", lines[j]):

--- a/build/parse_moomoo.py
+++ b/build/parse_moomoo.py
@@ -8,7 +8,7 @@ Each statement has a per-symbol table:
 We emit buy/sell/transfer events from BuyQ/SellQ/TransferIn/TransferOut and also
 record the ending quantity per symbol per month (to confirm current positions).
 """
-import glob, os, re, csv, subprocess, sys
+import glob, os, re, csv, subprocess
 
 DATA = os.path.join(os.path.dirname(__file__), "..", "data")
 NUM = r"[+\-]?[\d,]+(?:\.\d+)?"

--- a/ingestion/load.py
+++ b/ingestion/load.py
@@ -197,20 +197,28 @@ def prune_stale(session, model, keep_hashes, **scope):
     session.flush()
 
 
+def count(session, model, where=None):
+    """Row count for `model` (optionally filtered by `where`), used by loaders for the
+    +N-new / total tallies they print."""
+    stmt = select(func.count()).select_from(model)
+    if where is not None:
+        stmt = stmt.where(where)
+    return session.scalar(stmt)
+
+
 def upsert(session, model, payload, update_cols):
     """Idempotent on dedup_hash; mutable fields (amount/price/currency) are refreshed
     so re-ingesting a corrected ledger updates rows in place. Returns count of NEW rows."""
     if not payload:
         return 0
-    before = session.scalar(select(func.count()).select_from(model))
+    before = count(session, model)
     stmt = pg_insert(model).values(payload)
     stmt = stmt.on_conflict_do_update(
         index_elements=["dedup_hash"],
         set_={c: getattr(stmt.excluded, c) for c in update_cols})
     session.execute(stmt)
     session.flush()
-    after = session.scalar(select(func.count()).select_from(model))
-    return after - before
+    return count(session, model) - before
 
 
 def main():
@@ -226,12 +234,12 @@ def main():
     from ingestion.load_cdp_cost import load_cdp_cost
     nc = load_cdp_cost(s)
     s.commit()
-    print(f"txn: +{nt} new (total {s.scalar(select(func.count()).select_from(Txn))})")
-    print(f"dividend: +{nd} new (total {s.scalar(select(func.count()).select_from(Dividend))}), "
+    print(f"txn: +{nt} new (total {count(s, Txn)})")
+    print(f"dividend: +{nd} new (total {count(s, Dividend)}), "
           f"ex_date backfilled on {nx}")
     from portfolio.models import OptionTrade, CdpCostLot
-    print(f"option_trade: +{no} new (total {s.scalar(select(func.count()).select_from(OptionTrade))})")
-    print(f"cdp_cost_lot: +{nc} new (total {s.scalar(select(func.count()).select_from(CdpCostLot))})")
+    print(f"option_trade: +{no} new (total {count(s, OptionTrade)})")
+    print(f"cdp_cost_lot: +{nc} new (total {count(s, CdpCostLot)})")
     s.close()
 
 

--- a/ingestion/load.py
+++ b/ingestion/load.py
@@ -13,7 +13,7 @@ import sys
 from collections import Counter
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
-from sqlalchemy import func, insert, select, text
+from sqlalchemy import func, select, text
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 
 from portfolio.db import SessionLocal

--- a/ingestion/load.py
+++ b/ingestion/load.py
@@ -41,6 +41,14 @@ def h(*parts):
     return hashlib.sha256("|".join(str(p) for p in parts).encode()).hexdigest()
 
 
+def occ_hash(occ, key):
+    """Occurrence-disambiguated dedup hash. `occ` (a Counter) tracks how many times this exact
+    natural `key` tuple has been seen in the current file, so the nth identical row hashes
+    distinctly (genuine repeats stay distinct) yet stably on re-ingest."""
+    occ[key] += 1
+    return h(*key, occ[key])
+
+
 def pdate(s):
     s = (s or "").strip()
     for f in ("%Y-%m-%d", "%d-%b-%y", "%d %b %Y", "%d/%m/%Y", "%Y-%m"):
@@ -118,8 +126,7 @@ def load_ledger(session, acct, alias):
         # corrections to those mutable fields update the existing row instead of
         # inserting a duplicate. occ disambiguates genuinely repeated trades.
         key = (r["account"], r["ticker"], r["date"], r["action"], r["qty_signed"])
-        occ[key] += 1                      # nth identical row in this file -> distinct, but stable on re-ingest
-        dh = h(*key, occ[key])
+        dh = occ_hash(occ, key)            # nth identical row in this file -> distinct, but stable on re-ingest
         payload.append(dict(
             account_id=a.id, security_id=sid, trade_date=pdate(r["date"]),
             action=r["action"], qty_signed=num(r["qty_signed"]) or 0,
@@ -144,8 +151,7 @@ def load_dividends(session, acct, alias):
         if not a:
             continue
         key = (r["account"], r["ticker"], r["date"], r["gross"], r["source"])
-        occ[key] += 1
-        dh = h(*key, occ[key])
+        dh = occ_hash(occ, key)
         payload.append(dict(
             account_id=a.id, security_id=sid, pay_date=pdate(r["date"]), kind=r["kind"],
             gross=num(r["gross"]), net=num(r["gross"]), currency=r["currency"],

--- a/ingestion/load.py
+++ b/ingestion/load.py
@@ -153,12 +153,7 @@ def load_dividends(session, acct, alias):
             source_file=r["source"], batch_id=b.id, dedup_hash=dh,
         ))
     # prune dividends that vanished from the CSV (e.g. dateless rows now reparsed with a date)
-    hashes = {p["dedup_hash"] for p in payload}
-    stale = session.scalars(select(Dividend).filter_by(batch_id=b.id)).all()
-    for d in stale:
-        if d.dedup_hash not in hashes:
-            session.delete(d)
-    session.flush()
+    prune_stale(session, Dividend, {p["dedup_hash"] for p in payload}, batch_id=b.id)
     return upsert(session, Dividend, payload, ["gross", "net", "currency", "amount_per_unit", "units"])
 
 
@@ -191,6 +186,15 @@ def backfill_ex_dates(session):
             {"ex": r["ex_date"], "tk": r["ticker"], "pay": r["date"]}).rowcount
     session.flush()
     return n
+
+
+def prune_stale(session, model, keep_hashes, **scope):
+    """Delete `model` rows in `scope` (e.g. batch_id=… or account_id=…) whose dedup_hash isn't
+    in `keep_hashes` — removes entries that vanished from the source on re-ingest. Flushes."""
+    for old in session.scalars(select(model).filter_by(**scope)).all():
+        if old.dedup_hash not in keep_hashes:
+            session.delete(old)
+    session.flush()
 
 
 def upsert(session, model, payload, update_cols):

--- a/ingestion/load_cash.py
+++ b/ingestion/load_cash.py
@@ -10,9 +10,7 @@ import csv
 import os
 from collections import Counter
 
-from sqlalchemy import func, select
-
-from ingestion.load import batch, h, num, pdate, prune_stale, upsert
+from ingestion.load import batch, count, h, num, pdate, prune_stale, upsert
 from portfolio.db import SessionLocal
 from portfolio.models import CashTxn
 
@@ -58,8 +56,8 @@ def main():
     s = SessionLocal()
     n = load_cash(s)
     s.commit()
-    total = s.scalar(select(func.count()).select_from(CashTxn))
-    spend = s.scalar(select(func.count()).select_from(CashTxn).where(CashTxn.is_spend.is_(True)))
+    total = count(s, CashTxn)
+    spend = count(s, CashTxn, CashTxn.is_spend.is_(True))
     print(f"cash_txn: +{n} new (total {total}, {spend} counted as spend)")
     s.close()
 

--- a/ingestion/load_cash.py
+++ b/ingestion/load_cash.py
@@ -12,7 +12,7 @@ from collections import Counter
 
 from sqlalchemy import func, select
 
-from ingestion.load import batch, h, num, pdate, upsert
+from ingestion.load import batch, h, num, pdate, prune_stale, upsert
 from portfolio.db import SessionLocal
 from portfolio.models import CashTxn
 
@@ -48,11 +48,7 @@ def load_cash(session):
             source_file=r["source_file"], raw=r["raw"], batch_id=b.id, dedup_hash=dh,
         ))
     # rows that vanished from the CSV (e.g. a fixed parser bug) are pruned from this batch
-    hashes = {p["dedup_hash"] for p in payload}
-    for old in session.scalars(select(CashTxn).filter_by(batch_id=b.id)).all():
-        if old.dedup_hash not in hashes:
-            session.delete(old)
-    session.flush()
+    prune_stale(session, CashTxn, {p["dedup_hash"] for p in payload}, batch_id=b.id)
     return upsert(session, CashTxn, payload,
                   ["amount_sgd", "is_spend", "exclude_reason", "category", "subcategory",
                    "merchant", "description", "post_date", "fcy_amount", "fcy_currency"])

--- a/ingestion/load_cash.py
+++ b/ingestion/load_cash.py
@@ -10,7 +10,7 @@ import csv
 import os
 from collections import Counter
 
-from ingestion.load import batch, count, h, num, pdate, prune_stale, upsert
+from ingestion.load import batch, count, num, occ_hash, pdate, prune_stale, upsert
 from portfolio.db import SessionLocal
 from portfolio.models import CashTxn
 
@@ -31,8 +31,7 @@ def load_cash(session):
         # the same row; occ disambiguates genuinely identical lines in one statement.
         key = (r["source"], r["account_label"], r["txn_date"], r["description"][:120],
                r["amount_sgd"])
-        occ[key] += 1
-        dh = h(*key, occ[key])
+        dh = occ_hash(occ, key)
         payload.append(dict(
             source=r["source"], account_label=r["account_label"],
             txn_date=pdate(r["txn_date"]), post_date=pdate(r["post_date"]),

--- a/ingestion/load_cdp_cost.py
+++ b/ingestion/load_cdp_cost.py
@@ -13,7 +13,7 @@ from collections import Counter
 
 from sqlalchemy import func, select
 
-from ingestion.load import batch, h, pdate, upsert
+from ingestion.load import batch, h, pdate, prune_stale, upsert
 from portfolio.db import SessionLocal
 from portfolio.models import CdpCostLot
 from portfolio.performance import _ALIAS, _num
@@ -45,11 +45,7 @@ def load_cdp_cost(session):
             source_file="cdp-stocks/transactions.csv", batch_id=b.id, dedup_hash=dh,
         ))
     # rows dropped from the CSV are pruned from this batch
-    hashes = {p["dedup_hash"] for p in payload}
-    for old in session.scalars(select(CdpCostLot).filter_by(batch_id=b.id)).all():
-        if old.dedup_hash not in hashes:
-            session.delete(old)
-    session.flush()
+    prune_stale(session, CdpCostLot, {p["dedup_hash"] for p in payload}, batch_id=b.id)
     return upsert(session, CdpCostLot, payload,
                   ["ticker", "stock_name", "action", "qty", "unit_price", "amount",
                    "currency", "market", "trade_date"])

--- a/ingestion/load_cdp_cost.py
+++ b/ingestion/load_cdp_cost.py
@@ -14,10 +14,26 @@ from collections import Counter
 from ingestion.load import batch, count, occ_hash, pdate, prune_stale, upsert
 from portfolio.db import SessionLocal
 from portfolio.models import CdpCostLot
-from portfolio.performance import _ALIAS, _num
 
 ROOT = os.path.dirname(os.path.dirname(__file__))
 CSV = os.path.join(ROOT, "data", "cdp-stocks", "transactions.csv")
+
+# CDP code -> canonical SGX/exchange code (Holdings.md label aliasing; CWBU->SET is the
+# Cromwell->Stoneweg counter rename).
+_ALIAS = {"QAF": "Q01", "CWBU": "SET", "C": "C52"}
+
+
+def _num(s):
+    s = str(s or "").replace(",", "").replace("$", "").strip()
+    if not s or s == "-":
+        return 0.0
+    neg = s.startswith("(") and s.endswith(")")
+    s = s.strip("()")
+    try:
+        v = float(s)
+    except ValueError:
+        return 0.0
+    return -v if neg else v
 
 
 def load_cdp_cost(session):

--- a/ingestion/load_cdp_cost.py
+++ b/ingestion/load_cdp_cost.py
@@ -11,9 +11,7 @@ import csv
 import os
 from collections import Counter
 
-from sqlalchemy import func, select
-
-from ingestion.load import batch, h, pdate, prune_stale, upsert
+from ingestion.load import batch, count, h, pdate, prune_stale, upsert
 from portfolio.db import SessionLocal
 from portfolio.models import CdpCostLot
 from portfolio.performance import _ALIAS, _num
@@ -55,7 +53,7 @@ def main():
     s = SessionLocal()
     n = load_cdp_cost(s)
     s.commit()
-    total = s.scalar(select(func.count()).select_from(CdpCostLot))
+    total = count(s, CdpCostLot)
     print(f"cdp_cost_lot: +{n} new (total {total})")
     s.close()
 

--- a/ingestion/load_cdp_cost.py
+++ b/ingestion/load_cdp_cost.py
@@ -11,7 +11,7 @@ import csv
 import os
 from collections import Counter
 
-from ingestion.load import batch, count, h, pdate, prune_stale, upsert
+from ingestion.load import batch, count, occ_hash, pdate, prune_stale, upsert
 from portfolio.db import SessionLocal
 from portfolio.models import CdpCostLot
 from portfolio.performance import _ALIAS, _num
@@ -30,8 +30,7 @@ def load_cdp_cost(session):
         code = (r.get("Code") or "").upper()
         # stable natural key from the raw CSV cells; occ disambiguates identical repeats.
         key = (code, r.get("Date"), r.get("Action"), r.get("Qty"), r.get("Amount"))
-        occ[key] += 1
-        dh = h(*key, occ[key])
+        dh = occ_hash(occ, key)
         payload.append(dict(
             trade_date=pdate(r.get("Date")), code=code, ticker=_ALIAS.get(code, code),
             stock_name=(r.get("Stock Name") or "").strip() or None,

--- a/ingestion/parse_options.py
+++ b/ingestion/parse_options.py
@@ -33,7 +33,7 @@ from sqlalchemy import func, select
 
 from portfolio.db import SessionLocal
 from portfolio.models import OptionTrade
-from ingestion.load import ROOT, batch, h, maps, num, pdate, upsert
+from ingestion.load import ROOT, batch, h, maps, num, pdate, prune_stale, upsert
 
 TIGER_GLOBS = ["data/tiger-prime/*.csv", "data/tiger-cash-boost/*.csv"]
 IBKR_SRC = os.path.join(ROOT, "data", "ibkr-options", "options.csv")
@@ -225,15 +225,6 @@ _UPSERT_COLS = ["premium_open", "premium_close", "fees_open", "fees_close", "clo
                 "contracts", "realized_pl", "outcome", "security_id", "open_date"]
 
 
-def _prune(session, account_id, keep_hashes):
-    """Delete this account's option rows that aren't in the current payload — removes the old
-    archive-sourced rows on cutover and any contract that vanished from the source on re-ingest."""
-    for old in session.scalars(select(OptionTrade).filter_by(account_id=account_id)).all():
-        if old.dedup_hash not in keep_hashes:
-            session.delete(old)
-    session.flush()
-
-
 def load_options(session, acct, alias):
     tiger = acct.get("Tiger Prime")
     if not tiger:
@@ -244,7 +235,8 @@ def load_options(session, acct, alias):
     b = batch(session, "options", "tiger-flex/options", len(flex))
     for p in flex:
         p["batch_id"] = b.id
-    _prune(session, tiger.id, {p["dedup_hash"] for p in flex})
+    # replaces the retired archive rows on this account + any contract gone from the source
+    prune_stale(session, OptionTrade, {p["dedup_hash"] for p in flex}, account_id=tiger.id)
     n += upsert(session, OptionTrade, flex, _UPSERT_COLS)
     # IBKR — pre-reconciled orphan export under the IBKR account
     ibkr = acct.get("IBKR")
@@ -253,7 +245,7 @@ def load_options(session, acct, alias):
         b = batch(session, "options-ibkr", "data/ibkr-options/options.csv", len(arc))
         for p in arc:
             p["batch_id"] = b.id
-        _prune(session, ibkr.id, {p["dedup_hash"] for p in arc})
+        prune_stale(session, OptionTrade, {p["dedup_hash"] for p in arc}, account_id=ibkr.id)
         n += upsert(session, OptionTrade, arc, _UPSERT_COLS)
     return n
 

--- a/ingestion/parse_options.py
+++ b/ingestion/parse_options.py
@@ -29,11 +29,9 @@ import sys
 from collections import Counter, defaultdict
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
-from sqlalchemy import func, select
-
 from portfolio.db import SessionLocal
 from portfolio.models import OptionTrade
-from ingestion.load import ROOT, batch, h, maps, num, pdate, prune_stale, upsert
+from ingestion.load import ROOT, batch, count, h, maps, num, pdate, prune_stale, upsert
 
 TIGER_GLOBS = ["data/tiger-prime/*.csv", "data/tiger-cash-boost/*.csv"]
 IBKR_SRC = os.path.join(ROOT, "data", "ibkr-options", "options.csv")
@@ -255,7 +253,7 @@ def main():
     acct, alias = maps(s)
     n = load_options(s, acct, alias)
     s.commit()
-    total = s.scalar(select(func.count()).select_from(OptionTrade))
+    total = count(s, OptionTrade)
     print(f"option_trade: +{n} new (total {total})")
     s.close()
 

--- a/ingestion/parse_options.py
+++ b/ingestion/parse_options.py
@@ -31,7 +31,7 @@ from collections import Counter, defaultdict
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 from portfolio.db import SessionLocal
 from portfolio.models import OptionTrade
-from ingestion.load import ROOT, batch, count, h, maps, num, pdate, prune_stale, upsert
+from ingestion.load import ROOT, batch, count, maps, num, occ_hash, pdate, prune_stale, upsert
 
 TIGER_GLOBS = ["data/tiger-prime/*.csv", "data/tiger-cash-boost/*.csv"]
 IBKR_SRC = os.path.join(ROOT, "data", "ibkr-options", "options.csv")
@@ -168,7 +168,6 @@ def _reconcile(legs, a, alias):
             outcome = "open"
             realized = None
         key = (und, typ, str(strike), str(exp), str(open_d))
-        occ[key] += 1
         payload.append(dict(
             account_id=a.id, security_id=alias.get(und), underlying=und,
             market=d["market"], option_type=typ, contracts=oc, strike=strike, multiplier=mult,
@@ -176,7 +175,7 @@ def _reconcile(legs, a, alias):
             premium_open=prem_open, premium_close=prem_close,
             fees_open=d["open_fees"], fees_close=d["close_fees"], realized_pl=realized,
             currency=CCY.get(d["market"], "USD"), outcome=outcome,
-            source_file="tiger-flex/options", dedup_hash=h(*key, occ[key]),
+            source_file="tiger-flex/options", dedup_hash=occ_hash(occ, key),
         ))
     return payload
 
@@ -207,14 +206,13 @@ def _archive_legs(src, a, alias):
         else:
             outcome = "expired"
         key = (ticker, otype, str(strike), str(contracts), str(open_d), str(expiry))
-        occ[key] += 1
         payload.append(dict(
             account_id=a.id, security_id=alias.get(ticker), underlying=ticker,
             market=market or None, option_type=otype, contracts=contracts or 0, strike=strike,
             multiplier=mult, open_date=open_d, expiry_date=expiry, close_date=close_d,
             premium_open=prem_open, premium_close=prem_close, fees_open=fees_open,
             fees_close=fees_close, realized_pl=realized, currency=CCY.get(market, "USD"),
-            outcome=outcome, source_file="ibkr-options/options.csv", dedup_hash=h(*key, occ[key]),
+            outcome=outcome, source_file="ibkr-options/options.csv", dedup_hash=occ_hash(occ, key),
         ))
     return payload
 

--- a/portfolio/db.py
+++ b/portfolio/db.py
@@ -1,12 +1,18 @@
 from contextlib import contextmanager
 
-from sqlalchemy import create_engine
+from sqlalchemy import create_engine, text
 from sqlalchemy.orm import sessionmaker
 
 from .config import settings
 
 engine = create_engine(settings.database_url, future=True)
 SessionLocal = sessionmaker(bind=engine, autoflush=False, future=True)
+
+
+def fx_map(s):
+    """currency -> rate_to_sgd (float) from fx_rate. One entry per currency; callers
+    look rates up with fx.get(ccy, 1.0). (SGD may be absent — the .get default covers it.)"""
+    return {c: float(r) for c, r in s.execute(text("SELECT currency, rate_to_sgd FROM fx_rate")).all()}
 
 
 @contextmanager

--- a/portfolio/db.py
+++ b/portfolio/db.py
@@ -15,6 +15,13 @@ def fx_map(s):
     return {c: float(r) for c, r in s.execute(text("SELECT currency, rate_to_sgd FROM fx_rate")).all()}
 
 
+def latest_close(s):
+    """security_id -> latest close (float) from price — the last known price per security,
+    covering securities Yahoo can't price live (funds, delisted tickers)."""
+    return {sid: float(px) for sid, px in s.execute(text(
+        "SELECT DISTINCT ON (security_id) security_id, close FROM price ORDER BY security_id, date DESC")).all()}
+
+
 @contextmanager
 def session_scope(s=None):
     """Yield the caller's Session, or open (and afterwards close) an owned one.

--- a/portfolio/db.py
+++ b/portfolio/db.py
@@ -1,3 +1,5 @@
+from contextlib import contextmanager
+
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
@@ -5,3 +7,18 @@ from .config import settings
 
 engine = create_engine(settings.database_url, future=True)
 SessionLocal = sessionmaker(bind=engine, autoflush=False, future=True)
+
+
+@contextmanager
+def session_scope(s=None):
+    """Yield the caller's Session, or open (and afterwards close) an owned one.
+
+    Lets a function accept an optional Session for reuse inside a larger unit of work
+    while still closing the connection it opened itself."""
+    own = s is None
+    s = s or SessionLocal()
+    try:
+        yield s
+    finally:
+        if own:
+            s.close()

--- a/portfolio/networth.py
+++ b/portfolio/networth.py
@@ -62,6 +62,27 @@ def rate_for(s: Session, ccy: str, on_date: dt.date) -> Decimal:
     return Decimal(str(r))
 
 
+def _active_items(s: Session) -> tuple[dict, dict]:
+    """Active catalogue keyed by code, plus an id index, for resolving supplied entries."""
+    items = {i.code: i for i in s.scalars(select(NwItem).where(NwItem.active)).all()}
+    return items, {i.id: i for i in items.values()}
+
+
+def _resolve_item(items: dict, by_id: dict, v: dict) -> NwItem:
+    """Match a {code|item_id, ...} entry to its catalogue item; raise ValueError on unknown."""
+    it = by_id.get(v.get("item_id")) or items.get(v.get("code"))
+    if it is None:
+        raise ValueError(f"unknown item: {v.get('code') or v.get('item_id')}")
+    return it
+
+
+def _frozen_value(s: Session, it: NwItem, v: dict, on_date: dt.date) -> tuple:
+    """(native, currency, rate) for a supplied entry (or {}), FX frozen at on_date."""
+    native = Decimal(str(v.get("native_value", 0) or 0))
+    ccy = (v.get("currency") or it.currency_default or "SGD").upper()
+    return native, ccy, rate_for(s, ccy, on_date)
+
+
 def catalogue(s: Session | None = None) -> list[dict]:
     with _session(s) as s:
         items = s.scalars(select(NwItem).where(NwItem.active).order_by(NwItem.sort_order)).all()
@@ -155,28 +176,19 @@ def create_snapshot(date: dt.date, values: list[dict], note: str | None = None,
     with _session(s) as s:
         if s.scalar(select(NwSnapshot).where(NwSnapshot.date == date)):
             raise ValueError(f"snapshot for {date} already exists")
-        items = {i.code: i for i in s.scalars(select(NwItem).where(NwItem.active)).all()}
+        items, by_id = _active_items(s)
         if not items:
             # One NwValue is written per catalogue item below, so an empty catalogue produced a
             # snapshot with zero values: metrics all zero, breakdown blank, and no error anywhere.
             # Refuse it. An empty net worth is a seeding failure, not a reading.
             raise ValueError("net-worth catalogue is empty — run scripts/seed_networth.py")
-        by_id = {i.id: i for i in items.values()}
-        supplied = {}
-        for v in values:
-            it = by_id.get(v.get("item_id")) or items.get(v.get("code"))
-            if it is None:
-                raise ValueError(f"unknown item: {v.get('code') or v.get('item_id')}")
-            supplied[it.code] = v
+        supplied = {_resolve_item(items, by_id, v).code: v for v in values}
 
         snap = NwSnapshot(date=date, note=note, portfolio_value_sgd=live_portfolio_sgd(s))
         s.add(snap)
         s.flush()
         for code, it in items.items():
-            v = supplied.get(code, {})
-            native = Decimal(str(v.get("native_value", 0) or 0))
-            ccy = (v.get("currency") or it.currency_default or "SGD").upper()
-            rate = rate_for(s, ccy, date)
+            native, ccy, rate = _frozen_value(s, it, supplied.get(code, {}), date)
             s.add(NwValue(snapshot_id=snap.id, item_id=it.id, native_value=native,
                           currency=ccy, rate_to_sgd=rate, value_sgd=(native * rate)))
         s.commit()
@@ -196,16 +208,11 @@ def update_snapshot(snap_id: int, values: list[dict], note: str | None = None,
         snap = s.get(NwSnapshot, snap_id)
         if snap is None:
             return None
-        items = {i.code: i for i in s.scalars(select(NwItem).where(NwItem.active)).all()}
-        by_id = {i.id: i for i in items.values()}
+        items, by_id = _active_items(s)
         existing = {v.item_id: v for v in snap.values}
         for v in values:
-            it = by_id.get(v.get("item_id")) or items.get(v.get("code"))
-            if it is None:
-                raise ValueError(f"unknown item: {v.get('code') or v.get('item_id')}")
-            native = Decimal(str(v.get("native_value", 0) or 0))
-            ccy = (v.get("currency") or it.currency_default or "SGD").upper()
-            rate = rate_for(s, ccy, snap.date)
+            it = _resolve_item(items, by_id, v)
+            native, ccy, rate = _frozen_value(s, it, v, snap.date)
             row = existing.get(it.id)
             if row is None:                                 # item added after this snapshot
                 s.add(NwValue(snapshot_id=snap.id, item_id=it.id, native_value=native,

--- a/portfolio/networth.py
+++ b/portfolio/networth.py
@@ -13,6 +13,7 @@ fx + value_sgd + portfolio_value_sgd are frozen at capture so history stays stab
 from __future__ import annotations
 
 import datetime as dt
+from contextlib import contextmanager
 from decimal import Decimal
 
 from sqlalchemy import select, text
@@ -20,6 +21,18 @@ from sqlalchemy.orm import Session
 
 from .db import SessionLocal
 from .models import NwItem, NwSnapshot, NwValue
+
+
+@contextmanager
+def _session(s: Session | None):
+    """Yield the caller's Session, or open (and afterwards close) an owned one."""
+    own = s is None
+    s = s or SessionLocal()
+    try:
+        yield s
+    finally:
+        if own:
+            s.close()
 
 # Catalogue codes auto-pulled from broker/bank statements (see scripts/snapshot_from_statements.py).
 # Everything else is manual: entered in-app or carried forward. Single source of truth so the UI
@@ -50,14 +63,9 @@ def rate_for(s: Session, ccy: str, on_date: dt.date) -> Decimal:
 
 
 def catalogue(s: Session | None = None) -> list[dict]:
-    own = s is None
-    s = s or SessionLocal()
-    try:
+    with _session(s) as s:
         items = s.scalars(select(NwItem).where(NwItem.active).order_by(NwItem.sort_order)).all()
         return [_item_dict(i) for i in items]
-    finally:
-        if own:
-            s.close()
 
 
 def _item_dict(i: NwItem) -> dict:
@@ -123,45 +131,28 @@ def snapshot_detail(snap: NwSnapshot) -> dict:
 
 
 def list_snapshots(s: Session | None = None) -> list[dict]:
-    own = s is None
-    s = s or SessionLocal()
-    try:
+    with _session(s) as s:
         snaps = s.scalars(select(NwSnapshot).order_by(NwSnapshot.date.desc())).all()
         return [metrics(sn) for sn in snaps]
-    finally:
-        if own:
-            s.close()
 
 
 def get_snapshot(snap_id: int, s: Session | None = None) -> dict | None:
-    own = s is None
-    s = s or SessionLocal()
-    try:
+    with _session(s) as s:
         snap = s.get(NwSnapshot, snap_id)
         return snapshot_detail(snap) if snap else None
-    finally:
-        if own:
-            s.close()
 
 
 def latest(s: Session | None = None) -> dict | None:
-    own = s is None
-    s = s or SessionLocal()
-    try:
+    with _session(s) as s:
         snap = s.scalars(select(NwSnapshot).order_by(NwSnapshot.date.desc()).limit(1)).first()
         return snapshot_detail(snap) if snap else None
-    finally:
-        if own:
-            s.close()
 
 
 def create_snapshot(date: dt.date, values: list[dict], note: str | None = None,
                     s: Session | None = None) -> dict:
     """Create a dated snapshot. `values` = [{code|item_id, native_value, currency?}].
     Missing catalogue items default to 0 (BR2). Duplicate date rejected (BR1)."""
-    own = s is None
-    s = s or SessionLocal()
-    try:
+    with _session(s) as s:
         if s.scalar(select(NwSnapshot).where(NwSnapshot.date == date)):
             raise ValueError(f"snapshot for {date} already exists")
         items = {i.code: i for i in s.scalars(select(NwItem).where(NwItem.active)).all()}
@@ -191,9 +182,6 @@ def create_snapshot(date: dt.date, values: list[dict], note: str | None = None,
         s.commit()
         s.refresh(snap)
         return snapshot_detail(snap)
-    finally:
-        if own:
-            s.close()
 
 
 def update_snapshot(snap_id: int, values: list[dict], note: str | None = None,
@@ -204,9 +192,7 @@ def update_snapshot(snap_id: int, values: list[dict], note: str | None = None,
     Only supplied items are changed; their FX rate is re-frozen at the snapshot's OWN date
     (history stays stable) and value_sgd recomputed. Items not supplied and the frozen
     portfolio_value_sgd are left untouched. Returns the detail, or None if the id is unknown."""
-    own = s is None
-    s = s or SessionLocal()
-    try:
+    with _session(s) as s:
         snap = s.get(NwSnapshot, snap_id)
         if snap is None:
             return None
@@ -232,21 +218,13 @@ def update_snapshot(snap_id: int, values: list[dict], note: str | None = None,
         s.commit()
         s.refresh(snap)
         return snapshot_detail(snap)
-    finally:
-        if own:
-            s.close()
 
 
 def delete_snapshot(snap_id: int, s: Session | None = None) -> bool:
-    own = s is None
-    s = s or SessionLocal()
-    try:
+    with _session(s) as s:
         snap = s.get(NwSnapshot, snap_id)
         if snap is None:
             return False
         s.delete(snap)
         s.commit()
         return True
-    finally:
-        if own:
-            s.close()

--- a/portfolio/networth.py
+++ b/portfolio/networth.py
@@ -13,26 +13,13 @@ fx + value_sgd + portfolio_value_sgd are frozen at capture so history stays stab
 from __future__ import annotations
 
 import datetime as dt
-from contextlib import contextmanager
 from decimal import Decimal
 
 from sqlalchemy import select, text
 from sqlalchemy.orm import Session
 
-from .db import SessionLocal
+from .db import session_scope
 from .models import NwItem, NwSnapshot, NwValue
-
-
-@contextmanager
-def _session(s: Session | None):
-    """Yield the caller's Session, or open (and afterwards close) an owned one."""
-    own = s is None
-    s = s or SessionLocal()
-    try:
-        yield s
-    finally:
-        if own:
-            s.close()
 
 # Catalogue codes auto-pulled from broker/bank statements (see scripts/snapshot_from_statements.py).
 # Everything else is manual: entered in-app or carried forward. Single source of truth so the UI
@@ -96,7 +83,7 @@ def _write_value(s: Session, snap_id: int, it: NwItem, native, ccy, rate, existi
 
 
 def catalogue(s: Session | None = None) -> list[dict]:
-    with _session(s) as s:
+    with session_scope(s) as s:
         items = s.scalars(select(NwItem).where(NwItem.active).order_by(NwItem.sort_order)).all()
         return [_item_dict(i) for i in items]
 
@@ -164,19 +151,19 @@ def snapshot_detail(snap: NwSnapshot) -> dict:
 
 
 def list_snapshots(s: Session | None = None) -> list[dict]:
-    with _session(s) as s:
+    with session_scope(s) as s:
         snaps = s.scalars(select(NwSnapshot).order_by(NwSnapshot.date.desc())).all()
         return [metrics(sn) for sn in snaps]
 
 
 def get_snapshot(snap_id: int, s: Session | None = None) -> dict | None:
-    with _session(s) as s:
+    with session_scope(s) as s:
         snap = s.get(NwSnapshot, snap_id)
         return snapshot_detail(snap) if snap else None
 
 
 def latest(s: Session | None = None) -> dict | None:
-    with _session(s) as s:
+    with session_scope(s) as s:
         snap = s.scalars(select(NwSnapshot).order_by(NwSnapshot.date.desc()).limit(1)).first()
         return snapshot_detail(snap) if snap else None
 
@@ -185,7 +172,7 @@ def create_snapshot(date: dt.date, values: list[dict], note: str | None = None,
                     s: Session | None = None) -> dict:
     """Create a dated snapshot. `values` = [{code|item_id, native_value, currency?}].
     Missing catalogue items default to 0 (BR2). Duplicate date rejected (BR1)."""
-    with _session(s) as s:
+    with session_scope(s) as s:
         if s.scalar(select(NwSnapshot).where(NwSnapshot.date == date)):
             raise ValueError(f"snapshot for {date} already exists")
         items, by_id = _active_items(s)
@@ -215,7 +202,7 @@ def update_snapshot(snap_id: int, values: list[dict], note: str | None = None,
     Only supplied items are changed; their FX rate is re-frozen at the snapshot's OWN date
     (history stays stable) and value_sgd recomputed. Items not supplied and the frozen
     portfolio_value_sgd are left untouched. Returns the detail, or None if the id is unknown."""
-    with _session(s) as s:
+    with session_scope(s) as s:
         snap = s.get(NwSnapshot, snap_id)
         if snap is None:
             return None
@@ -233,7 +220,7 @@ def update_snapshot(snap_id: int, values: list[dict], note: str | None = None,
 
 
 def delete_snapshot(snap_id: int, s: Session | None = None) -> bool:
-    with _session(s) as s:
+    with session_scope(s) as s:
         snap = s.get(NwSnapshot, snap_id)
         if snap is None:
             return False

--- a/portfolio/networth.py
+++ b/portfolio/networth.py
@@ -83,6 +83,18 @@ def _frozen_value(s: Session, it: NwItem, v: dict, on_date: dt.date) -> tuple:
     return native, ccy, rate_for(s, ccy, on_date)
 
 
+def _write_value(s: Session, snap_id: int, it: NwItem, native, ccy, rate, existing=None) -> None:
+    """Insert a NwValue for `it` (value_sgd = native*rate), or update its existing row in place.
+    `existing` is an item_id -> NwValue index; None means always insert."""
+    row = existing.get(it.id) if existing else None
+    if row is None:
+        s.add(NwValue(snapshot_id=snap_id, item_id=it.id, native_value=native,
+                      currency=ccy, rate_to_sgd=rate, value_sgd=native * rate))
+    else:
+        row.native_value, row.currency = native, ccy
+        row.rate_to_sgd, row.value_sgd = rate, native * rate
+
+
 def catalogue(s: Session | None = None) -> list[dict]:
     with _session(s) as s:
         items = s.scalars(select(NwItem).where(NwItem.active).order_by(NwItem.sort_order)).all()
@@ -189,8 +201,7 @@ def create_snapshot(date: dt.date, values: list[dict], note: str | None = None,
         s.flush()
         for code, it in items.items():
             native, ccy, rate = _frozen_value(s, it, supplied.get(code, {}), date)
-            s.add(NwValue(snapshot_id=snap.id, item_id=it.id, native_value=native,
-                          currency=ccy, rate_to_sgd=rate, value_sgd=(native * rate)))
+            _write_value(s, snap.id, it, native, ccy, rate)
         s.commit()
         s.refresh(snap)
         return snapshot_detail(snap)
@@ -213,13 +224,7 @@ def update_snapshot(snap_id: int, values: list[dict], note: str | None = None,
         for v in values:
             it = _resolve_item(items, by_id, v)
             native, ccy, rate = _frozen_value(s, it, v, snap.date)
-            row = existing.get(it.id)
-            if row is None:                                 # item added after this snapshot
-                s.add(NwValue(snapshot_id=snap.id, item_id=it.id, native_value=native,
-                              currency=ccy, rate_to_sgd=rate, value_sgd=(native * rate)))
-            else:
-                row.native_value, row.currency = native, ccy
-                row.rate_to_sgd, row.value_sgd = rate, native * rate
+            _write_value(s, snap.id, it, native, ccy, rate, existing)   # insert if added after snapshot
         if note is not None:
             snap.note = note
         s.commit()

--- a/portfolio/options.py
+++ b/portfolio/options.py
@@ -10,15 +10,14 @@ import os
 import sys
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
-from sqlalchemy import select, text
+from sqlalchemy import select
 
-from portfolio.db import SessionLocal
+from portfolio.db import SessionLocal, fx_map
 from portfolio.models import OptionTrade
 
 
 def _fx(s):
-    rows = s.execute(text("SELECT currency, rate_to_sgd FROM fx_rate")).all()
-    fx = {c: float(r) for c, r in rows}
+    fx = fx_map(s)
     fx.setdefault("SGD", 1.0)
     return fx
 

--- a/portfolio/options.py
+++ b/portfolio/options.py
@@ -114,21 +114,29 @@ def compute():
     }
 
 
+def _closed_trades():
+    """Yield (trade, fx) for each closed (realized) trade — expired legs ARE realized.
+    Opens the session and loads FX once; the session stays open until iteration finishes."""
+    s = SessionLocal()
+    fx = _fx(s)
+    try:
+        for t in s.scalars(select(OptionTrade)).all():
+            if not _is_open(t):
+                yield t, fx
+    finally:
+        s.close()
+
+
 def realized_by_ticker():
     """Closed-trade realized P/L (SGD + native) keyed by underlying ticker.
     For folding the options income stream into per-security (Holdings) views."""
-    s = SessionLocal()
-    fx = _fx(s)
     out = {}
-    for t in s.scalars(select(OptionTrade)).all():
-        if _is_open(t):                                # not yet realized (expired legs ARE realized)
-            continue
+    for t, fx in _closed_trades():
         r = out.setdefault(t.underlying, {"pl_sgd": 0.0, "pl_native": 0.0, "trades": 0,
                                           "currency": t.currency, "market": t.market})
         r["pl_sgd"] += _sgd(t.realized_pl, t.currency, fx)
         r["pl_native"] += float(t.realized_pl or 0)
         r["trades"] += 1
-    s.close()
     return {k: {**v, "pl_sgd": round(v["pl_sgd"], 2), "pl_native": round(v["pl_native"], 2)}
             for k, v in out.items()}
 
@@ -136,12 +144,8 @@ def realized_by_ticker():
 def realized_by(dim):
     """Closed-trade realized P/L (SGD) grouped by dimension: 'market' | 'bucket' | 'account'.
     Options trade on the Tiger Prime cash account, so bucket='cash', account='Tiger Prime'."""
-    s = SessionLocal()
-    fx = _fx(s)
     agg = {}
-    for t in s.scalars(select(OptionTrade)).all():
-        if _is_open(t):
-            continue
+    for t, fx in _closed_trades():
         if dim == "market":
             key = t.market or "—"
         elif dim == "bucket":
@@ -149,7 +153,6 @@ def realized_by(dim):
         else:                                          # account
             key = "Tiger Prime"
         agg[key] = agg.get(key, 0.0) + _sgd(t.realized_pl, t.currency, fx)
-    s.close()
     return {k: round(v, 2) for k, v in agg.items()}
 
 

--- a/portfolio/options.py
+++ b/portfolio/options.py
@@ -153,17 +153,20 @@ def realized_by(dim):
     return {k: round(v, 2) for k, v in agg.items()}
 
 
-def trades_for(underlying):
-    """Per-underlying option trade list (for the holding-detail view)."""
+def _trade_dicts(stmt):
+    """Run `stmt` (an OptionTrade select) and serialize each row to a dict at latest FX."""
     s = SessionLocal()
     fx = _fx(s)
-    trades = s.scalars(
-        select(OptionTrade).filter(OptionTrade.underlying == underlying.upper())
-        .order_by(OptionTrade.open_date.desc().nullslast())
-    ).all()
-    out = [_trade_dict(t, fx) for t in trades]
+    out = [_trade_dict(t, fx) for t in s.scalars(stmt).all()]
     s.close()
     return out
+
+
+def trades_for(underlying):
+    """Per-underlying option trade list (for the holding-detail view)."""
+    return _trade_dicts(
+        select(OptionTrade).filter(OptionTrade.underlying == underlying.upper())
+        .order_by(OptionTrade.open_date.desc().nullslast()))
 
 
 def _trade_dict(t, fx):
@@ -182,14 +185,8 @@ def _trade_dict(t, fx):
 
 
 def recent(limit=200):
-    s = SessionLocal()
-    fx = _fx(s)
-    trades = s.scalars(
-        select(OptionTrade).order_by(OptionTrade.open_date.desc().nullslast()).limit(limit)
-    ).all()
-    out = [_trade_dict(t, fx) for t in trades]
-    s.close()
-    return out
+    return _trade_dicts(
+        select(OptionTrade).order_by(OptionTrade.open_date.desc().nullslast()).limit(limit))
 
 
 if __name__ == "__main__":

--- a/portfolio/options.py
+++ b/portfolio/options.py
@@ -33,6 +33,11 @@ def _f(x):
     return float(x) if x is not None else None
 
 
+def _d(x):
+    """x.isoformat() for a truthy date/datetime, else None (nullable date -> nullable ISO string)."""
+    return x.isoformat() if x else None
+
+
 def _is_open(t):
     """A contract is open only until it resolves. Expired-worthless legs carry
     outcome='expired' with close_date=None (never bought back) — those are REALIZED,
@@ -180,9 +185,9 @@ def _trade_dict(t, fx):
     return {
         "underlying": t.underlying, "type": t.option_type,
         "contracts": float(t.contracts or 0), "strike": _f(t.strike),
-        "open_date": t.open_date.isoformat() if t.open_date else None,
-        "expiry": t.expiry_date.isoformat() if t.expiry_date else None,
-        "close_date": t.close_date.isoformat() if t.close_date else None,
+        "open_date": _d(t.open_date),
+        "expiry": _d(t.expiry_date),
+        "close_date": _d(t.close_date),
         "premium_open": _f(t.premium_open),
         "premium_close": _f(t.premium_close),
         "realized_native": _f(t.realized_pl),

--- a/portfolio/options.py
+++ b/portfolio/options.py
@@ -28,6 +28,11 @@ def _sgd(v, ccy, fx):
     return float(v) * fx.get(ccy or "SGD", 1.0)
 
 
+def _f(x):
+    """float(x), passing None through (nullable numeric column -> nullable output)."""
+    return float(x) if x is not None else None
+
+
 def _is_open(t):
     """A contract is open only until it resolves. Expired-worthless legs carry
     outcome='expired' with close_date=None (never bought back) — those are REALIZED,
@@ -174,13 +179,13 @@ def trades_for(underlying):
 def _trade_dict(t, fx):
     return {
         "underlying": t.underlying, "type": t.option_type,
-        "contracts": float(t.contracts or 0), "strike": float(t.strike) if t.strike is not None else None,
+        "contracts": float(t.contracts or 0), "strike": _f(t.strike),
         "open_date": t.open_date.isoformat() if t.open_date else None,
         "expiry": t.expiry_date.isoformat() if t.expiry_date else None,
         "close_date": t.close_date.isoformat() if t.close_date else None,
-        "premium_open": float(t.premium_open) if t.premium_open is not None else None,
-        "premium_close": float(t.premium_close) if t.premium_close is not None else None,
-        "realized_native": float(t.realized_pl) if t.realized_pl is not None else None,
+        "premium_open": _f(t.premium_open),
+        "premium_close": _f(t.premium_close),
+        "realized_native": _f(t.realized_pl),
         "realized_sgd": round(_sgd(t.realized_pl, t.currency, fx), 2),
         "currency": t.currency, "outcome": t.outcome,
     }

--- a/portfolio/performance.py
+++ b/portfolio/performance.py
@@ -174,6 +174,49 @@ def _fx_and_price(s):
     return fx, price
 
 
+def _carry_corporate_actions(s, pos, meta):
+    """Carry a closed predecessor's cost onto the surviving security (e.g. C31 -> 9CI on the
+    2021 CapitaLand restructuring; rename/split/consolidation/merger/switch). Mutates pos."""
+    ca = s.execute(text("SELECT from_ticker, to_ticker, type FROM corporate_action "
+                        "WHERE type IN ('rename','split','consolidation','merger','switch')")).all()
+    # match predecessor/successor within the SAME funding bucket (corp actions are bucket-agnostic)
+    tk_k = {(b, m["canonical_ticker"]): (b, sid) for (b, sid), m in meta.items()}
+    buckets = {b for (b, _) in pos}
+    switched = set()                       # successor keys whose cost carried through a cash switch
+    for frm, to, typ in ca:
+        for b in buckets:
+            kf, kt = tk_k.get((b, frm)), tk_k.get((b, to))
+            if not (kf and kt):
+                continue
+            if not (pos[kf]["invested"] > 1e-6 and abs(pos[kf]["units"]) < 1e-6):
+                continue                   # predecessor must be a closed position carrying cost
+            if typ == "switch":
+                # cash switch (e.g. CPF fund switch): the redemption proceeds were reinvested
+                # into the successor, not withdrawn. Carry the cost basis + the BUY legs only;
+                # DROP the redemption inflow so it isn't double-counted as a gain. Successor may
+                # already hold its own later top-up cost, so don't require it to be empty.
+                pos[kt]["flows"].extend([fl for fl in pos[kf]["flows"] if fl[1] < 0])
+                for fld in ("invested", "buy_cost"):
+                    pos[kt][fld] += pos[kf][fld]
+                switched.add(kt)
+            elif pos[kt]["invested"] < 1e-6:        # non-cash conversion: successor starts empty
+                pos[kt]["flows"].extend(pos[kf]["flows"])
+                for fld in ("invested", "buy_cost", "buy_qty", "proceeds"):
+                    pos[kt][fld] += pos[kf][fld]
+            else:
+                continue
+            for fld in ("invested", "buy_cost", "buy_qty", "proceeds"):
+                pos[kf][fld] = 0.0
+            pos[kf]["flows"] = []
+    # a switched holding rebased its units (predecessor units != successor units), so its carried
+    # buy_qty is meaningless. The position was never sold for cash (only fee nibbles), so treat the
+    # whole current holding as carrying the full invested cost: cost_basis = invested, realised = 0.
+    for k in switched:
+        if pos[k]["units"] > 1e-6:
+            pos[k]["buy_cost"] = pos[k]["invested"]
+            pos[k]["buy_qty"] = pos[k]["units"]
+
+
 def _build_row(k, p, m, fx, price, today):
     """Assemble one position's output dict (native ccy + SGD) from its accumulated flows/units."""
     ccy = m["currency"] or "SGD"
@@ -299,46 +342,7 @@ def compute(session=None):
         pos[k]["income"] += amt
         pos[k]["flows"].append((d["pay_date"] or today, amt))
 
-    # corporate-action cost carryover: a closed predecessor's cost follows to the surviving
-    # security (e.g. C31 -> 9CI on the 2021 CapitaLand restructuring; rename/split/consolidation)
-    ca = s.execute(text("SELECT from_ticker, to_ticker, type FROM corporate_action "
-                        "WHERE type IN ('rename','split','consolidation','merger','switch')")).all()
-    # match predecessor/successor within the SAME funding bucket (corp actions are bucket-agnostic)
-    tk_k = {(b, m["canonical_ticker"]): (b, sid) for (b, sid), m in meta.items()}
-    buckets = {b for (b, _) in pos}
-    switched = set()                       # successor keys whose cost carried through a cash switch
-    for frm, to, typ in ca:
-        for b in buckets:
-            kf, kt = tk_k.get((b, frm)), tk_k.get((b, to))
-            if not (kf and kt):
-                continue
-            if not (pos[kf]["invested"] > 1e-6 and abs(pos[kf]["units"]) < 1e-6):
-                continue                   # predecessor must be a closed position carrying cost
-            if typ == "switch":
-                # cash switch (e.g. CPF fund switch): the redemption proceeds were reinvested
-                # into the successor, not withdrawn. Carry the cost basis + the BUY legs only;
-                # DROP the redemption inflow so it isn't double-counted as a gain. Successor may
-                # already hold its own later top-up cost, so don't require it to be empty.
-                pos[kt]["flows"].extend([fl for fl in pos[kf]["flows"] if fl[1] < 0])
-                for fld in ("invested", "buy_cost"):
-                    pos[kt][fld] += pos[kf][fld]
-                switched.add(kt)
-            elif pos[kt]["invested"] < 1e-6:        # non-cash conversion: successor starts empty
-                pos[kt]["flows"].extend(pos[kf]["flows"])
-                for fld in ("invested", "buy_cost", "buy_qty", "proceeds"):
-                    pos[kt][fld] += pos[kf][fld]
-            else:
-                continue
-            for fld in ("invested", "buy_cost", "buy_qty", "proceeds"):
-                pos[kf][fld] = 0.0
-            pos[kf]["flows"] = []
-    # a switched holding rebased its units (predecessor units != successor units), so its carried
-    # buy_qty is meaningless. The position was never sold for cash (only fee nibbles), so treat the
-    # whole current holding as carrying the full invested cost: cost_basis = invested, realised = 0.
-    for k in switched:
-        if pos[k]["units"] > 1e-6:
-            pos[k]["buy_cost"] = pos[k]["invested"]
-            pos[k]["buy_qty"] = pos[k]["units"]
+    _carry_corporate_actions(s, pos, meta)
 
     out = []
     for k, p in pos.items():

--- a/portfolio/performance.py
+++ b/portfolio/performance.py
@@ -223,6 +223,12 @@ def _apply_txn(p, r, today):
     return None
 
 
+def _rn(x, n, mult=1.0):
+    """round(x * mult, n), passing None through unchanged — for nullable output fields.
+    The None-check is on the base `x` (before multiplying) so a None never hits the *mult."""
+    return round(x * mult, n) if x is not None else None
+
+
 def _build_row(k, p, m, fx, price, today):
     """Assemble one position's output dict (native ccy + SGD) from its accumulated flows/units."""
     ccy = m["currency"] or "SGD"
@@ -252,10 +258,10 @@ def _build_row(k, p, m, fx, price, today):
         "name": m["name"], "market": m["market"], "asset_type": m["asset_type"], "currency": ccy,
         "units": round(p["units"], 4), "price": px, "mv_native": round(mv, 2),
         "avg_cost": round(avg_cost, 4) if avg_cost else None,
-        "cost_basis_native": round(cost_basis, 2) if cost_basis is not None else None,
-        "cost_basis_sgd": round(cost_basis * rate, 2) if cost_basis is not None else None,
-        "unrealised_pl_sgd": round(unreal * rate, 2) if unreal is not None else None,
-        "realised_pl_sgd": round(realised * rate, 2) if realised is not None else None,
+        "cost_basis_native": _rn(cost_basis, 2),
+        "cost_basis_sgd": _rn(cost_basis, 2, rate),
+        "unrealised_pl_sgd": _rn(unreal, 2, rate),
+        "realised_pl_sgd": _rn(realised, 2, rate),
         "invested_native": round(p["invested"], 2), "income_native": round(p["income"], 2),
         "fees_sgd": round(p["fees"] * rate, 2), "cost_known": cost_known,
         "uncosted_units": round(p["uncosted_units"], 4),
@@ -263,7 +269,7 @@ def _build_row(k, p, m, fx, price, today):
         "invested_sgd": round(p["invested"] * rate, 2) if cost_known else 0.0,
         "mv_sgd": round(mv * rate, 2), "income_sgd": round(p["income"] * rate, 2),
         "pl_sgd": round(total_pl * rate, 2) if cost_known else None,
-        "xirr": round(xirr, 4) if xirr is not None else None,
+        "xirr": _rn(xirr, 4),
         "simple_return": round(simple, 4) if cost_known else None,
     }
 

--- a/portfolio/performance.py
+++ b/portfolio/performance.py
@@ -13,7 +13,7 @@ from collections import defaultdict
 
 from sqlalchemy import text
 
-from .db import SessionLocal
+from .db import session_scope
 
 log = logging.getLogger(__name__)
 
@@ -37,12 +37,10 @@ def cdp_transactions(session=None):
     """CDP trades from the cdp_cost_lot table (priced) for the transactions view — the cost
     record the CDP statements omit. Loaded from data/cdp-stocks/transactions.csv by
     ingestion.load_cdp_cost. Returns txn-like dicts."""
-    s = session or SessionLocal()
-    rows = s.execute(text(
-        "SELECT trade_date, ticker, stock_name, action, qty, unit_price, amount, currency "
-        "FROM cdp_cost_lot ORDER BY trade_date")).mappings().all()
-    if session is None:
-        s.close()
+    with session_scope(session) as s:
+        rows = s.execute(text(
+            "SELECT trade_date, ticker, stock_name, action, qty, unit_price, amount, currency "
+            "FROM cdp_cost_lot ORDER BY trade_date")).mappings().all()
     return [{
         "trade_date": r["trade_date"].isoformat() if r["trade_date"] else None, "account": "CDP",
         "ticker": r["ticker"], "name": r["stock_name"] or "", "action": r["action"] or "",
@@ -66,11 +64,9 @@ def cdp_cost(session=None):
 
     Transfers are skipped: the position is grouped per (funding_bucket, security), so a CDP->FSM
     move keeps both legs in the same position and the cost carries across on its own."""
-    s = session or SessionLocal()
-    rows = s.execute(text(
-        "SELECT ticker, trade_date, qty, amount, action FROM cdp_cost_lot")).all()
-    if session is None:
-        s.close()
+    with session_scope(session) as s:
+        rows = s.execute(text(
+            "SELECT ticker, trade_date, qty, amount, action FROM cdp_cost_lot")).all()
     out = {}
     for ticker, d, qty, amount, action in rows:
         if (action or "").strip().lower() in CDP_TRANSFER:
@@ -289,68 +285,68 @@ def _build_row(k, p, m, fx, price, today):
 
 
 def compute(session=None):
-    s = session or SessionLocal()
     today = dt.date.today()
-    fx, price = _fx_and_price(s)
+    with session_scope(session) as s:
+        fx, price = _fx_and_price(s)
 
-    # group txns + dividends per (account, security)
-    rows = s.execute(text("""
-        SELECT t.account_id, a.name account, a.funding_bucket, t.security_id,
-               sec.canonical_ticker, sec.name, sec.market, sec.asset_type, sec.currency,
-               t.trade_date, t.action, t.qty_signed, t.price, t.gross_amount, t.fees
-        FROM txn t JOIN account a ON a.id=t.account_id JOIN security sec ON sec.id=t.security_id
-    """)).mappings().all()
-    divs = s.execute(text("""
-        SELECT account_id, security_id, pay_date, gross, currency FROM dividend
-    """)).mappings().all()
+        # group txns + dividends per (account, security)
+        rows = s.execute(text("""
+            SELECT t.account_id, a.name account, a.funding_bucket, t.security_id,
+                   sec.canonical_ticker, sec.name, sec.market, sec.asset_type, sec.currency,
+                   t.trade_date, t.action, t.qty_signed, t.price, t.gross_amount, t.fees
+            FROM txn t JOIN account a ON a.id=t.account_id JOIN security sec ON sec.id=t.security_id
+        """)).mappings().all()
+        divs = s.execute(text("""
+            SELECT account_id, security_id, pay_date, gross, currency FROM dividend
+        """)).mappings().all()
 
-    cdp = cdp_cost(s)
-    # group per (bucket, security): transfers within a bucket (e.g. CDP->FSM) keep the cost
-    # together, so a position transferred into FSM still carries its original CDP purchase cost.
-    pos = defaultdict(lambda: {"units": 0.0, "flows": [], "invested": 0.0, "proceeds": 0.0,
-                                "income": 0.0, "buy_cost": 0.0, "buy_qty": 0.0, "fees": 0.0,
-                                "uncosted_units": 0.0, "accounts": set()})
-    meta = {}
-    _unknown_actions = set()
-    for r in rows:
-        k = (r["funding_bucket"], r["security_id"])
-        meta[k] = r
-        p = pos[k]
-        p["units"] += float(r["qty_signed"])
-        p["accounts"].add(r["account"])
-        if r["account"] == "CDP":
-            continue                                   # CDP cost comes from cdp-stocks below
-        unk = _apply_txn(p, r, today)
-        if unk is not None:
-            _unknown_actions.add(unk)
+        cdp = cdp_cost(s)
+        # group per (bucket, security): transfers within a bucket (e.g. CDP->FSM) keep the cost
+        # together, so a position transferred into FSM still carries its original CDP purchase cost.
+        pos = defaultdict(lambda: {"units": 0.0, "flows": [], "invested": 0.0, "proceeds": 0.0,
+                                    "income": 0.0, "buy_cost": 0.0, "buy_qty": 0.0, "fees": 0.0,
+                                    "uncosted_units": 0.0, "accounts": set()})
+        meta = {}
+        _unknown_actions = set()
+        for r in rows:
+            k = (r["funding_bucket"], r["security_id"])
+            meta[k] = r
+            p = pos[k]
+            p["units"] += float(r["qty_signed"])
+            p["accounts"].add(r["account"])
+            if r["account"] == "CDP":
+                continue                                   # CDP cost comes from cdp-stocks below
+            unk = _apply_txn(p, r, today)
+            if unk is not None:
+                _unknown_actions.add(unk)
 
-    if _unknown_actions:
-        log.warning("unclassified txn action(s) %s — treated as zero-cash; units may be uncosted",
-                    sorted(_unknown_actions))
+        if _unknown_actions:
+            log.warning("unclassified txn action(s) %s — treated as zero-cash; units may be uncosted",
+                        sorted(_unknown_actions))
 
-    # CDP cost (cdp-stocks) -> the CASH bucket position for that security
-    sec_by_ticker = {m["canonical_ticker"]: sid for (b, sid), m in meta.items()}
-    for tk, c in cdp.items():
-        sid = sec_by_ticker.get(tk)
-        k = ("cash", sid)
-        if sid is None or k not in pos:
-            continue
-        pos[k]["flows"].extend(c["flows"])
-        pos[k]["invested"] += c["invested"]
-        pos[k]["buy_cost"] += c["buy_cost"]
-        pos[k]["buy_qty"] += c["buy_qty"]
-        pos[k]["proceeds"] += sum(a for _, a in c["flows"] if a > 0)
+        # CDP cost (cdp-stocks) -> the CASH bucket position for that security
+        sec_by_ticker = {m["canonical_ticker"]: sid for (b, sid), m in meta.items()}
+        for tk, c in cdp.items():
+            sid = sec_by_ticker.get(tk)
+            k = ("cash", sid)
+            if sid is None or k not in pos:
+                continue
+            pos[k]["flows"].extend(c["flows"])
+            pos[k]["invested"] += c["invested"]
+            pos[k]["buy_cost"] += c["buy_cost"]
+            pos[k]["buy_qty"] += c["buy_qty"]
+            pos[k]["proceeds"] += sum(a for _, a in c["flows"] if a > 0)
 
-    bucket_by_acct_id = {r["account_id"]: r["funding_bucket"] for r in rows}
-    for d in divs:
-        k = (bucket_by_acct_id.get(d["account_id"]), d["security_id"])
-        if k not in pos:
-            continue
-        amt = float(d["gross"] or 0)
-        pos[k]["income"] += amt
-        pos[k]["flows"].append((d["pay_date"] or today, amt))
+        bucket_by_acct_id = {r["account_id"]: r["funding_bucket"] for r in rows}
+        for d in divs:
+            k = (bucket_by_acct_id.get(d["account_id"]), d["security_id"])
+            if k not in pos:
+                continue
+            amt = float(d["gross"] or 0)
+            pos[k]["income"] += amt
+            pos[k]["flows"].append((d["pay_date"] or today, amt))
 
-    _carry_corporate_actions(s, pos, meta)
+        _carry_corporate_actions(s, pos, meta)
 
     out = []
     for k, p in pos.items():
@@ -366,19 +362,15 @@ def compute(session=None):
     for r in out:
         o = opt.get(r["ticker"]) if r["bucket"] == "cash" else None
         r["options_pl_sgd"] = o["pl_sgd"] if o else 0.0
-    if session is None:
-        s.close()
     return out
 
 
 def alloc_by_account(session=None):
     """market value per account (SGD) — for allocation charts (no cost needed)."""
-    s = session or SessionLocal()
-    fx, price = _fx_and_price(s)
-    rows = s.execute(text(
-        "SELECT account, security_id, currency, units FROM current_position WHERE units > 0")).all()
-    if session is None:
-        s.close()
+    with session_scope(session) as s:
+        fx, price = _fx_and_price(s)
+        rows = s.execute(text(
+            "SELECT account, security_id, currency, units FROM current_position WHERE units > 0")).all()
     agg = defaultdict(float)
     for acct, sid, ccy, u in rows:
         px = price.get(sid)

--- a/portfolio/performance.py
+++ b/portfolio/performance.py
@@ -13,7 +13,7 @@ from collections import defaultdict
 
 from sqlalchemy import text
 
-from .db import session_scope
+from .db import fx_map, session_scope
 
 log = logging.getLogger(__name__)
 
@@ -164,7 +164,7 @@ def _xirr(flows, guess=0.1):
 
 def _fx_and_price(s):
     """Latest FX (currency -> rate_to_sgd) and latest close per security_id."""
-    fx = {c: float(r) for c, r in s.execute(text("SELECT currency, rate_to_sgd FROM fx_rate")).all()}
+    fx = fx_map(s)
     price = {sid: float(px) for sid, px in s.execute(text(
         "SELECT DISTINCT ON (security_id) security_id, close FROM price ORDER BY security_id, date DESC")).all()}
     return fx, price

--- a/portfolio/performance.py
+++ b/portfolio/performance.py
@@ -324,7 +324,7 @@ def compute(session=None):
                         sorted(_unknown_actions))
 
         # CDP cost (cdp-stocks) -> the CASH bucket position for that security
-        sec_by_ticker = {m["canonical_ticker"]: sid for (b, sid), m in meta.items()}
+        sec_by_ticker = {m["canonical_ticker"]: sid for (_, sid), m in meta.items()}
         for tk, c in cdp.items():
             sid = sec_by_ticker.get(tk)
             k = ("cash", sid)

--- a/portfolio/performance.py
+++ b/portfolio/performance.py
@@ -166,12 +166,18 @@ def _xirr(flows, guess=0.1):
     return (lo + hi) / 2
 
 
+def _fx_and_price(s):
+    """Latest FX (currency -> rate_to_sgd) and latest close per security_id."""
+    fx = {c: float(r) for c, r in s.execute(text("SELECT currency, rate_to_sgd FROM fx_rate")).all()}
+    price = {sid: float(px) for sid, px in s.execute(text(
+        "SELECT DISTINCT ON (security_id) security_id, close FROM price ORDER BY security_id, date DESC")).all()}
+    return fx, price
+
+
 def compute(session=None):
     s = session or SessionLocal()
     today = dt.date.today()
-    fx = {c: float(r) for c, r in s.execute(text("SELECT currency, rate_to_sgd FROM fx_rate")).all()}
-    price = {(sid): float(px) for sid, px in s.execute(text(
-        "SELECT DISTINCT ON (security_id) security_id, close FROM price ORDER BY security_id, date DESC")).all()}
+    fx, price = _fx_and_price(s)
 
     # group txns + dividends per (account, security)
     rows = s.execute(text("""
@@ -239,14 +245,9 @@ def compute(session=None):
         pos[k]["buy_qty"] += c["buy_qty"]
         pos[k]["proceeds"] += sum(a for _, a in c["flows"] if a > 0)
 
-    bucket_of_acct = {r["account"]: r["funding_bucket"] for r in rows}
+    bucket_by_acct_id = {r["account_id"]: r["funding_bucket"] for r in rows}
     for d in divs:
-        # find the bucket this dividend's account belongs to
-        b = None
-        for r in rows:
-            if r["account_id"] == d["account_id"]:
-                b = r["funding_bucket"]; break
-        k = (b, d["security_id"])
+        k = (bucket_by_acct_id.get(d["account_id"]), d["security_id"])
         if k not in pos:
             continue
         amt = float(d["gross"] or 0)
@@ -356,9 +357,7 @@ def compute(session=None):
 def alloc_by_account(session=None):
     """market value per account (SGD) — for allocation charts (no cost needed)."""
     s = session or SessionLocal()
-    fx = {c: float(r) for c, r in s.execute(text("SELECT currency, rate_to_sgd FROM fx_rate")).all()}
-    price = {sid: float(px) for sid, px in s.execute(text(
-        "SELECT DISTINCT ON (security_id) security_id, close FROM price ORDER BY security_id, date DESC")).all()}
+    fx, price = _fx_and_price(s)
     rows = s.execute(text(
         "SELECT account, security_id, currency, units FROM current_position WHERE units > 0")).all()
     if session is None:

--- a/portfolio/performance.py
+++ b/portfolio/performance.py
@@ -174,6 +174,51 @@ def _fx_and_price(s):
     return fx, price
 
 
+def _build_row(k, p, m, fx, price, today):
+    """Assemble one position's output dict (native ccy + SGD) from its accumulated flows/units."""
+    ccy = m["currency"] or "SGD"
+    rate = fx.get(ccy, 1.0)
+    px = price.get(k[1])
+    mv = (p["units"] * px) if px else 0.0
+    flows = list(p["flows"])
+    if p["units"] > 1e-6 and px:
+        flows.append((today, mv))
+    cost_known = p["invested"] > 1e-6
+    # XIRR is only meaningful when every unit that entered has a known cost and the flows
+    # span long enough for annualisation to mean something.
+    span = (max(d for d, _ in flows) - min(d for d, _ in flows)).days if flows else 0
+    xirr_ok = cost_known and p["uncosted_units"] < 1e-6 and span >= MIN_XIRR_DAYS
+    xirr = _xirr(flows) if xirr_ok else None
+    total_pl = (mv + p["proceeds"] + p["income"] - p["invested"]) if cost_known else None
+    simple = (total_pl / p["invested"]) if cost_known else None
+    # cost basis of CURRENT holding (avg cost × held units) + unrealised P/L
+    avg_cost = (p["buy_cost"] / p["buy_qty"]) if p["buy_qty"] > 1e-6 else None
+    cost_basis = (avg_cost * p["units"]) if (avg_cost and p["units"] > 1e-6) else None
+    unreal = (mv - cost_basis) if cost_basis is not None else None
+    # realised stock P/L = sell proceeds − cost of the shares sold (buy_cost minus the
+    # cost still tied up in the current holding). Closed positions: cost_basis None -> all sold.
+    realised = (p["proceeds"] - p["buy_cost"] + (cost_basis or 0.0)) if cost_known else None
+    return {
+        "bucket": k[0], "accounts": sorted(p["accounts"]), "ticker": m["canonical_ticker"],
+        "name": m["name"], "market": m["market"], "asset_type": m["asset_type"], "currency": ccy,
+        "units": round(p["units"], 4), "price": px, "mv_native": round(mv, 2),
+        "avg_cost": round(avg_cost, 4) if avg_cost else None,
+        "cost_basis_native": round(cost_basis, 2) if cost_basis is not None else None,
+        "cost_basis_sgd": round(cost_basis * rate, 2) if cost_basis is not None else None,
+        "unrealised_pl_sgd": round(unreal * rate, 2) if unreal is not None else None,
+        "realised_pl_sgd": round(realised * rate, 2) if realised is not None else None,
+        "invested_native": round(p["invested"], 2), "income_native": round(p["income"], 2),
+        "fees_sgd": round(p["fees"] * rate, 2), "cost_known": cost_known,
+        "uncosted_units": round(p["uncosted_units"], 4),
+        "total_pl_native": round(total_pl, 2) if cost_known else None,
+        "invested_sgd": round(p["invested"] * rate, 2) if cost_known else 0.0,
+        "mv_sgd": round(mv * rate, 2), "income_sgd": round(p["income"] * rate, 2),
+        "pl_sgd": round(total_pl * rate, 2) if cost_known else None,
+        "xirr": round(xirr, 4) if xirr is not None else None,
+        "simple_return": round(simple, 4) if cost_known else None,
+    }
+
+
 def compute(session=None):
     s = session or SessionLocal()
     today = dt.date.today()
@@ -300,47 +345,7 @@ def compute(session=None):
         m = meta.get(k)
         if not m:
             continue
-        ccy = m["currency"] or "SGD"
-        rate = fx.get(ccy, 1.0)
-        px = price.get(k[1])
-        mv = (p["units"] * px) if px else 0.0
-        flows = list(p["flows"])
-        if p["units"] > 1e-6 and px:
-            flows.append((today, mv))
-        cost_known = p["invested"] > 1e-6
-        # XIRR is only meaningful when every unit that entered has a known cost and the flows
-        # span long enough for annualisation to mean something.
-        span = (max(d for d, _ in flows) - min(d for d, _ in flows)).days if flows else 0
-        xirr_ok = cost_known and p["uncosted_units"] < 1e-6 and span >= MIN_XIRR_DAYS
-        xirr = _xirr(flows) if xirr_ok else None
-        total_pl = (mv + p["proceeds"] + p["income"] - p["invested"]) if cost_known else None
-        simple = (total_pl / p["invested"]) if cost_known else None
-        # cost basis of CURRENT holding (avg cost × held units) + unrealised P/L
-        avg_cost = (p["buy_cost"] / p["buy_qty"]) if p["buy_qty"] > 1e-6 else None
-        cost_basis = (avg_cost * p["units"]) if (avg_cost and p["units"] > 1e-6) else None
-        unreal = (mv - cost_basis) if cost_basis is not None else None
-        # realised stock P/L = sell proceeds − cost of the shares sold (buy_cost minus the
-        # cost still tied up in the current holding). Closed positions: cost_basis None -> all sold.
-        realised = (p["proceeds"] - p["buy_cost"] + (cost_basis or 0.0)) if cost_known else None
-        out.append({
-            "bucket": k[0], "accounts": sorted(p["accounts"]), "ticker": m["canonical_ticker"],
-            "name": m["name"], "market": m["market"], "asset_type": m["asset_type"], "currency": ccy,
-            "units": round(p["units"], 4), "price": px, "mv_native": round(mv, 2),
-            "avg_cost": round(avg_cost, 4) if avg_cost else None,
-            "cost_basis_native": round(cost_basis, 2) if cost_basis is not None else None,
-            "cost_basis_sgd": round(cost_basis * rate, 2) if cost_basis is not None else None,
-            "unrealised_pl_sgd": round(unreal * rate, 2) if unreal is not None else None,
-            "realised_pl_sgd": round(realised * rate, 2) if realised is not None else None,
-            "invested_native": round(p["invested"], 2), "income_native": round(p["income"], 2),
-            "fees_sgd": round(p["fees"] * rate, 2), "cost_known": cost_known,
-            "uncosted_units": round(p["uncosted_units"], 4),
-            "total_pl_native": round(total_pl, 2) if cost_known else None,
-            "invested_sgd": round(p["invested"] * rate, 2) if cost_known else 0.0,
-            "mv_sgd": round(mv * rate, 2), "income_sgd": round(p["income"] * rate, 2),
-            "pl_sgd": round(total_pl * rate, 2) if cost_known else None,
-            "xirr": round(xirr, 4) if xirr is not None else None,
-            "simple_return": round(simple, 4) if cost_known else None,
-        })
+        out.append(_build_row(k, p, m, fx, price, today))
     # fold in the options income stream per underlying (realized, SGD). Options trade on the
     # cash account, so attach to the cash-bucket row for that security; orphan underlyings
     # (no stock position) are still counted in the Performance rollup via options.realized_by().

--- a/portfolio/performance.py
+++ b/portfolio/performance.py
@@ -13,7 +13,7 @@ from collections import defaultdict
 
 from sqlalchemy import text
 
-from .db import fx_map, session_scope
+from .db import fx_map, latest_close, session_scope
 
 log = logging.getLogger(__name__)
 
@@ -165,8 +165,7 @@ def _xirr(flows, guess=0.1):
 def _fx_and_price(s):
     """Latest FX (currency -> rate_to_sgd) and latest close per security_id."""
     fx = fx_map(s)
-    price = {sid: float(px) for sid, px in s.execute(text(
-        "SELECT DISTINCT ON (security_id) security_id, close FROM price ORDER BY security_id, date DESC")).all()}
+    price = latest_close(s)
     return fx, price
 
 

--- a/portfolio/performance.py
+++ b/portfolio/performance.py
@@ -17,21 +17,6 @@ from .db import fx_map, latest_close, session_scope
 
 log = logging.getLogger(__name__)
 
-_ALIAS = {"QAF": "Q01", "CWBU": "SET", "C": "C52"}
-
-
-def _num(s):
-    s = str(s or "").replace(",", "").replace("$", "").strip()
-    if not s or s == "-":
-        return 0.0
-    neg = s.startswith("(") and s.endswith(")")
-    s = s.strip("()")
-    try:
-        v = float(s)
-    except ValueError:
-        return 0.0
-    return -v if neg else v
-
 
 def cdp_transactions(session=None):
     """CDP trades from the cdp_cost_lot table (priced) for the transactions view — the cost

--- a/portfolio/performance.py
+++ b/portfolio/performance.py
@@ -18,6 +18,11 @@ from .db import fx_map, latest_close, session_scope
 log = logging.getLogger(__name__)
 
 
+def _f(x):
+    """float(x), passing None through unchanged — for nullable numeric fields."""
+    return float(x) if x is not None else None
+
+
 def cdp_transactions(session=None):
     """CDP trades from the cdp_cost_lot table (priced) for the transactions view — the cost
     record the CDP statements omit. Loaded from data/cdp-stocks/transactions.csv by
@@ -30,8 +35,8 @@ def cdp_transactions(session=None):
         "trade_date": r["trade_date"].isoformat() if r["trade_date"] else None, "account": "CDP",
         "ticker": r["ticker"], "name": r["stock_name"] or "", "action": r["action"] or "",
         "qty_signed": float(r["qty"] or 0),
-        "price": float(r["unit_price"]) if r["unit_price"] is not None else None,
-        "gross_amount": float(r["amount"]) if r["amount"] is not None else None,
+        "price": _f(r["unit_price"]),
+        "gross_amount": _f(r["amount"]),
         "currency": r["currency"] or "SGD", "source_file": "cdp-stocks/transactions.csv",
     } for r in rows]
 
@@ -201,7 +206,7 @@ def _apply_txn(p, r, today):
     """Fold one non-CDP txn row into its position accumulator `p`. Returns the action
     string if it couldn't be classified (caller should warn), else None."""
     act = r["action"]
-    px = float(r["price"]) if r["price"] is not None else None
+    px = _f(r["price"])
     fee = abs(float(r["fees"])) if r["fees"] is not None else 0.0   # native ccy, same as px*qty
     kind = classify(act, px)
     if kind == "cash":

--- a/portfolio/performance.py
+++ b/portfolio/performance.py
@@ -217,6 +217,32 @@ def _carry_corporate_actions(s, pos, meta):
             pos[k]["buy_qty"] = pos[k]["units"]
 
 
+def _apply_txn(p, r, today):
+    """Fold one non-CDP txn row into its position accumulator `p`. Returns the action
+    string if it couldn't be classified (caller should warn), else None."""
+    act = r["action"]
+    px = float(r["price"]) if r["price"] is not None else None
+    fee = abs(float(r["fees"])) if r["fees"] is not None else 0.0   # native ccy, same as px*qty
+    kind = classify(act, px)
+    if kind == "cash":
+        # fees are a real cost: bigger outflow on a buy, smaller net inflow on a sell
+        cash = -float(r["qty_signed"]) * px - fee
+        p["fees"] += fee
+        p["flows"].append((r["trade_date"] or today, cash))
+        if cash < 0:
+            p["invested"] += -cash
+            p["buy_cost"] += -cash
+            p["buy_qty"] += float(r["qty_signed"])
+        else:
+            p["proceeds"] += cash
+    elif kind == "uncosted":
+        if float(r["qty_signed"]) > 0:
+            p["uncosted_units"] += float(r["qty_signed"])
+    elif kind == "unknown":
+        return act                                     # don't silently hand out free units
+    return None
+
+
 def _build_row(k, p, m, fx, price, today):
     """Assemble one position's output dict (native ccy + SGD) from its accumulated flows/units."""
     ccy = m["currency"] or "SGD"
@@ -294,27 +320,9 @@ def compute(session=None):
         p["accounts"].add(r["account"])
         if r["account"] == "CDP":
             continue                                   # CDP cost comes from cdp-stocks below
-        act = r["action"]
-        px = float(r["price"]) if r["price"] is not None else None
-        fee = abs(float(r["fees"])) if r["fees"] is not None else 0.0   # native ccy, same as px*qty
-        kind = classify(act, px)
-        if kind == "cash":
-            cash = -float(r["qty_signed"]) * px
-            # fees are a real cost: bigger outflow on a buy, smaller net inflow on a sell
-            cash -= fee
-            p["fees"] += fee
-            p["flows"].append((r["trade_date"] or today, cash))
-            if cash < 0:
-                p["invested"] += -cash
-                p["buy_cost"] += -cash
-                p["buy_qty"] += float(r["qty_signed"])
-            else:
-                p["proceeds"] += cash
-        elif kind == "uncosted":
-            if float(r["qty_signed"]) > 0:
-                p["uncosted_units"] += float(r["qty_signed"])
-        elif kind == "unknown":
-            _unknown_actions.add(act)                  # don't silently hand out free units
+        unk = _apply_txn(p, r, today)
+        if unk is not None:
+            _unknown_actions.add(unk)
 
     if _unknown_actions:
         log.warning("unclassified txn action(s) %s — treated as zero-cash; units may be uncosted",

--- a/portfolio/performance.py
+++ b/portfolio/performance.py
@@ -363,10 +363,16 @@ def alloc_by_account(session=None):
     return {k: {"mv_sgd": round(v, 2)} for k, v in agg.items()}
 
 
+def empty_group():
+    """Zeroed rollup-group accumulator. Shared with server.main so the groups it
+    synthesises for orphan option underlyings match rollup()'s schema exactly."""
+    return {"mv_sgd": 0.0, "income_sgd": 0.0, "pl_sgd": 0.0, "cost_sgd": 0.0,
+            "capital_sgd": 0.0, "invested_sgd": 0.0,
+            "realised_pl_sgd": 0.0, "unrealised_pl_sgd": 0.0}
+
+
 def rollup(rows, by):
-    agg = defaultdict(lambda: {"mv_sgd": 0.0, "income_sgd": 0.0, "pl_sgd": 0.0, "cost_sgd": 0.0,
-                               "capital_sgd": 0.0, "invested_sgd": 0.0,
-                               "realised_pl_sgd": 0.0, "unrealised_pl_sgd": 0.0})
+    agg = defaultdict(empty_group)
     for r in rows:
         # include closed positions (units≈0): they still carry realised P/L + dividends.
         if r["units"] <= 1e-6 and not r["cost_known"] and abs(r["income_sgd"]) < 1e-6:

--- a/portfolio/recurring.py
+++ b/portfolio/recurring.py
@@ -177,7 +177,7 @@ def _infer_cadence(gaps):
     if not gaps:
         return None
     g = statistics.median(gaps)
-    for cad, nominal in (("weekly", 7), ("monthly", 30), ("quarterly", 91), ("annual", 365)):
+    for cad, nominal in CADENCE_DAYS.items():
         if nominal * 0.7 <= g <= nominal * 1.3:
             return cad
     return None

--- a/portfolio/recurring.py
+++ b/portfolio/recurring.py
@@ -102,9 +102,8 @@ def _occurrences(s, match):
 
 def list_recurring():
     """Every registered recurring charge with matched-occurrence timing + status."""
-    s = SessionLocal()
     today = dt.date.today()
-    try:
+    with SessionLocal() as s:
         defs = s.execute(text(
             "SELECT id, name, merchant_match, category, cadence, expected_amount, "
             "expected_day, active, notes FROM recurring_spend ORDER BY name")).mappings().all()
@@ -143,14 +142,11 @@ def list_recurring():
                 "status": "inactive" if not d["active"] else _status(next_due, today),
             })
         return out
-    finally:
-        s.close()
 
 
 def add(name, merchant_match=None, category=None, cadence="monthly",
         expected_amount=None, expected_day=None, notes=None):
-    s = SessionLocal()
-    try:
+    with SessionLocal() as s:
         row = s.execute(text(
             "INSERT INTO recurring_spend (name, merchant_match, category, cadence, "
             "expected_amount, expected_day, notes) VALUES "
@@ -160,28 +156,20 @@ def add(name, merchant_match=None, category=None, cadence="monthly",
              "amt": expected_amount, "day": expected_day, "notes": notes}).scalar()
         s.commit()
         return row
-    finally:
-        s.close()
 
 
 def delete(rid):
-    s = SessionLocal()
-    try:
+    with SessionLocal() as s:
         s.execute(text("DELETE FROM recurring_spend WHERE id = :id"), {"id": rid})
         s.commit()
-    finally:
-        s.close()
 
 
 def dismiss(merchant):
     """Mark a detected merchant as a false positive so detect_candidates stops suggesting it."""
-    s = SessionLocal()
-    try:
+    with SessionLocal() as s:
         s.execute(text("INSERT INTO recurring_dismissed (merchant) VALUES (:m) "
                        "ON CONFLICT (merchant) DO NOTHING"), {"m": merchant})
         s.commit()
-    finally:
-        s.close()
 
 
 def _infer_cadence(gaps):
@@ -204,8 +192,7 @@ def detect_candidates(min_occurrences=3):
     hsbc / trust) and DBS GIRO / standing instructions — so one-off transfers, PayNow, ATM
     withdrawals etc. never surface as suggestions. Merchants the user has dismissed are
     excluded so a rejected suggestion never reappears."""
-    s = SessionLocal()
-    try:
+    with SessionLocal() as s:
         registered = [r[0].lower() for r in s.execute(text(
             "SELECT merchant_match FROM recurring_spend WHERE merchant_match IS NOT NULL")).all()]
         dismissed = {r[0].lower() for r in s.execute(text(
@@ -246,5 +233,3 @@ def detect_candidates(min_occurrences=3):
             })
         out.sort(key=lambda r: r["avg_amount"], reverse=True)
         return out
-    finally:
-        s.close()

--- a/portfolio/recurring.py
+++ b/portfolio/recurring.py
@@ -17,6 +17,11 @@ from portfolio.db import SessionLocal
 CADENCE_DAYS = {"weekly": 7, "monthly": 30, "quarterly": 91, "annual": 365}
 
 
+def _d(x):
+    """x.isoformat() for a truthy date, else None (nullable date -> nullable ISO string)."""
+    return x.isoformat() if x else None
+
+
 def _add_period(d, cadence):
     """Next occurrence date after `d` for a cadence, using calendar months where sensible."""
     if cadence == "weekly":
@@ -128,10 +133,10 @@ def list_recurring():
                 "expected_amount": exp, "expected_day": d["expected_day"],
                 "active": d["active"], "notes": d["notes"],
                 "occurrences": len(occ),
-                "last_seen": last_date.isoformat() if last_date else None,
+                "last_seen": _d(last_date),
                 "last_amount": last_amt, "avg_amount": avg_amt,
                 "typical_day": typical_day,
-                "next_due": next_due.isoformat() if next_due else None,
+                "next_due": _d(next_due),
                 "shift": shift,                         # 'prev'|'next' if weekend-adjusted, else None
                 "amount_drift": drift,
                 "status": "inactive" if not d["active"] else _status(next_due, today),

--- a/portfolio/recurring.py
+++ b/portfolio/recurring.py
@@ -5,6 +5,7 @@ overdue / amount-drifted charges. Also auto-detects recurring merchants not yet 
 All amounts SGD, positive magnitude (spend). Occurrence = an is_spend cash_txn whose merchant
 contains the recurring's merchant_match (case-insensitive).
 """
+import calendar
 import datetime as dt
 import statistics
 
@@ -27,17 +28,11 @@ def _add_period(d, cadence):
     return _add_months(d, 1)                            # monthly (default)
 
 
-def _mdays(y, m):
-    """Days in month m of year y (leap-aware)."""
-    return [31, 29 if y % 4 == 0 and (y % 100 or y % 400 == 0) else 28,
-            31, 30, 31, 30, 31, 31, 30, 31, 30, 31][m - 1]
-
-
 def _add_months(d, n):
     m = d.month - 1 + n
     y = d.year + m // 12
     m = m % 12 + 1
-    return dt.date(y, m, min(d.day, _mdays(y, m)))
+    return dt.date(y, m, min(d.day, calendar.monthrange(y, m)[1]))
 
 
 # ---- business-day handling: GIRO / standing instructions / card charges only post on
@@ -66,7 +61,7 @@ def _infer_shift(occ, nominal_day):
         return "next"
     nxt = prev = 0
     for d, _ in occ:
-        nominal = dt.date(d.year, d.month, min(nominal_day, _mdays(d.year, d.month)))
+        nominal = dt.date(d.year, d.month, min(nominal_day, calendar.monthrange(d.year, d.month)[1]))
         if not _is_weekend(nominal):
             continue
         delta = (d - nominal).days

--- a/portfolio/twr.py
+++ b/portfolio/twr.py
@@ -18,7 +18,7 @@ from collections import defaultdict
 
 from sqlalchemy import text
 
-from .db import SessionLocal
+from .db import SessionLocal, latest_close
 
 UA = {"User-Agent": "Mozilla/5.0"}
 
@@ -206,9 +206,7 @@ def compute_twr():
         "FROM dividend WHERE pay_date IS NOT NULL AND security_id = ANY(:ids)"),
         {"ids": ids}).mappings().all()
     # last known close per security — covers what Yahoo can't price (funds, delisted tickers)
-    last_px = {sid: float(px) for sid, px in s.execute(text(
-        "SELECT DISTINCT ON (security_id) security_id, close FROM price ORDER BY security_id, date DESC"
-    )).all()}
+    last_px = latest_close(s)
     s.close()
 
     start = min((t["trade_date"] for t in txns), default=dt.date.today())

--- a/portfolio/twr.py
+++ b/portfolio/twr.py
@@ -23,6 +23,10 @@ from .db import SessionLocal, latest_close
 UA = {"User-Agent": "Mozilla/5.0"}
 
 
+def _r4(x):
+    return round(x, 4) if x is not None else None
+
+
 def ysym(tk, market):
     if market == "SG":
         return f"{tk}.SI"
@@ -304,9 +308,9 @@ def compute_twr():
     invested = sum(-a for _, a in flows if a < 0)
     received = sum(a for _, a in flows if a > 0)
     years = max((today - start).days / 365.0, 0.1)
-    return {"xirr_annualised": round(xirr, 4) if xirr is not None else None,
-            "twr_annualised": round(twr_ann, 4) if twr_ann is not None else None,
-            "twr_cumulative": round(twr_cum, 4) if twr_cum is not None else None,
+    return {"xirr_annualised": _r4(xirr),
+            "twr_annualised": _r4(twr_ann),
+            "twr_cumulative": _r4(twr_cum),
             "invested_sgd": round(invested, 0), "value_plus_income_sgd": round(received, 0),
             "years": round(years, 1), "from": str(start),
             "note": "money-weighted (XIRR, pay-date dividends) + time-weighted (TWR, ex-date "

--- a/portfolio/twr.py
+++ b/portfolio/twr.py
@@ -10,6 +10,7 @@ arrives without a txn price (transfer, snapshot-diff open, fund switch) still ca
 basis instead of landing in the terminal value for free.
 Run: PYTHONPATH=. .venv/bin/python -m portfolio.twr
 """
+import bisect
 import datetime as dt
 import json
 import urllib.request
@@ -93,10 +94,28 @@ def running_units(txns, sids):
 
 
 def units_on(cum, sid, day):
-    import bisect
     d_, u_ = cum[sid]
     i = bisect.bisect_right(d_, day) - 1
     return u_[i] if i >= 0 else 0.0
+
+
+def traded_vwap(txns):
+    """sid -> sorted [(date, vwap)] from priced txn rows.
+
+    Volume-weights same-day priced rows into one price per (security, day), so securities
+    Yahoo has no daily series for (funds, delisted tickers) still get a nearest-dated cost
+    basis. Zero-qty priced rows carry no vwap and are dropped."""
+    day_px, day_qty = defaultdict(float), defaultdict(float)
+    for t in txns:
+        if t["price"] is not None:
+            q = abs(float(t["qty_signed"]))
+            day_px[(t["security_id"], t["trade_date"])] += q * float(t["price"])
+            day_qty[(t["security_id"], t["trade_date"])] += q
+    txn_px = defaultdict(list)
+    for (sid, day), q in sorted(day_qty.items()):
+        if q > 1e-9:
+            txn_px[sid].append((day, day_px[(sid, day)] / q))
+    return txn_px
 
 
 def contributions(txns, sids, px, ccy_of, fx):
@@ -214,16 +233,7 @@ def compute_twr():
     price_sids = [sid for sid, p in prices.items() if p]
 
     # traded price per (security, day), for securities Yahoo has no daily series for
-    day_px, day_qty = defaultdict(float), defaultdict(float)
-    for t in txns:
-        if t["price"] is not None:
-            q = abs(float(t["qty_signed"]))
-            day_px[(t["security_id"], t["trade_date"])] += q * float(t["price"])
-            day_qty[(t["security_id"], t["trade_date"])] += q
-    txn_px = defaultdict(list)                           # sid -> sorted [(date, vwap)]
-    for (sid, day), q in sorted(day_qty.items()):
-        if q > 1e-9:                                    # zero-qty priced rows carry no vwap
-            txn_px[sid].append((day, day_px[(sid, day)] / q))
+    txn_px = traded_vwap(txns)
 
     def px_daily(sid, day):
         """Daily close, forward-filled for a pre-history buy."""

--- a/scripts/seed.py
+++ b/scripts/seed.py
@@ -11,7 +11,7 @@ import os
 import sys
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
-from sqlalchemy import select
+from sqlalchemy import func, select
 
 from portfolio.db import SessionLocal
 from portfolio.models import Account, CorporateAction, Security, SecurityAlias
@@ -141,10 +141,9 @@ def main():
                                   from_ticker=frm, to_ticker=to, ratio_num=rn, ratio_den=rd, notes=note))
 
     s.commit()
-    print(f"accounts: {s.scalar(select(__import__('sqlalchemy').func.count()).select_from(Account))}")
-    print(f"securities: {s.scalar(select(__import__('sqlalchemy').func.count()).select_from(Security))}")
-    print(f"aliases: {s.scalar(select(__import__('sqlalchemy').func.count()).select_from(SecurityAlias))}")
-    print(f"corporate_actions: {s.scalar(select(__import__('sqlalchemy').func.count()).select_from(CorporateAction))}")
+    for label, model in (("accounts", Account), ("securities", Security),
+                         ("aliases", SecurityAlias), ("corporate_actions", CorporateAction)):
+        print(f"{label}: {s.scalar(select(func.count()).select_from(model))}")
     s.close()
 
 

--- a/server/main.py
+++ b/server/main.py
@@ -19,7 +19,7 @@ from sqlalchemy import text
 from portfolio.config import settings
 
 from server import auth
-from portfolio.db import SessionLocal
+from portfolio.db import SessionLocal, fx_map
 from portfolio.performance import alloc_by_account, compute, rollup
 
 logging.basicConfig(level=logging.INFO,
@@ -338,8 +338,7 @@ def dividends_annual():
     Historical FX is not stored, so prior years use today's rate (an approximation)."""
     from collections import defaultdict
     s = SessionLocal()
-    fx = {c: float(r) for c, r in s.execute(text(
-        "SELECT currency, rate_to_sgd FROM fx_rate")).all()}
+    fx = fx_map(s)
     rows = s.execute(text(
         "SELECT EXTRACT(YEAR FROM d.pay_date)::int yr, "
         "COALESCE(a.funding_bucket, 'cash') bucket, d.currency, sum(d.gross) gross "

--- a/server/main.py
+++ b/server/main.py
@@ -519,8 +519,7 @@ def _spend_where(frm, to, extra=""):
 def spending_summary(frm: str | None = Query(None, alias="from"),
                      to: str | None = Query(None, alias="to")):
     where, p = _spend_where(frm, to)
-    s = SessionLocal()
-    try:
+    with SessionLocal() as s:
         total = s.execute(text(f"SELECT COALESCE(SUM(-amount_sgd),0) FROM cash_txn WHERE {where}"),
                           p).scalar()
         by_group = s.execute(text(
@@ -541,8 +540,6 @@ def spending_summary(frm: str | None = Query(None, alias="from"),
             "by_subcategory": [dict(r) for r in by_sub],
             "by_month": [dict(r) for r in by_month],
         }
-    finally:
-        s.close()
 
 
 @app.get("/api/spending/trends")
@@ -550,8 +547,7 @@ def spending_trends(frm: str | None = Query(None, alias="from"),
                     to: str | None = Query(None, alias="to")):
     """Monthly spend split by group — a stacked time series (one key per group)."""
     where, p = _spend_where(frm, to)
-    s = SessionLocal()
-    try:
+    with SessionLocal() as s:
         rows = s.execute(text(
             f"SELECT to_char(txn_date,'YYYY-MM') ym, category, ROUND(SUM(-amount_sgd),2) v "
             f"FROM cash_txn WHERE {where} GROUP BY ym, category ORDER BY ym"), p).mappings().all()
@@ -562,8 +558,6 @@ def spending_trends(frm: str | None = Query(None, alias="from"),
             m[r["category"]] = float(r["v"])
         out = [{**{g: 0 for g in groups}, **m} for m in series.values()]
         return {"groups": groups, "series": sorted(out, key=lambda x: x["ym"])}
-    finally:
-        s.close()
 
 
 @app.get("/api/spending/transactions")
@@ -586,29 +580,23 @@ def spending_transactions(frm: str | None = Query(None, alias="from"),
         w.append("subcategory = :sub"); p["sub"] = subcategory
     if source:
         w.append("source = :src"); p["src"] = source
-    s = SessionLocal()
-    try:
+    with SessionLocal() as s:
         rows = s.execute(text(
             f"SELECT txn_date, source, account_label, merchant, description, amount_sgd, "
             f"direction, is_spend, exclude_reason, category, subcategory "
             f"FROM cash_txn WHERE {' AND '.join(w)} "
             f"ORDER BY txn_date DESC, id DESC LIMIT :lim"), p).mappings().all()
         return [dict(r) for r in rows]
-    finally:
-        s.close()
 
 
 @app.get("/api/spending/categories")
 def spending_categories():
-    s = SessionLocal()
-    try:
+    with SessionLocal() as s:
         rows = s.execute(text(
             "SELECT category, subcategory, ROUND(SUM(-amount_sgd),2) v, COUNT(*) n "
             "FROM cash_txn WHERE is_spend GROUP BY category, subcategory ORDER BY category, v DESC"
         )).mappings().all()
         return [dict(r) for r in rows]
-    finally:
-        s.close()
 
 
 # ---------------- recurring spends ----------------

--- a/server/main.py
+++ b/server/main.py
@@ -20,7 +20,7 @@ from portfolio.config import settings
 
 from server import auth
 from portfolio.db import SessionLocal, fx_map
-from portfolio.performance import alloc_by_account, compute, rollup
+from portfolio.performance import alloc_by_account, compute, empty_group, rollup
 
 logging.basicConfig(level=logging.INFO,
                     format="%(asctime)s %(levelname)s %(name)s %(message)s")  # SECURITY-03
@@ -202,9 +202,7 @@ def performance(by: str = Query("market", enum=["market", "bucket", "account"]))
     # options book so orphan underlyings with no stock position are still counted)
     from portfolio.options import realized_by
     for k, v in realized_by(by).items():
-        r.setdefault(k, {"mv_sgd": 0.0, "income_sgd": 0.0, "pl_sgd": 0.0, "cost_sgd": 0.0,
-                         "capital_sgd": 0.0, "invested_sgd": 0.0,
-                         "realised_pl_sgd": 0.0, "unrealised_pl_sgd": 0.0})
+        r.setdefault(k, empty_group())
         r[k]["options_pl_sgd"] = v
     for g in r.values():
         g.setdefault("options_pl_sgd", 0.0)

--- a/server/main.py
+++ b/server/main.py
@@ -133,6 +133,11 @@ def _date_key(field):
     return lambda r: (r[field] is None, str(r[field] or ""))
 
 
+def _f(x):
+    """float(x), passing None through unchanged."""
+    return float(x) if x is not None else None
+
+
 def perf_all():
     return _cached("all", compute)
 
@@ -253,12 +258,12 @@ def holding(ticker: str, bucket: str = "cash"):
     # enrich each dividend with qty held at pay date + declared rate per unit.
     # prefer statement-stated values; fall back to ledger replay / implied (gross/qty).
     for x in divs:
-        units = float(x["units"]) if x["units"] is not None else None
+        units = _f(x["units"])
         if units is None and x["pay_date"] is not None:
             units = round(sum(float(t["qty_signed"] or 0) for t in txns
                               if t["account"] == x["account"] and t["trade_date"] is not None
                               and str(t["trade_date"]) <= str(x["pay_date"])), 4)
-        rate = float(x["amount_per_unit"]) if x["amount_per_unit"] is not None else None
+        rate = _f(x["amount_per_unit"])
         if rate is None and units and units > 1e-6:
             rate = round(float(x["gross"] or 0) / units, 6)
         x["units"] = units
@@ -312,8 +317,8 @@ def dividend_details():
     out = []
     for d in divs:
         gross = float(d["gross"] or 0)
-        declared = float(d["declared_rate"]) if d["declared_rate"] is not None else None
-        stated = float(d["stated_units"]) if d["stated_units"] is not None else None
+        declared = _f(d["declared_rate"])
+        stated = _f(d["stated_units"])
         held = None
         if d["pay_date"] is not None and d["security_id"] is not None:
             held = round(sum(q for td, q in by.get((d["account_id"], d["security_id"]), [])

--- a/server/main.py
+++ b/server/main.py
@@ -116,16 +116,19 @@ async def _unhandled(request: Request, exc: Exception):
 _cache: dict = {}
 
 
+def _cached(key, fn):
+    """Memoize fn()'s result in the process-wide _cache under key (cleared by /refresh)."""
+    if key not in _cache:
+        _cache[key] = fn()
+    return _cache[key]
+
+
 def perf_all():
-    if "all" not in _cache:
-        _cache["all"] = compute()
-    return _cache["all"]
+    return _cached("all", compute)
 
 
 def perf():
-    if "rows" not in _cache:
-        _cache["rows"] = [r for r in perf_all() if r["units"] > 1e-6]
-    return _cache["rows"]
+    return _cached("rows", lambda: [r for r in perf_all() if r["units"] > 1e-6])
 
 
 @app.post("/api/refresh")
@@ -402,10 +405,8 @@ def portfolio_return():
 
 @app.get("/api/options")
 def options_summary():
-    if "opt" not in _cache:
-        from portfolio.options import compute
-        _cache["opt"] = compute()
-    return _cache["opt"]
+    from portfolio.options import compute
+    return _cached("opt", compute)
 
 
 @app.get("/api/options-trades")

--- a/server/main.py
+++ b/server/main.py
@@ -128,6 +128,11 @@ def _dicts(s, sql, params=None):
     return [dict(r) for r in s.execute(text(sql), params or {}).mappings().all()]
 
 
+def _date_key(field):
+    """Sort key over a nullable date `field`: null dates sort last (ascending)."""
+    return lambda r: (r[field] is None, str(r[field] or ""))
+
+
 def perf_all():
     return _cached("all", compute)
 
@@ -242,7 +247,7 @@ def holding(ticker: str, bucket: str = "cash"):
     if bucket == "cash":                               # CDP trades from cdp-stocks (priced)
         from portfolio.performance import cdp_transactions
         txns += [r for r in cdp_transactions() if r["ticker"] == ticker]
-    txns.sort(key=lambda r: (r["trade_date"] is None, str(r["trade_date"] or "")))
+    txns.sort(key=_date_key("trade_date"))
     bal = 0.0
     for t in txns:
         bal += float(t["qty_signed"] or 0)
@@ -333,7 +338,7 @@ def dividend_details():
             "rate_source": ("declared" if declared is not None else ("implied" if implied is not None else None)),
             "flags": flags,
         })
-    out.sort(key=lambda r: (r["pay_date"] is None, str(r["pay_date"] or "")), reverse=True)
+    out.sort(key=_date_key("pay_date"), reverse=True)
     return {"rows": out, "flagged": sum(1 for r in out if r["flags"]), "total": len(out)}
 
 
@@ -392,7 +397,7 @@ def transactions(account: str | None = None, ticker: str | None = None, limit: i
         if ticker:
             cdp = [r for r in cdp if r["ticker"] == ticker]
         rows += cdp
-    rows.sort(key=lambda r: (r["trade_date"] is None, str(r["trade_date"] or "")))
+    rows.sort(key=_date_key("trade_date"))
     return rows[:limit]
 
 

--- a/server/main.py
+++ b/server/main.py
@@ -123,6 +123,11 @@ def _cached(key, fn):
     return _cache[key]
 
 
+def _dicts(s, sql, params=None):
+    """Run a text() query on session `s` and return its rows as plain dicts."""
+    return [dict(r) for r in s.execute(text(sql), params or {}).mappings().all()]
+
+
 def perf_all():
     return _cached("all", compute)
 
@@ -218,21 +223,21 @@ def holding(ticker: str, bucket: str = "cash"):
     summary = next((r for r in perf_all() if r["ticker"] == ticker and r["bucket"] == bucket), None)
     accts = BUCKET_ACCTS.get(bucket, [])
     s = SessionLocal()
-    txns = [dict(r) for r in s.execute(text(
+    txns = _dicts(s,
         "SELECT t.trade_date, a.name account, t.action, t.qty_signed, t.price, t.gross_amount, "
         "t.currency, t.source_file FROM txn t JOIN account a ON a.id=t.account_id "
         "JOIN security sec ON sec.id=t.security_id "
         "WHERE sec.canonical_ticker=:tk AND a.name = ANY(:accts) AND a.name <> 'CDP' "
         # cash dividends are recorded as 0-qty 'stock dividend' txns — they belong in the
         # dividend history, not the transaction ledger (they don't change the position)
-        "AND NOT (t.action ILIKE '%dividend%' AND t.qty_signed = 0)"),
-        {"tk": ticker, "accts": accts}).mappings().all()]
-    divs = [dict(r) for r in s.execute(text(
+        "AND NOT (t.action ILIKE '%dividend%' AND t.qty_signed = 0)",
+        {"tk": ticker, "accts": accts})
+    divs = _dicts(s,
         "SELECT d.pay_date, a.name account, d.gross, d.currency, d.kind, "
         "d.units, d.amount_per_unit FROM dividend d "
         "JOIN account a ON a.id=d.account_id JOIN security sec ON sec.id=d.security_id "
-        "WHERE sec.canonical_ticker=:tk AND a.name = ANY(:accts) ORDER BY d.pay_date"),
-        {"tk": ticker, "accts": accts}).mappings().all()]
+        "WHERE sec.canonical_ticker=:tk AND a.name = ANY(:accts) ORDER BY d.pay_date",
+        {"tk": ticker, "accts": accts})
     s.close()
     if bucket == "cash":                               # CDP trades from cdp-stocks (priced)
         from portfolio.performance import cdp_transactions
@@ -266,18 +271,18 @@ def holding(ticker: str, bucket: str = "cash"):
 @app.get("/api/dividends")
 def dividends():
     s = SessionLocal()
-    by = s.execute(text(
+    by = _dicts(s,
         "SELECT s.market, d.currency, round(sum(d.gross)) gross, count(*) n "
         "FROM dividend d LEFT JOIN security s ON s.id=d.security_id "
-        "GROUP BY s.market, d.currency ORDER BY gross DESC NULLS LAST")).mappings().all()
-    recent = s.execute(text(
+        "GROUP BY s.market, d.currency ORDER BY gross DESC NULLS LAST")
+    recent = _dicts(s,
         "SELECT d.pay_date, a.name account, COALESCE(s.name,'?') name, "
         "s.canonical_ticker ticker, d.gross, d.currency "
         "FROM dividend d JOIN account a ON a.id=d.account_id "
         "LEFT JOIN security s ON s.id=d.security_id "
-        "WHERE d.pay_date IS NOT NULL ORDER BY d.pay_date DESC LIMIT 50")).mappings().all()
+        "WHERE d.pay_date IS NOT NULL ORDER BY d.pay_date DESC LIMIT 50")
     s.close()
-    return {"by_market": [dict(r) for r in by], "recent": [dict(r) for r in recent]}
+    return {"by_market": by, "recent": recent}
 
 
 @app.get("/api/dividend-details")
@@ -287,12 +292,12 @@ def dividend_details():
     determined (no position data, missing date, or unmapped ticker) for manual input."""
     from collections import defaultdict
     s = SessionLocal()
-    divs = [dict(r) for r in s.execute(text(
+    divs = _dicts(s,
         "SELECT d.id, d.pay_date, a.id account_id, a.name account, a.funding_bucket bucket, "
         "d.security_id, COALESCE(sec.name, d.source_file) name, sec.canonical_ticker ticker, "
         "d.gross, d.currency, d.amount_per_unit declared_rate, d.units stated_units "
         "FROM dividend d JOIN account a ON a.id=d.account_id "
-        "LEFT JOIN security sec ON sec.id=d.security_id")).mappings().all()]
+        "LEFT JOIN security sec ON sec.id=d.security_id")
     # txns grouped per (account, security) for point-in-time qty replay
     by = defaultdict(list)
     for aid, sid, td, q in s.execute(text(
@@ -379,7 +384,7 @@ def transactions(account: str | None = None, ticker: str | None = None, limit: i
             q += " AND a.name=:acct"; p["acct"] = account
         if ticker:
             q += " AND s.canonical_ticker=:tk"; p["tk"] = ticker
-        rows = [dict(r) for r in s.execute(text(q + " LIMIT 2000"), p).mappings().all()]
+        rows = _dicts(s, q + " LIMIT 2000", p)
     s.close()
     if account in (None, "CDP"):                       # add CDP from cdp-stocks
         from portfolio.performance import cdp_transactions
@@ -417,9 +422,9 @@ def options_trades(limit: int = 500):
 @app.get("/api/accounts")
 def accounts():
     s = SessionLocal()
-    rows = s.execute(text("SELECT name, broker, funding_bucket FROM account ORDER BY funding_bucket, name")).mappings().all()
+    rows = _dicts(s, "SELECT name, broker, funding_bucket FROM account ORDER BY funding_bucket, name")
     s.close()
-    return [dict(r) for r in rows]
+    return rows
 
 
 # ---------------- net worth ----------------
@@ -522,23 +527,23 @@ def spending_summary(frm: str | None = Query(None, alias="from"),
     with SessionLocal() as s:
         total = s.execute(text(f"SELECT COALESCE(SUM(-amount_sgd),0) FROM cash_txn WHERE {where}"),
                           p).scalar()
-        by_group = s.execute(text(
+        by_group = _dicts(s,
             f"SELECT category, ROUND(SUM(-amount_sgd),2) v, COUNT(*) n FROM cash_txn "
-            f"WHERE {where} GROUP BY category ORDER BY v DESC"), p).mappings().all()
-        by_sub = s.execute(text(
+            f"WHERE {where} GROUP BY category ORDER BY v DESC", p)
+        by_sub = _dicts(s,
             f"SELECT category, subcategory, ROUND(SUM(-amount_sgd),2) v, COUNT(*) n FROM cash_txn "
-            f"WHERE {where} GROUP BY category, subcategory ORDER BY v DESC"), p).mappings().all()
-        by_month = s.execute(text(
+            f"WHERE {where} GROUP BY category, subcategory ORDER BY v DESC", p)
+        by_month = _dicts(s,
             f"SELECT to_char(txn_date,'YYYY-MM') ym, ROUND(SUM(-amount_sgd),2) v FROM cash_txn "
-            f"WHERE {where} GROUP BY ym ORDER BY ym"), p).mappings().all()
+            f"WHERE {where} GROUP BY ym ORDER BY ym", p)
         months = len(by_month) or 1
         return {
             "total_sgd": round(float(total), 2),
             "avg_month_sgd": round(float(total) / months, 2),
             "months": months,
-            "by_group": [dict(r) for r in by_group],
-            "by_subcategory": [dict(r) for r in by_sub],
-            "by_month": [dict(r) for r in by_month],
+            "by_group": by_group,
+            "by_subcategory": by_sub,
+            "by_month": by_month,
         }
 
 
@@ -581,22 +586,19 @@ def spending_transactions(frm: str | None = Query(None, alias="from"),
     if source:
         w.append("source = :src"); p["src"] = source
     with SessionLocal() as s:
-        rows = s.execute(text(
+        return _dicts(s,
             f"SELECT txn_date, source, account_label, merchant, description, amount_sgd, "
             f"direction, is_spend, exclude_reason, category, subcategory "
             f"FROM cash_txn WHERE {' AND '.join(w)} "
-            f"ORDER BY txn_date DESC, id DESC LIMIT :lim"), p).mappings().all()
-        return [dict(r) for r in rows]
+            f"ORDER BY txn_date DESC, id DESC LIMIT :lim", p)
 
 
 @app.get("/api/spending/categories")
 def spending_categories():
     with SessionLocal() as s:
-        rows = s.execute(text(
+        return _dicts(s,
             "SELECT category, subcategory, ROUND(SUM(-amount_sgd),2) v, COUNT(*) n "
-            "FROM cash_txn WHERE is_spend GROUP BY category, subcategory ORDER BY category, v DESC"
-        )).mappings().all()
-        return [dict(r) for r in rows]
+            "FROM cash_txn WHERE is_spend GROUP BY category, subcategory ORDER BY category, v DESC")
 
 
 # ---------------- recurring spends ----------------


### PR DESCRIPTION
## What Changed

- Extracted repeated inline idioms into shared helpers across `portfolio/`, `ingestion/`, `build/`, and `server/main.py` — nullable-value serializers (`_f`/`_d`/`_r4`/`_rn`), session/context managers, and DB query helpers (`db.fx_map`, `db.latest_close`, `count`, `occ_hash`, `prune_stale`, `_dicts`), collapsing dozens of copy-pasted lines.
- Consolidated duplicated `build/` logic into new shared modules (`_csvout.py`, `_dates.py`, `_pdf.py`, `_ledgercommon.py`) covering CSV output, date parsing, `pdftotext` invocation, and ticker-alias/transfer-direction predicates.
- Broke large functions in `portfolio/performance.py`, `options.py`, `twr.py`, and `networth.py` into focused helpers; removed dead code, dead imports/bindings, and an inverted cross-layer import; replaced a hand-rolled days-in-month table with `calendar.monthrange` and an O(n²) dividend lookup with a dict. All changes behavior-preserving.

## Risk Assessment

✅ Low: A large but disciplined, purely non-functional deduplication/refactor across 43 commits, each verified behavior-preserving against the original with no dangling references, broken imports, or semantic drift.

## Testing

Set up the Python env (uv sync + pytest/httpx) and ran the full unittest/pytest suite: 133 pure-logic tests passed offline, and the 3 remaining failures were purely environmental (no running Postgres) — after starting the project's own docker DB and applying migrations, all 136 tests pass. To show the refactoring end-to-end at the product surface, I authenticated against the live FastAPI app and hit the refactored endpoints: /api/options-trades and /api/options exercise the consolidated `_d()`/`_f()` nullable serialization helpers (real trades with `close_date: null`, float strikes/premiums, yearly rollup groups), /api/networth/snapshots returns correct nullable `note`/date fields, /api/transactions and /api/accounts exercise the consolidated session boilerplate, and /api/spending/recurring{,/detect} exercise recurring.py's `_d()` helper (correct `last_seen` date serialization) — all returning 200 with correct real-data JSON. No product code failures; the change is behavior-preserving as intended. Transient docker infra was torn down and the DB container restored to its prior stopped state.

<details>
<summary>Evidence: Live API responses from refactored endpoints (real seeded data)</summary>

<code>GET /api/options-trades -&gt; 200 [{&#34;underlying&#34;:&#34;INTC&#34;,&#34;type&#34;:&#34;put&#34;,&#34;contracts&#34;:2.0,&#34;strike&#34;:98.0,&#34;open_date&#34;:&#34;2026-07-07&#34;,&#34;close_date&#34;:null,&#34;premium_open&#34;:0.82,&#34;realized_sgd&#34;:209.73,&#34;currency&#34;:&#34;USD&#34;,&#34;outcome&#34;:&#34;expired&#34;}, …]&#10;GET /api/options -&gt; 200 {&#34;total_pl_sgd&#34;:166570.09,&#34;trades_closed&#34;:378,&#34;wins&#34;:327,&#34;win_rate&#34;:0.8651,&#34;by_year&#34;:[…]}&#10;GET /api/networth/snapshots -&gt; 200 [{&#34;id&#34;:1,&#34;date&#34;:&#34;2026-06-21&#34;,&#34;note&#34;:null,&#34;net_worth&#34;:1763368.11,…}]&#10;GET /api/spending/recurring/detect -&gt; 200 [{&#34;merchant&#34;:&#34;…&#34;,&#34;cadence&#34;:&#34;monthly&#34;,&#34;occurrences&#34;:4,&#34;avg_amount&#34;:1095.2,&#34;last_seen&#34;:&#34;2026-06-30&#34;}, …]</code>

```text
/Users/selwynyeow/.no-mistakes/worktrees/96679a5ba100/01KY2HHZ23Z04H1M76GTY5ESBX/.venv/lib/python3.12/site-packages/fastapi/testclient.py:1: StarletteDeprecationWarning: Using `httpx` with `starlette.testclient` is deprecated; install `httpx2` instead.
  from starlette.testclient import TestClient as TestClient  # noqa
/Users/selwynyeow/.no-mistakes/worktrees/96679a5ba100/01KY2HHZ23Z04H1M76GTY5ESBX/.venv/lib/python3.12/site-packages/jwt/api_jwt.py:147: InsecureKeyLengthWarning: The HMAC key is 15 bytes long, which is below the minimum recommended length of 32 bytes for SHA256. See RFC 7518 Section 3.2.
  return self._jws.encode(
2026-07-21 22:50:16,655 INFO httpx HTTP Request: GET http://testserver/api/health "HTTP/1.1 200 OK"
/Users/selwynyeow/.no-mistakes/worktrees/96679a5ba100/01KY2HHZ23Z04H1M76GTY5ESBX/.venv/lib/python3.12/site-packages/jwt/api_jwt.py:368: InsecureKeyLengthWarning: The HMAC key is 15 bytes long, which is below the minimum recommended length of 32 bytes for SHA256. See RFC 7518 Section 3.2.
  decoded = self.decode_complete(
2026-07-21 22:50:16,740 INFO httpx HTTP Request: GET http://testserver/api/options-trades "HTTP/1.1 200 OK"
2026-07-21 22:50:16,754 INFO httpx HTTP Request: GET http://testserver/api/options "HTTP/1.1 200 OK"
2026-07-21 22:50:16,764 INFO httpx HTTP Request: GET http://testserver/api/networth/items "HTTP/1.1 200 OK"
2026-07-21 22:50:16,792 INFO httpx HTTP Request: GET http://testserver/api/networth/snapshots "HTTP/1.1 200 OK"
2026-07-21 22:50:16,816 INFO httpx HTTP Request: GET http://testserver/api/transactions "HTTP/1.1 200 OK"
2026-07-21 22:50:16,818 WARNING api spending denied path=/api/spending/recurring
2026-07-21 22:50:16,819 INFO httpx HTTP Request: GET http://testserver/api/spending/recurring "HTTP/1.1 403 Forbidden"
2026-07-21 22:50:16,824 INFO httpx HTTP Request: GET http://testserver/api/accounts "HTTP/1.1 200 OK"
GET /api/health  ->  200  {"ok": true}
GET /api/options-trades  ->  200  [{"underlying": "INTC", "type": "put", "contracts": 2.0, "strike": 98.0, "open_date": "2026-07-07", "expiry": "2026-07-10", "close_date": null, "premium_open": 0.82, "premium_close": 0.0, "realized_native": 162.48, "realized_sgd": 209.73, "currency": "USD", "outcome": "expired"}, {"underlying": "INT…
GET /api/options  ->  200  {"total_pl_sgd": 166570.09, "total_premium_sgd": 325290.29, "trades_closed": 378, "wins": 327, "losses": 51, "win_rate": 0.8651, "open_trades": 7, "by_year": [{"trades": 91, "wins": 86, "premium_sgd": 37927.57640000001, "pl_sgd": 30149.667380000003, "pl_native": 23357.349999999988, "currency": null,…
GET /api/networth/items  ->  200  [{"id": 1, "code": "posb", "label": "POSB Shared Account", "kind": "asset", "currency_default": "SGD", "is_liquid": true, "is_housing": false, "is_cpf": false, "sort_order": 0, "is_manual": true}, {"id": 2, "code": "dbs_multiplier", "label": "DBS Multiplier", "kind": "asset", "currency_default": "SG…
GET /api/networth/snapshots  ->  200  [{"id": 1, "date": "2026-06-21", "note": null, "portfolio_value_sgd": 1029006.95, "total_assets": 2048017.2, "total_liabilities": 284649.09, "liquid_assets": 175410.91, "net_worth": 1763368.11, "net_worth_excl_housing": 1654017.2, "net_worth_excl_housing_cpf": 1208482.9}]
GET /api/transactions  ->  200  [{"trade_date": "2015-11-05", "account": "CDP", "ticker": "42R", "name": "Jumbo", "action": "ipo", "qty_signed": 3000.0, "price": 0.25, "gross_amount": -752.0, "currency": "SGD", "source_file": "cdp-stocks/transactions.csv"}, {"trade_date": "2016-07-07", "account": "CDP", "ticker": "43Q", "name": "A…
GET /api/spending/recurring  ->  403  {"detail": "forbidden"}
GET /api/accounts  ->  200  [{"name": "CDP", "broker": "SGX CDP", "funding_bucket": "cash"}, {"name": "FSM", "broker": "iFast / FSMOne", "funding_bucket": "cash"}, {"name": "IBKR", "broker": "Interactive Brokers", "funding_bucket": "cash"}, {"name": "Moomoo", "broker": "Moomoo Financial SG", "funding_bucket": "cash"}, {"name":…
GET /api/spending/recurring  ->  200  []
GET /api/spending/recurring/detect  ->  200  [{"merchant": "YEOW ZHI XUAN  REF:SI", "cadence": "monthly", "occurrences": 4, "avg_amount": 1095.2, "typical_day": 30, "last_seen": "2026-06-30"}, {"merchant": "TAY BEE LIAN  REF:     SI", "cadence": "monthly", "occurrences": 9, "avg_amount": 500.0, "typical_day": 1, "last_seen": "2025-09-01"}, {"merchant": "TAY BEE L…
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>⏭️ **intent** - skipped</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Rebase** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ `aidlc-docs/audit.md` - branch carries 3 commit(s) that exist on your local main branch but were never pushed to origin/main; rebasing would bundle this unrelated work (5 file(s)) into the PR:
- c632111 docs(aidlc): log snapshot-baseline + ex_date data-loss fix
- 20673ae fix(dividends): round-trip ex_date so export can&#39;t destroy it
- 13068e1 fix(snapshot): bound --all-new delta by snapshot date, not note text

Push main to origin, or rebase your branch onto origin/main, before gating.

🔧 Fix applied.
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`uv sync --extra dev` + installed pytest/httpx (missing test deps)</code>
- <code>`python -m pytest tests/ -q` — 133 pure-logic tests passed offline (performance, options, recurring, networth, twr, load, dividends)</code>
- <code>Started project&#39;s docker postgres (`docker compose`/`docker start portfolio_db`, port 5544) + `alembic upgrade head` to unblock the 3 DB-integration tests</code>
- <code>`python -m pytest tests/ -q` with DATABASE_URL — 136 passed, 0 failed</code>
- `Live API probe via FastAPI TestClient with authenticated session against refactored server/main.py endpoints, captured real JSON responses`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
