### PR TITLE
refactor(build): share num/norm_ticker/canon primitives and add TWR/Performance ADR

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,95 @@
+# Portfolio Tracker
+
+A personal investment + spending tracker. Statement PDFs/CSVs are parsed to flat files
+(`build/`), loaded into Postgres (`ingestion/`), and served as portfolio metrics
+(`portfolio/`) to a React SPA. This glossary pins the domain terms the compute layer repeats;
+it is a glossary only, not a spec.
+
+## Language
+
+### Identity & instruments
+
+**Canonical ticker**:
+The one exchange code a security is known by after collapsing renames (Cromwell→Stoneweg is
+`CWBU`→`SET`). Applying the rename map is `canon`; the raw-symbol normaliser that strips
+suffixes and paren-codes without renaming is `norm_ticker`.
+_Avoid_: symbol, code (ambiguous about whether the rename is applied)
+
+**Funding bucket**:
+The pool a position is grouped into for cost purposes — `cash`, `CPF`, or `SRS` — derived from
+the account. A security transferred between custodians inside the same bucket keeps one
+position, so its original cost carries across.
+_Avoid_: account (an account maps INTO a bucket; several accounts share one bucket)
+
+**Position**:
+The running state of one (funding bucket, security) pair: units held, cost, cashflows, income.
+Building it up by replaying transactions in order is the **position fold**.
+_Avoid_: holding (reserve for the current non-zero units specifically), lot
+
+### Cashflows & their classification
+
+**External flow**:
+A unit change that is real money in or out (a buy, a sell, a cash rights issue) — the only kind
+that belongs in a return's cashflow series. Also called a **contribution** when signed as money in.
+_Avoid_: transaction (a transaction may be an external flow, a return-in-kind, or neither)
+
+**Return-in-kind**:
+A unit change that is part of the *return*, not an external contribution: units received free
+(stock dividend, bonus, scrip). Kept inside the return, never in the cashflow series.
+
+**Cost-in-kind**:
+Units redeemed to pay a fee (Endowus). No cash leaves the investor, so the market-value drop
+already carries the cost — booking a cash outflow too would charge the fee twice.
+
+**Uncosted units**:
+Units that landed in a position via a transaction whose price the source never recorded. They
+count toward market value, but their presence makes a money-weighted return meaningless (there
+is no cost to weight against), so it is suppressed.
+
+### Returns
+
+**Money-weighted return (XIRR)**:
+The internal rate of return over a position's dated cashflows plus its current market value as a
+terminal inflow. Sensitive to contribution timing. Computed per position and portfolio-wide.
+_Avoid_: IRR, return (unqualified)
+
+**Time-weighted return (TWR)**:
+The chain-linked product of daily sub-period returns with external flows removed, so
+contribution timing is stripped out and the number is comparable to an index. Portfolio-wide only.
+_Avoid_: return (unqualified)
+
+### Income
+
+**Dividend attribution**:
+Assigning a dividend to the units that earned it — *units held at pay_date*, replayed from the
+transaction ledger, with an *implied rate* (gross ÷ units) when a statement omits it. This is the
+cash-landed view. Return math deliberately folds dividends on **ex_date** instead (the day the
+price drops); the two dates are a real distinction, not a discrepancy.
+_Avoid_: dividend date (name the basis — pay_date or ex_date — explicitly)
+
+### Money
+
+**Native / SGD conversion**:
+Every value is computed in the security's native currency, then converted to SGD for
+aggregation. The single policy: SGD (or absent currency) is 1:1; a present foreign rate is used;
+a *missing* foreign rate fails loud rather than silently converting at 1.0.
+_Avoid_: currency conversion (name the direction — always native→SGD)
+
+### Spending
+
+**Spend**:
+The positive magnitude of a *counted* cash outflow. Transfers, card-bill payments, and income
+are excluded from every spend metric though they remain inspectable.
+_Avoid_: expense, cash-out, outflow (an outflow may be an excluded transfer)
+
+### Net worth
+
+**Net-worth snapshot**:
+A dated record of all manual assets/liabilities plus the frozen live portfolio value, with FX
+frozen at the snapshot date. Snapshots are forward-delta: each carries values forward from the
+prior one unless overridden.
+_Avoid_: balance, statement
+
+**Catalogue**:
+The single source of truth for which net-worth line items exist and whether each is auto-pulled
+from statements or entered manually.

