### PR TITLE
test(auth): make gate tests DB-independent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,5 @@ data/*
 .playwright-mcp/
 .vercel
 .env*
+
+.scratch

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -92,7 +92,9 @@ def test_user_from_request_garbage_cookie():
 @pytest.fixture
 def client():
     from server.main import app
-    return TestClient(app)
+    # raise_server_exceptions=False so a DB-less handler surfaces as a 500 instead of
+    # re-raising: these tests only assert the gate's decision (!= 401), never the DB path.
+    return TestClient(app, raise_server_exceptions=False)
 
 
 def test_health_is_public(client):

--- a/tests/test_spending_access.py
+++ b/tests/test_spending_access.py
@@ -35,7 +35,9 @@ def _cfg():
 @pytest.fixture
 def client():
     from server.main import app
-    return TestClient(app)
+    # raise_server_exceptions=False so a DB-less handler surfaces as a 500 instead of
+    # re-raising: these tests only assert the gate's decision (!= 403 / 401 / 404), never the DB path.
+    return TestClient(app, raise_server_exceptions=False)
 
 
 def _session(client, email):


### PR DESCRIPTION
## What Changed

- Updated `tests/test_auth.py` and `tests/test_spending_access.py` so the auth-gate tests no longer depend on a reachable database (e.g. via `raise_server_exceptions=False`), letting them pass even against an unreachable DB.
- Added a `.scratch` ignore entry to `.gitignore`.

## Risk Assessment

✅ Low: Test-only change plus a .gitignore entry; makes two TestClient fixtures DB-independent via a documented, behavior-preserving flag while keeping deny-side assertions on exact status codes.

## Testing

Set up the venv (uv sync + pytest/httpx2), then ran the two gate test modules with DATABASE_URL pointed at an unreachable Postgres (127.0.0.1:1) to enforce true DB-independence: all 41 tests pass. A contrast run using the base-commit test files (which lack raise_server_exceptions=False) fails the gate-passthrough tests with a psycopg connection-refused error, proving the change delivers the stated intent. No product UI is involved (test-only, backend auth gate), so evidence is CLI transcripts rather than screenshots; working tree restored clean afterward.

<details>
<summary>Evidence: Gate tests pass with unreachable DB (target)</summary>

<code>$ DATABASE_URL=&#39;postgresql+psycopg://nobody:nobody@127.0.0.1:1/nodb&#39; pytest tests/test_auth.py tests/test_spending_access.py&#10;&#10;41 passed, 32 warnings in 0.67s</code>

```text
### Gate tests are DB-independent — DATABASE_URL points at an unreachable server (127.0.0.1:1)
$ DATABASE_URL='postgresql+psycopg://nobody:nobody@127.0.0.1:1/nodb' pytest tests/test_auth.py tests/test_spending_access.py

41 passed, 32 warnings in 0.67s
```
</details>
<details>
<summary>Evidence: Base-commit contrast: gate tests fail without DB</summary>

<code>psycopg.OperationalError: connection to server at &#34;127.0.0.1&#34;, port 1 failed: Connection refused&#10;2 failed, 1 passed, 4 warnings in 1.48s</code>

```text
### Contrast: SAME tests on the BASE commit (93296dc, before raise_server_exceptions=False), same unreachable DB
$ pytest test_protected_route_passes_gate_with_session test_bypass_opens_gate test_authorized_session_passes_the_gate

                logger.debug("connection failed: %s: %s", descr, str(ex))
E               psycopg.OperationalError: connection failed: connection to server at "127.0.0.1", port 1 failed: could not receive data from server: Connection refused
                logger.debug("connection failed: %s: %s", descr, str(ex))
E               sqlalchemy.exc.OperationalError: (psycopg.OperationalError) connection failed: connection to server at "127.0.0.1", port 1 failed: could not receive data from server: Connection refused
psycopg.OperationalError: connection failed: connection to server at "127.0.0.1", port 1 failed: could not receive data from server: Connection refused
sqlalchemy.exc.OperationalError: (psycopg.OperationalError) connection failed: connection to server at "127.0.0.1", port 1 failed: could not receive data from server: Connection refused
                logger.debug("connection failed: %s: %s", descr, str(ex))
E               psycopg.OperationalError: connection failed: connection to server at "127.0.0.1", port 1 failed: could not receive data from server: Connection refused
                logger.debug("connection failed: %s: %s", descr, str(ex))
E               sqlalchemy.exc.OperationalError: (psycopg.OperationalError) connection failed: connection to server at "127.0.0.1", port 1 failed: could not receive data from server: Connection refused

2 failed, 1 passed, 4 warnings in 1.48s
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>⏭️ **intent** - skipped</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`DATABASE_URL=&#39;postgresql+psycopg://nobody:nobody@127.0.0.1:1/nodb&#39; pytest tests/test_auth.py tests/test_spending_access.py` → 41 passed against an unreachable DB (target commit)</code>
- <code>Contrast run on base commit 93296dc test files (no raise_server_exceptions=False), same unreachable DB: `test_protected_route_passes_gate_with_session`, `test_bypass_opens_gate` fail with sqlalchemy OperationalError (connection refused) — 2 failed, confirming the change is what makes the gate tests DB-independent</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
