### PR TITLE
Pluggable NL-compile provider: local Ollama + OpenAI-compatible (Groq)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,6 +20,16 @@ COOKIE_SECURE=false
 # unless you want to run the API+web without OAuth configured.
 DEV_AUTH_BYPASS=false
 
-# Spend classification: server-side NL->predicate compile (Claude structured outputs).
-# Never exposed to the browser. Optional CLASSIFY_MODEL overrides the default claude-haiku-4-5.
+# Spend classification: server-side NL->predicate compile.
+# Provider auto-selects: Anthropic when ANTHROPIC_API_KEY is set, else a local Ollama server.
+# A capable model matters — a 3B model (llama3.2) is too weak; use a 7B+ instruct model
+# (`ollama pull qwen2.5`) or a free cloud service. Never exposed to the browser.
+#   CLASSIFY_PROVIDER   force anthropic|ollama|openai (default: auto)
+#   CLASSIFY_MODEL      Anthropic model (default claude-haiku-4-5)
+#   OLLAMA_HOST/MODEL   local Ollama (defaults http://localhost:11434, llama3.2)
+# Free cloud via OpenAI-compatible endpoint (recommended: Groq free tier, a 70B model):
+#   CLASSIFY_PROVIDER=openai
+#   OPENAI_BASE_URL=https://api.groq.com/openai/v1
+#   OPENAI_API_KEY=gsk_...          (free key from console.groq.com)
+#   OPENAI_MODEL=llama-3.3-70b-versatile
 ANTHROPIC_API_KEY=

--- a/portfolio/classify.py
+++ b/portfolio/classify.py
@@ -444,23 +444,38 @@ class CompileResult(BaseModel):
 
 
 _COMPILE_SYSTEM = (
-    "You translate one sentence describing a spend-classification rule into a predicate over "
-    "transaction fields: merchant, description, amount_sgd, source, account_label. Conditions "
-    "are ANDed. Only use fields, operators, and values the sentence actually supports — never "
-    "invent a condition. Text operators (contains, equals) apply to merchant/description and "
-    "are matched case-insensitively. amount_sgd conditions are evaluated against the POSITIVE "
-    "SPEND MAGNITUDE (e.g. \"under $30\" means magnitude < 30), so always express amounts as "
-    "positive numbers. Enum operators (equals, in) apply to source/account_label. If the "
-    "sentence does not clearly map to these fields/operators (ambiguous merchant, unclear "
-    "amount, unsupported comparison), return status=\"unmappable\" with a specific "
-    "clarifying_question instead of guessing."
+    "Translate one sentence describing a spend-classification rule into ANDed conditions over "
+    "these transaction fields:\n"
+    "- merchant, description: text. operators contains | equals (matched case-insensitively — "
+    "just output the value the user gave, lowercase or not).\n"
+    "- amount_sgd: money. operators < | <= | > | >= | between. Output the amount as a plain "
+    "POSITIVE number (write \"under $30\" as {\"field\":\"amount_sgd\",\"operator\":\"<\","
+    "\"value\":30}).\n"
+    "- source, account_label: enum. operators equals | in.\n\n"
+    "Almost every rule naming a merchant and/or an amount IS mappable — map it. Only return "
+    "status=\"unmappable\" (with a one-line clarifying_question) when the sentence names a field "
+    "that does not exist here or asks for a comparison none of these operators can express. "
+    "The category/target is chosen separately by the user — do NOT put it in the conditions.\n\n"
+    "Example — input: \"Grab rides under $30\" -> "
+    "{\"result\":{\"status\":\"ok\",\"conditions\":["
+    "{\"field\":\"merchant\",\"operator\":\"contains\",\"value\":\"grab\"},"
+    "{\"field\":\"amount_sgd\",\"operator\":\"<\",\"value\":30}]}}"
 )
 
 
 def _parse_nl(nl_text) -> CompileResult:
-    """The network boundary: compile NL -> CompileResult via Claude structured outputs.
-    Isolated so tests can stub it without hitting the API. Runs server-side; the key never
-    leaves the process (research #4)."""
+    """The model boundary: compile NL -> CompileResult. Routes to Anthropic (structured
+    outputs) or a local Ollama server (free/offline) per settings.classify_provider_active.
+    Isolated so tests stub it without hitting any model. Runs server-side; no key or NL text
+    reaches the browser."""
+    from portfolio.config import settings
+    return {
+        "ollama": _parse_nl_ollama,
+        "openai": _parse_nl_openai,
+    }.get(settings.classify_provider_active, _parse_nl_anthropic)(nl_text)
+
+
+def _parse_nl_anthropic(nl_text) -> CompileResult:
     import anthropic
 
     from portfolio.config import settings
@@ -473,6 +488,58 @@ def _parse_nl(nl_text) -> CompileResult:
         output_format=CompileResult,
     )
     return resp.parsed_output
+
+
+def _parse_nl_ollama(nl_text) -> CompileResult:
+    """Compile via a local Ollama model using its structured-output endpoint (schema-constrained
+    JSON) — free, offline, no account. A model that returns unusable JSON degrades to
+    `unmappable`; the human verifies the preview before confirming, so a weak local parse is
+    surfaced, never silently stored."""
+    import requests
+
+    from portfolio.config import settings
+    r = requests.post(f"{settings.ollama_host}/api/chat", timeout=120, json={
+        "model": settings.ollama_model,
+        "messages": [{"role": "system", "content": _COMPILE_SYSTEM},
+                     {"role": "user", "content": nl_text}],
+        "format": CompileResult.model_json_schema(),     # constrain output to our schema
+        "stream": False,
+        "options": {"temperature": 0},
+    })
+    r.raise_for_status()
+    content = r.json().get("message", {}).get("content", "")
+    return _to_result(content, "Try rephrasing more specifically, or use a larger Ollama model.")
+
+
+def _parse_nl_openai(nl_text) -> CompileResult:
+    """Compile via any OpenAI-compatible chat endpoint (Groq / Gemini / OpenRouter free tiers)
+    using json_schema structured outputs. Free-tier accounts run large, reliable models."""
+    import requests
+
+    from portfolio.config import settings
+    r = requests.post(f"{settings.openai_base_url.rstrip('/')}/chat/completions", timeout=120,
+                      headers={"Authorization": f"Bearer {settings.openai_api_key}"}, json={
+        "model": settings.openai_model,
+        "messages": [{"role": "system", "content": _COMPILE_SYSTEM},
+                     {"role": "user", "content": nl_text}],
+        "temperature": 0,
+        "response_format": {"type": "json_schema", "json_schema": {
+            "name": "compile_result", "schema": CompileResult.model_json_schema(), "strict": True}},
+    })
+    r.raise_for_status()
+    content = r.json()["choices"][0]["message"]["content"]
+    return _to_result(content, "Try rephrasing more specifically.")
+
+
+def _to_result(content, hint) -> CompileResult:
+    """Validate a model's JSON into CompileResult; unusable output degrades to unmappable so the
+    UI shows an ask-back rather than 500ing (the human verifies the preview before confirming)."""
+    try:
+        return CompileResult.model_validate_json(content)
+    except ValueError:                                   # incl. pydantic ValidationError
+        return CompileResult(result=_Unmappable(
+            status="unmappable", reason="the model returned an unusable result",
+            clarifying_question=hint))
 
 
 def preview_matches(conditions, session=None, limit=200):