--- a/build/__init__.py
+++ b/build/__init__.py
@@ -1,0 +1,8 @@
+"""Statement parsers (PDF/CSV -> normalized flat files).
+
+Marks build/ as a package so the ingestion loaders (run as `-m ingestion.*`
+with the repo root on sys.path) can share the parse-layer primitives in
+`build._ledgercommon` instead of re-copying them. The parser scripts themselves
+still run as bare scripts (`python3 build/x.py`, build/ on sys.path[0]) and
+import their siblings by bare name; this file is inert in that mode.
+"""

--- a/build/_ledgercommon.py
+++ b/build/_ledgercommon.py
@@ -1,4 +1,13 @@
-"""Shared ledger conventions used by build_ledger.py and build_viewer.py."""
+"""Shared statement-parsing conventions used across build/ scripts (and, via
+`from build._ledgercommon import ...`, the ingestion loaders).
+
+Holds the parse-layer primitives that every statement parser reimplemented inline:
+the `ALIAS`/`canon` counter-rename map, the `num` money parser, and the
+`norm_ticker` symbol normaliser. Kept import-free (only stdlib `re`) so it loads
+cleanly whether imported as a bare sibling (`python3 build/x.py`, build/ on
+sys.path[0]) or as a package member (`-m ingestion.x`, repo root on path).
+"""
+import re
 
 # Holdings.md label -> canonical SGX/exchange code used in transaction data.
 # CWBU->SET: SGX counter renamed (Cromwell->Stoneweg).
@@ -7,6 +16,42 @@ ALIAS = {"QAF": "Q01", "CWBU": "SET", "C": "C52"}
 
 def canon(t):
     return ALIAS.get(t, t)
+
+
+def num(s):
+    """Parse a money/quantity cell to float. Strips thousands separators and `$`,
+    reads `(1.23)` as -1.23, and maps blanks/`-`/`--` to 0.0. This is the
+    0.0-sentinel flavour; ingestion/load.py deliberately keeps a None-sentinel
+    variant for nullable DB columns (a missing price is NULL, not zero)."""
+    if s is None:
+        return 0.0
+    s = str(s).strip().replace(",", "").replace("$", "")
+    if s in ("", "-", "--"):
+        return 0.0
+    neg = s.startswith("(") and s.endswith(")")
+    s = s.strip("()")
+    try:
+        v = float(s)
+    except ValueError:
+        return 0.0
+    return -v if neg else v
+
+
+def norm_ticker(sym, market):
+    """Normalise a display symbol to its bare exchange code: pull a trailing
+    "(00823)" out of "Link Reit (00823)", drop a ".SI/.US/.HK" suffix, zero-pad
+    HK numeric tickers to 5 digits, upper-case. Does NOT apply `canon` — compose
+    `canon(norm_ticker(...))` when the canonical rename is also wanted."""
+    if not sym:
+        return ""
+    sym = sym.strip()
+    m = re.search(r"\(([^)]+)\)\s*$", sym)          # "Link Reit (00823)" -> 00823
+    if m:
+        sym = m.group(1).strip()
+    sym = re.sub(r"\.(SI|US|HK)$", "", sym, flags=re.I)
+    if market == "HK" and re.fullmatch(r"\d+", sym):
+        sym = sym.zfill(5)
+    return sym.upper()
 
 
 # transfer-leg action predicates (both underscore and space spellings occur)

--- a/build/build_ledger.py
+++ b/build/build_ledger.py
@@ -13,32 +13,12 @@ import csv, glob, os, re
 from collections import defaultdict
 from _csvout import write_csv
 from _dates import try_date
-from _ledgercommon import canon, is_transfer_in, is_transfer_out
+from _ledgercommon import canon, is_transfer_in, is_transfer_out, norm_ticker, num
 
 DATA = os.path.join(os.path.dirname(__file__), "..", "data")
 ROOT = os.path.join(os.path.dirname(__file__), "..")
 
 # ---------- helpers ----------
-def num(s):
-    if s is None: return 0.0
-    s = str(s).strip().replace(",", "").replace("$", "")
-    if s in ("", "-", "--"): return 0.0
-    neg = s.startswith("(") and s.endswith(")")
-    s = s.strip("()")
-    try: v = float(s)
-    except ValueError: return 0.0
-    return -v if neg else v
-
-def norm_ticker(sym, market):
-    if not sym: return ""
-    sym = sym.strip()
-    m = re.search(r"\(([^)]+)\)\s*$", sym)          # "Link Reit (00823)" -> 00823
-    if m: sym = m.group(1).strip()
-    sym = re.sub(r"\.(SI|US|HK)$", "", sym, flags=re.I)
-    if market == "HK" and re.fullmatch(r"\d+", sym):
-        sym = sym.zfill(5)
-    return sym.upper()
-
 def parse_date(s):
     s = (s or "").strip().split("\n")[0].split(",")[0].strip()
     d = try_date(s, ("%Y-%m-%d", "%d-%b-%y", "%d %b %Y", "%d/%m/%Y", "%Y%m%d"))

--- a/build/parse_dividends.py
+++ b/build/parse_dividends.py
@@ -16,28 +16,19 @@ from collections import defaultdict
 from _pdf import raw_text
 from _csvout import write_csv
 from _dates import try_date
+from _ledgercommon import canon, norm_ticker, num
 
 HERE = os.path.dirname(__file__)
 DATA = os.path.join(HERE, "..", "data")
-ALIAS = {"QAF": "Q01", "CWBU": "SET", "C": "C52"}
-def canon(t): return ALIAS.get(t, t)
+
 
 def norm(sym, market):
-    sym = (sym or "").strip()
-    m = re.search(r"\(([^)]+)\)\s*$", sym)
-    if m: sym = m.group(1).strip()
-    sym = re.sub(r"\.(SI|US|HK)$", "", sym, flags=re.I)
-    if market == "HK" and re.fullmatch(r"\d+", sym): sym = sym.zfill(5)
-    return canon(sym.upper())
+    return canon(norm_ticker(sym, market))
 
 def market_of(sym):
     if ".SI" in sym: return "SG"
     inner = sym.split("(")[-1].strip(") ")
     return "HK" if (inner.isdigit() or sym.strip().isdigit()) else "US"
-
-def num(s):
-    try: return float(str(s).replace(",", "").replace("$", ""))
-    except ValueError: return 0.0
 
 CCY = {"HK": "HKD", "SG": "SGD", "US": "USD"}
 DIV = []

--- a/docs/adr/0001-do-not-unify-twr-and-performance.md
+++ b/docs/adr/0001-do-not-unify-twr-and-performance.md
@@ -1,0 +1,72 @@
+# Do not unify the TWR and Performance return engines
+
+## Status
+
+accepted
+
+## Context
+
+`portfolio/performance.py` (`compute` → pure `fold_positions`) and `portfolio/twr.py`
+(`compute_twr` → pure `_twr`) both build the same conceptual pipeline —
+transactions → positions → dated cashflows → a return number — and `twr.py` already
+imports `_xirr` from `performance.py`. That surface similarity invites a merge into one
+"return ledger" module. Before writing any code we ran a design-it-twice exercise: three
+independent designs for a unified interface, each under a different constraint (minimise
+the interface / maximise flexibility / optimise for the common caller).
+
+All three converged on the same answer: **do not unify.** The two engines differ on every
+axis that matters, and the differences are essential, not incidental:
+
+| Axis | performance | twr |
+| --- | --- | --- |
+| Cadence | single latest snapshot | value on every trading day |
+| Price source | DB `latest_close` (date-insensitive) | live Yahoo daily curve (date-sensitive) |
+| Dividend basis | pay_date | ex_date for TWR, pay_date for its XIRR |
+| Grouping | per (funding bucket, security) | portfolio-wide |
+| Output | full per-position P&L decomposition | one chain-linked TWR + one portfolio XIRR |
+
+Each design revealed the *same* failure mode from its own angle:
+
+- **Minimal interface** — collapsing the two cadences behind ≤3 entry points only works by
+  hiding an undocumented precondition: `timeweighted()` returns a confidently-wrong ~0% if
+  handed a date-insensitive price source. A pass-through with a hidden mode constraint is
+  shallower than two honest functions.
+- **Maximal flexibility** — pluggable price/date-basis/cadence/grouping/metric ports turn the
+  module into a six-port framework the caller must assemble; the interface balloons to the
+  size of the implementation, and the only valid (metric × source) combinations are
+  essentially the two we started with. Filing, not fusion.
+- **Common-caller-first** — the hot path (per-position snapshot P&L for the web views) is
+  already optimal at one no-arg call; unifying gives it nothing and risks dragging ex-date,
+  daily cadence, and live network I/O onto a path that has no use for them.
+
+## Decision
+
+Keep `performance` and `twr` as two separate modules. They share exactly what they already
+share — `_xirr` — plus the *concept* of external-flow-vs-return-in-kind classification, which
+is currently spelled twice (`performance.classify` + `CASH_TRADE`/`ZERO_CASH` vs twr's
+`RETURN_IN_KIND`/`COST_IN_KIND`/`NON_EXTERNAL`). We do **not** put snapshot P&L and
+daily-series TWR behind one interface.
+
+## Consequences
+
+The endorsed shared substrate is a follow-up, not part of this decision, and is deliberately
+sequenced so nothing touches the return engine unverified:
+
+1. **Promote `_xirr`** from a private in `performance.py` to a public `portfolio/xirr.py`, so
+   `twr.py` stops importing another module's private. Already directly unit-tested
+   (`tests/test_twr.py`), so this is a low-risk, verifiable move.
+2. **Extract one flow classifier** (`external / return-in-kind / cost-in-kind`) that both
+   engines consume, ending the twice-named concept. Both taxonomies already have test
+   coverage (`test_performance.py::classify*`, `test_twr.py` contribution tests), so the merge
+   is checkable on both sides.
+3. **Give `compute_twr` an injectable price/FX seam** (a `PriceSource` port wrapping the live
+   Yahoo `daily()` fetch and the DB fallback). The pure fold `_twr` is *already* separated and
+   tested; the residual untested surface is only the `compute_twr` fetch adapter, hard-wired to
+   live Yahoo and the Postgres-only `current_position` view. A port makes that adapter testable
+   with a fixture source — the single highest-value change, and the precondition for doing (2)
+   safely against the twr side.
+
+Not doing this leaves one real cost: the flow-classification concept lives in two places and
+can drift. That is accepted for now; the drift risk is bounded (both copies are unit-tested)
+and strictly smaller than the cost of a shallow unification that flattens the cadence
+distinction.