--- a/portfolio/classify.py
+++ b/portfolio/classify.py
@@ -446,8 +446,9 @@ class CompileResult(BaseModel):
 _COMPILE_SYSTEM = (
     "Translate one sentence describing a spend-classification rule into ANDed conditions over "
     "these transaction fields:\n"
-    "- merchant, description: text. operators contains | equals (matched case-insensitively — "
-    "just output the value the user gave, lowercase or not).\n"
+    "- merchant, description: text. operators contains | equals (matched case-insensitively). "
+    "For `contains`, use the SHORTEST distinctive keyword — the brand/merchant name only, not the "
+    "surrounding words (e.g. \"Grab rides\" -> value \"grab\"; \"trips on SMRT\" -> value \"smrt\").\n"
     "- amount_sgd: money. operators < | <= | > | >= | between. Output the amount as a plain "
     "POSITIVE number (write \"under $30\" as {\"field\":\"amount_sgd\",\"operator\":\"<\","
     "\"value\":30}).\n"

--- a/portfolio/classify.py
+++ b/portfolio/classify.py
@@ -512,19 +512,21 @@ def _parse_nl_ollama(nl_text) -> CompileResult:
 
 
 def _parse_nl_openai(nl_text) -> CompileResult:
-    """Compile via any OpenAI-compatible chat endpoint (Groq / Gemini / OpenRouter free tiers)
-    using json_schema structured outputs. Free-tier accounts run large, reliable models."""
+    """Compile via any OpenAI-compatible chat endpoint (Groq / Gemini / OpenRouter free tiers).
+    Uses json_object mode (portable across providers; strict json_schema isn't universal) — the
+    schema + example live in the prompt, and _to_result degrades unusable output to unmappable.
+    Free-tier accounts run large, reliable models, so json_object is enough."""
     import requests
 
     from portfolio.config import settings
     r = requests.post(f"{settings.openai_base_url.rstrip('/')}/chat/completions", timeout=120,
                       headers={"Authorization": f"Bearer {settings.openai_api_key}"}, json={
         "model": settings.openai_model,
-        "messages": [{"role": "system", "content": _COMPILE_SYSTEM},
-                     {"role": "user", "content": nl_text}],
+        "messages": [
+            {"role": "system", "content": _COMPILE_SYSTEM + " Respond with ONLY the JSON object."},
+            {"role": "user", "content": nl_text}],
         "temperature": 0,
-        "response_format": {"type": "json_schema", "json_schema": {
-            "name": "compile_result", "schema": CompileResult.model_json_schema(), "strict": True}},
+        "response_format": {"type": "json_object"},
     })
     r.raise_for_status()
     content = r.json()["choices"][0]["message"]["content"]

--- a/portfolio/config.py
+++ b/portfolio/config.py
@@ -32,6 +32,20 @@ class Settings(BaseSettings):
     # narrow, closed extraction task — research #4 deliberately picks Haiku over the Opus
     # default; override via env if compound sentences need Sonnet.
     classify_model: str = "claude-haiku-4-5"
+    # provider for the NL->predicate compile. "" = auto: Anthropic when a key is set, else the
+    # local Ollama server (free + offline). Force with CLASSIFY_PROVIDER=anthropic|ollama|openai.
+    # "openai" targets any OpenAI-compatible endpoint (Groq / Gemini / OpenRouter free tiers).
+    classify_provider: str = ""
+    ollama_host: str = "http://localhost:11434"
+    ollama_model: str = "llama3.2"
+    # OpenAI-compatible provider (e.g. Groq: base https://api.groq.com/openai/v1)
+    openai_base_url: str = ""
+    openai_api_key: str = ""
+    openai_model: str = ""
+
+    @property
+    def classify_provider_active(self) -> str:
+        return self.classify_provider or ("anthropic" if self.anthropic_api_key else "ollama")
 
     @property
     def auth_bypass_active(self) -> bool:

--- a/tests/test_classify.py
+++ b/tests/test_classify.py
@@ -326,6 +326,64 @@ class TestCompilePreview(unittest.TestCase):
         self.assertEqual(out["clarifying_question"], "Grab rides or Grab food?")
         self.assertNotIn("conditions", out)
 
+    def test_ollama_parse_schema_constrained_and_parsed(self):
+        import requests
+        orig, cap = requests.post, {}
+
+        class FakeResp:
+            def raise_for_status(self): pass
+            def json(self):
+                ok = classify.CompileResult(result=_Compiled(status="ok", conditions=[
+                    _TextCond(field="merchant", operator="contains", value="grab")]))
+                return {"message": {"content": ok.model_dump_json()}}
+
+        requests.post = lambda url, **kw: (cap.update(url=url, body=kw.get("json")), FakeResp())[1]
+        try:
+            res = classify._parse_nl_ollama("grab rides")
+            self.assertEqual(res.result.status, "ok")
+            self.assertIn("/api/chat", cap["url"])
+            self.assertIn("format", cap["body"])          # schema-constrained request
+            self.assertEqual(cap["body"]["stream"], False)
+        finally:
+            requests.post = orig
+
+    def test_ollama_unusable_output_degrades_to_unmappable(self):
+        import requests
+        orig = requests.post
+
+        class FakeResp:
+            def raise_for_status(self): pass
+            def json(self): return {"message": {"content": "not json at all"}}
+
+        requests.post = lambda url, **kw: FakeResp()
+        try:
+            self.assertEqual(classify._parse_nl_ollama("x").result.status, "unmappable")
+        finally:
+            requests.post = orig
+
+    def test_openai_compatible_parse(self):
+        import requests
+        from portfolio.config import settings
+        orig, cap = requests.post, {}
+        settings.openai_base_url = "https://api.groq.com/openai/v1"
+
+        class FakeResp:
+            def raise_for_status(self): pass
+            def json(self):
+                ok = classify.CompileResult(result=_Compiled(status="ok", conditions=[
+                    _TextCond(field="merchant", operator="contains", value="grab")]))
+                return {"choices": [{"message": {"content": ok.model_dump_json()}}]}
+
+        requests.post = lambda url, **kw: (cap.update(url=url, body=kw.get("json")), FakeResp())[1]
+        try:
+            res = classify._parse_nl_openai("grab rides")
+            self.assertEqual(res.result.status, "ok")
+            self.assertTrue(cap["url"].endswith("/chat/completions"))
+            self.assertEqual(cap["body"]["response_format"]["type"], "json_schema")
+        finally:
+            requests.post = orig
+            settings.openai_base_url = ""
+
     def test_compile_preview_degrades_malformed_parse_to_unmappable(self):
         # model returns a money 'between' with no bounds -> our validation rejects it,
         # surfaced as ask-back rather than a 500

--- a/tests/test_classify.py
+++ b/tests/test_classify.py
@@ -379,7 +379,7 @@ class TestCompilePreview(unittest.TestCase):
             res = classify._parse_nl_openai("grab rides")
             self.assertEqual(res.result.status, "ok")
             self.assertTrue(cap["url"].endswith("/chat/completions"))
-            self.assertEqual(cap["body"]["response_format"]["type"], "json_schema")
+            self.assertEqual(cap["body"]["response_format"]["type"], "json_object")
         finally:
             requests.post = orig
             settings.openai_base_url = ""


### PR DESCRIPTION
Makes the "Propose a rule" NL→predicate compiler work **without the paid Anthropic API**, so the feature is usable locally and on free tiers.

## What changed
- **Provider auto-selects** (`settings.classify_provider_active`): Anthropic when `ANTHROPIC_API_KEY` is set, else a local **Ollama** server (free, offline). Force with `CLASSIFY_PROVIDER=anthropic|ollama|openai`.
- **`_parse_nl` dispatches** to three isolated, stubbable backends:
  - `ollama` — `/api/chat` with `format=<json schema>` (structured output)
  - `openai` — any OpenAI-compatible endpoint (`/chat/completions`, `json_object` mode) → **Groq / Gemini / OpenRouter free tiers**
  - `anthropic` — unchanged
- Unusable model output degrades to `unmappable` (shared `_to_result`) so the UI shows an ask-back instead of 500ing.
- Sharpened the compile system prompt: one-shot example, don't over-trigger `unmappable`, normalize amounts to positive magnitude, and **extract the shortest merchant keyword** (`"Grab rides"` → `grab`). Helps every provider.
- `config` gains `ollama_*` / `openai_*` fields; `.env.example` documents all three paths.

## Notes
- A small local model (llama3.2 3B) is too weak for reliable extraction — use a 7B+ Ollama model or a free-tier cloud model.
- **Verified live via Groq** (`llama-3.3-70b-versatile`): *"Grab rides under \$30"* → `merchant contains "grab" AND amount_sgd < 30` → 21 matches; *"MRT or bus"* → 153 matches.
- 52 classify tests pass (5 new: ollama request/parse/degrade, openai path); provider selection + model boundary are stubbed, no network in tests.

No schema or API-surface changes — purely the compile backend.