--- a/ingestion/load_cdp_cost.py
+++ b/ingestion/load_cdp_cost.py
@@ -11,30 +11,13 @@ import csv
 import os
 from collections import Counter
 
+from build._ledgercommon import canon, num
 from ingestion.load import batch, count, occ_hash, pdate, prune_stale, upsert
 from portfolio.db import SessionLocal
 from portfolio.models import CdpCostLot
 
 ROOT = os.path.dirname(os.path.dirname(__file__))
 CSV = os.path.join(ROOT, "data", "cdp-stocks", "transactions.csv")
-
-# CDP code -> canonical SGX/exchange code (Holdings.md label aliasing; CWBU->SET is the
-# Cromwell->Stoneweg counter rename).
-_ALIAS = {"QAF": "Q01", "CWBU": "SET", "C": "C52"}
-
-
-def _num(s):
-    s = str(s or "").replace(",", "").replace("$", "").strip()
-    if not s or s == "-":
-        return 0.0
-    neg = s.startswith("(") and s.endswith(")")
-    s = s.strip("()")
-    try:
-        v = float(s)
-    except ValueError:
-        return 0.0
-    return -v if neg else v
-
 
 def load_cdp_cost(session):
     if not os.path.exists(CSV):
@@ -48,11 +31,11 @@ def load_cdp_cost(session):
         key = (code, r.get("Date"), r.get("Action"), r.get("Qty"), r.get("Amount"))
         dh = occ_hash(occ, key)
         payload.append(dict(
-            trade_date=pdate(r.get("Date")), code=code, ticker=_ALIAS.get(code, code),
+            trade_date=pdate(r.get("Date")), code=code, ticker=canon(code),
             stock_name=(r.get("Stock Name") or "").strip() or None,
             action=(r.get("Action") or "").strip() or None,
-            qty=_num(r.get("Qty")), unit_price=_num(r.get("Unit Price")) or None,
-            amount=_num(r.get("Amount")),
+            qty=num(r.get("Qty")), unit_price=num(r.get("Unit Price")) or None,
+            amount=num(r.get("Amount")),
             currency=(r.get("Currency") or "").strip() or "SGD",
             market=(r.get("Market") or "").strip() or None,
             source_file="cdp-stocks/transactions.csv", batch_id=b.id, dedup_hash=dh,

--- a/tests/test_ledgercommon.py
+++ b/tests/test_ledgercommon.py
@@ -1,0 +1,67 @@
+"""build._ledgercommon — the shared statement-parse primitives.
+
+These `num` / `norm_ticker` / `canon` helpers used to be copy-pasted (and quietly
+divergent) across build_ledger.py, parse_dividends.py, and ingestion/load_cdp_cost.py.
+Now there is one home, so the contract each caller relied on is pinned here:
+  - num reads `(1.23)` as -1.23 and maps blanks/`-`/`--` to 0.0 (the 0.0-sentinel
+    flavour; ingestion/load.py keeps a separate None-sentinel `num` on purpose).
+  - norm_ticker is the bare-code normaliser WITHOUT canon; the dividend parser's old
+    `norm` is exactly `canon(norm_ticker(...))`.
+
+Run: PYTHONPATH=. .venv/bin/python -m pytest tests/test_ledgercommon.py -q
+"""
+from build._ledgercommon import canon, is_transfer_in, is_transfer_out, norm_ticker, num
+
+
+def test_num_strips_separators_and_symbols():
+    assert num("1,234.50") == 1234.5
+    assert num("$1,000") == 1000.0
+    assert num(" 42 ") == 42.0
+
+
+def test_num_reads_parenthesised_as_negative():
+    # build_ledger + load_cdp_cost relied on this; the old dividend-parser copy did NOT
+    # handle it (it returned 0.0), so consolidating had to keep the paren behaviour.
+    assert num("(5.00)") == -5.0
+    assert num("(1,234.50)") == -1234.5
+
+
+def test_num_blank_sentinels_are_zero():
+    for blank in ("", "-", "--", None, "   "):
+        assert num(blank) == 0.0
+
+
+def test_num_garbage_is_zero_not_raise():
+    assert num("n/a") == 0.0
+
+
+def test_norm_ticker_extracts_trailing_paren_code():
+    assert norm_ticker("Link Reit (00823)", "HK") == "00823"
+
+
+def test_norm_ticker_strips_exchange_suffix_and_uppercases():
+    assert norm_ticker("d05.SI", "SG") == "D05"
+    assert norm_ticker("aapl.US", "US") == "AAPL"
+
+
+def test_norm_ticker_zero_pads_hk_numeric_only():
+    assert norm_ticker("5", "HK") == "00005"
+    assert norm_ticker("5", "US") == "5"          # non-HK left as-is
+
+
+def test_norm_ticker_does_not_apply_canon():
+    # the whole reason norm_ticker is canon-free: callers compose canon when they want it.
+    assert norm_ticker("CWBU", "SG") == "CWBU"
+    assert canon(norm_ticker("CWBU", "SG")) == "SET"
+
+
+def test_canon_renames_known_counters_only():
+    assert canon("CWBU") == "SET"     # Cromwell -> Stoneweg
+    assert canon("QAF") == "Q01"
+    assert canon("D05") == "D05"      # unknown -> unchanged
+
+
+def test_transfer_predicates_accept_both_spellings():
+    assert is_transfer_out("transfer_out") and is_transfer_out("transfer out")
+    assert is_transfer_in("transfer_in") and is_transfer_in("transfer in")
+    assert not is_transfer_out("buy")


### PR DESCRIPTION
## What Changed

- Consolidated the `num`, `norm_ticker`, and `canon` primitives into `build/_ledgercommon.py`, dropping the duplicated local copies from `build/build_ledger.py`, `build/parse_dividends.py`, and `ingestion/load_cdp_cost.py`; added `tests/test_ledgercommon.py` pinning the shared contract.
- Aligned dividend parsing onto the shared `num`, which reads parenthesized values (e.g. `(5.00)`) as negative rather than the old parser's `0.0` — the one behavior delta in an otherwise pure refactor, documented by `test_num_reads_parenthesised_as_negative`.
- Added `docs/adr/0001-do-not-unify-twr-and-performance.md` recording the decision to keep TWR and Performance separate, and seeded a top-level `CONTEXT.md`.

## Risk Assessment

✅ Low: Well-bounded deduplication of existing helpers with byte-identical logic for build_ledger/load_cdp_cost and a single intentional, test-pinned behavior change in the dividend parser; package/import layout verified against all call sites.

## Testing

Set up a fresh uv venv (no venv existed), installed pytest + project deps, and ran the full test suite (178 passed) plus the new tests/test_ledgercommon.py (10 passed) that pin the consolidated primitives' contract. Because this is a behavior-preserving refactor, I built a differential harness that transcribes the OLD per-call-site inline `num`/`norm_ticker`/`canon` implementations from base commit 3f36b02 and compares them against the new shared build._ledgercommon primitives across a battery of realistic money strings and symbol/market pairs — every preserved-behavior case matched byte-for-byte, and the one intentional change (parse_dividends' weaker `num` now correctly reading parenthesised negatives and sentinels) surfaced exactly as documented in the ADR/tests. I also confirmed both invocation import modes resolve and that load_cdp_cost.py no longer carries its local copies. Running the actual parser scripts end-to-end is blocked by the private, gitignored source statements (data/fsm/... etc.) being absent from the repo — the scripts import and execute the shared primitives fine and only crash later on the missing input file — so the differential harness stands in as the behavior-equivalence evidence. This is a data-processing/CLI change with no UI surface, so no visual artifact applies.

<details>
<summary>Evidence: Behavior-preservation differential (old inline vs shared primitives)</summary>

<code>num() build_ledger + load_cdp_cost were byte-identical; shared num matches — 18/18 [OK]&#10;norm_ticker() inline vs shared — 14/14 [OK]&#10;parse_dividends norm = canon(norm_ticker(...)) composition preserved — 14/14 [OK]&#10;parse_dividends num INTENTIONAL upgrade: &#39;(5.00)&#39; old=0.0 -&gt; shared=-5.0 ; &#39;(1,234.50)&#39; old=0.0 -&gt; shared=-1234.5&#10;RESULT: ALL PRESERVED-BEHAVIOR CASES MATCH</code>

```text
========================================================================
num() — build_ledger + load_cdp_cost were byte-identical; shared num matches
========================================================================
  [OK ] '1,234.50'  build=    1234.5  cdp=    1234.5  shared=    1234.5
  [OK ] '$1,000'  build=    1000.0  cdp=    1000.0  shared=    1000.0
  [OK ] ' 42 '  build=      42.0  cdp=      42.0  shared=      42.0
  [OK ] '(5.00)'  build=      -5.0  cdp=      -5.0  shared=      -5.0
  [OK ] '(1,234.50)'  build=   -1234.5  cdp=   -1234.5  shared=   -1234.5
    [OK ] ''  build=       0.0  cdp=       0.0  shared=       0.0
   [OK ] '-'  build=       0.0  cdp=       0.0  shared=       0.0
  [OK ] '--'  build=       0.0  cdp=       0.0  shared=       0.0
  [OK ] None  build=       0.0  cdp=       0.0  shared=       0.0
  [OK ] '   '  build=       0.0  cdp=       0.0  shared=       0.0
  [OK ] 'n/a'  build=       0.0  cdp=       0.0  shared=       0.0
   [OK ] '0'  build=       0.0  cdp=       0.0  shared=       0.0
  [OK ] '-0'  build=      -0.0  cdp=      -0.0  shared=      -0.0
  [OK ] '(0)'  build=      -0.0  cdp=      -0.0  shared=      -0.0
  [OK ] '1.5e3'  build=    1500.0  cdp=    1500.0  shared=    1500.0
  [OK ] '$(3,000.00)'  build=   -3000.0  cdp=   -3000.0  shared=   -3000.0
  [OK ] ' -12 '  build=     -12.0  cdp=     -12.0  shared=     -12.0
  [OK ] '1000000'  build= 1000000.0  cdp= 1000000.0  shared= 1000000.0

========================================================================
norm_ticker() — build_ledger inline vs shared (must be identical)
========================================================================
  [OK ] 'Link Reit (00823)',HK  inline= '00823'  shared= '00823'
  [OK ] 'd05.SI',SG  inline=   'D05'  shared=   'D05'
  [OK ] 'aapl.US',US  inline=  'AAPL'  shared=  'AAPL'
  [OK ] '5',HK  inline= '00005'  shared= '00005'
  [OK ] '5',US  inline=     '5'  shared=     '5'
  [OK ] 'CWBU',SG  inline=  'CWBU'  shared=  'CWBU'
  [OK ] 'QAF',SG  inline=   'QAF'  shared=   'QAF'
  [OK ] 'C',SG  inline=     'C'  shared=     'C'
  [OK ] 'D05',SG  inline=   'D05'  shared=   'D05'
  [OK ] '0700.HK',HK  inline= '00700'  shared= '00700'
  [OK ] '  ',SG  inline=      ''  shared=      ''
  [OK ] '',US  inline=      ''  shared=      ''
  [OK ] 'Tencent (700)',HK  inline= '00700'  shared= '00700'
  [OK ] 'BRK.B',US  inline= 'BRK.B'  shared= 'BRK.B'

========================================================================
parse_dividends norm = canon(norm_ticker(...))  (composition preserved)
========================================================================
  [OK ] 'Link Reit (00823)',HK  old_norm= '00823'  canon(norm_ticker)= '00823'
  [OK ] 'd05.SI',SG  old_norm=   'D05'  canon(norm_ticker)=   'D05'
  [OK ] 'aapl.US',US  old_norm=  'AAPL'  canon(norm_ticker)=  'AAPL'
  [OK ] '5',HK  old_norm= '00005'  canon(norm_ticker)= '00005'
  [OK ] '5',US  old_norm=     '5'  canon(norm_ticker)=     '5'
  [OK ] 'CWBU',SG  old_norm=   'SET'  canon(norm_ticker)=   'SET'
  [OK ] 'QAF',SG  old_norm=   'Q01'  canon(norm_ticker)=   'Q01'
  [OK ] 'C',SG  old_norm=   'C52'  canon(norm_ticker)=   'C52'
  [OK ] 'D05',SG  old_norm=   'D05'  canon(norm_ticker)=   'D05'
  [OK ] '0700.HK',HK  old_norm= '00700'  canon(norm_ticker)= '00700'
  [OK ] '  ',SG  old_norm=      ''  canon(norm_ticker)=      ''
  [OK ] '',US  old_norm=      ''  canon(norm_ticker)=      ''
  [OK ] 'Tencent (700)',HK  old_norm= '00700'  canon(norm_ticker)= '00700'
  [OK ] 'BRK.B',US  old_norm= 'BRK.B'  canon(norm_ticker)= 'BRK.B'

========================================================================
parse_dividends num — INTENTIONAL upgrade (old copy silently mis-parsed)
========================================================================
  [UPGRADED]   '(5.00)'  old_div_num=       0.0  shared_num=      -5.0
  [UPGRADED] '(1,234.50)'  old_div_num=       0.0  shared_num=   -1234.5
  [    same]         ''  old_div_num=       0.0  shared_num=       0.0
  [    same]        '-'  old_div_num=       0.0  shared_num=       0.0
  [    same]       '--'  old_div_num=       0.0  shared_num=       0.0
  [    same]       None  old_div_num=       0.0  shared_num=       0.0
  [    same]      'n/a'  old_div_num=       0.0  shared_num=       0.0

RESULT: ALL PRESERVED-BEHAVIOR CASES MATCH
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>⏭️ **intent** - skipped</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ℹ️ `build/parse_dividends.py:19` - Consolidating onto the shared `num` changes the dividend parser&#39;s numeric behavior: its old local `num` did NOT understand parentheses (`num(&#34;(5.00)&#34;)` -&gt; 0.0 via ValueError), whereas the shared `num` reads `(5.00)` as -5.0. Any dividend source cell that arrives parenthesized (e.g. a reversal/withholding adjustment) now flips from 0.0 to a negative gross. This is deliberate and documented in tests/test_ledgercommon.py (`test_num_reads_parenthesised_as_negative`), so no action needed, but noting the one real functional delta in an otherwise pure refactor.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`PYTHONPATH=. .venv/bin/python -m pytest tests/test_ledgercommon.py -v` — 10 pinned-contract tests pass</code>
- <code>`PYTHONPATH=. .venv/bin/python -m pytest -q` — full suite 178 passed</code>
- <code>Differential harness (`/tmp/diff_harness.py`) comparing OLD base-commit inline `num`/`norm_ticker`/`canon` (transcribed verbatim from 3f36b02) vs shared primitives across ~18 money strings and 14 symbol/market pairs — all preserved-behavior cases match; parse_dividends `num` shows the documented intentional upgrade (`(5.00)`→-5.0 vs old 0.0)</code>
- <code>Import-mode checks: bare-sibling import (`from _ledgercommon import ...` with build/ on path) and package import (`from build._ledgercommon import ...` for `-m ingestion.*`) both resolve; confirmed load_cdp_cost.py dropped its local `_num`/`_ALIAS`</code>
- <code>Attempted end-to-end `python3 build/parse_dividends.py` and `build/build_ledger.py` — reached and executed the shared-primitive-using parse stages, then failed on absent private data (`data/fsm/ifast_historical.csv`)</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
