### PR TITLE
feat(web): add posthog error tracking via same-origin ingest proxy

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,6 +15,9 @@ SPENDING_EMAILS=you@gmail.com
 ALLOWED_ORIGINS=http://localhost:5173,http://localhost:8000
 # cookie Secure flag — true in prod (HTTPS), false for local http dev
 COOKIE_SECURE=false
+# PostHog region host the same-origin /ingest proxy forwards to (default https://us.i.posthog.com).
+# Must match the region of VITE_PUBLIC_POSTHOG_KEY; see DEPLOY.md.
+#POSTHOG_HOST=https://us.i.posthog.com
 # LOCAL DEV ONLY: skip Google sign-in entirely (every request treated as dev@localhost).
 # Force-disabled on Vercel regardless of this value, so it can never unlock prod. Leave unset/false
 # unless you want to run the API+web without OAuth configured.

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -37,7 +37,7 @@ Project → Settings → Environment Variables (Production + Preview):
 | `DATABASE_URL` | the `sslmode=require` Postgres URL |
 | `VITE_PUBLIC_POSTHOG_KEY` | PostHog project API key (`phc_…`) |
 | `VITE_PUBLIC_POSTHOG_HOST` | PostHog host, e.g. `https://us.i.posthog.com` — used as `ui_host` (toolbar links) and to gate `posthog.init()`; events go through the same-origin `/ingest` proxy, not here |
-| `POSTHOG_HOST` | Server-side upstream the `/ingest` proxy forwards to — same region host as above (`https://us.i.posthog.com`). Defaults to that if unset |
+| `POSTHOG_HOST` | Server-side upstream the `/ingest` proxy forwards to — same region host as above (`https://us.i.posthog.com`). Defaults to that if unset. Must be a `*.i.posthog.com` region host: the proxy derives the assets host from it, so a custom/self-hosted value logs a startup warning and leaves the lazily-loaded bundles (exception autocapture, surveys, recorder) 404ing — error tracking silently off |
 
 > **PostHog is all-or-nothing and build-time.** Missing either `VITE_*` var skips
 > `posthog.init()`, so the deploy ships with no analytics *and* no error tracking (uncaught

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -43,9 +43,7 @@ Project → Settings → Environment Variables (Production + Preview):
 > `posthog.init()`, so the deploy ships with no analytics *and* no error tracking (uncaught
 > exceptions, unhandled promise rejections, React render errors). `VITE_*` vars are baked into
 > the bundle at build time — adding them takes effect on the next deploy, not on the running
-> one. No CSP change is needed: the SPA posts to the same-origin `/ingest` reverse proxy
-> (`server/main.py`), which `connect-src 'self'` / `script-src 'self'` already cover — see
-> [Security ops → Headers](#security-ops).
+> one. No CSP change is needed — see [Security ops](#security-ops) for why.
 
 > **`SPENDING_EMAILS` fails closed.** Omit it and the Spending section disappears for everyone —
 > the nav item is hidden and `/api/spending/*` returns 403, including for accounts in
@@ -105,8 +103,9 @@ auth work — the endpoint is auth-protected either way.
 - **Dependency scan (SECURITY-10)**: `uv pip install pip-audit && pip-audit -r requirements.txt`
   before each deploy. Lock files (`uv.lock`, pinned `requirements.txt`) are committed.
 - **Local dev**: copy `.env.example` → `.env` (`COOKIE_SECURE=false` for http), and
-  `web/.env.example` → `web/.env.local`. Run API (`uvicorn api.main:app --port 8000`) +
-  `npm run dev` (Vite proxies `/api` → 8000, same-origin cookie works).
+  `web/.env.example` → `web/.env.local`. Run API (`make api`, i.e. `uvicorn server.main:app
+  --port 8000`) + `npm run dev` (Vite proxies `/api` **and** `/ingest` → 8000, so the
+  same-origin cookie works and PostHog traffic takes the same proxy path as production).
 - **Headers**: HTTP security headers (CSP/HSTS/X-Content-Type-Options/X-Frame-Options/
   Referrer-Policy) are set by the FastAPI middleware in `server/main.py`, which serves both
   the API and the static SPA. CSP allows `accounts.google.com` for Google Identity Services
@@ -118,3 +117,7 @@ auth work — the endpoint is auth-protected either way.
   bundles). Because the traffic is first-party, the strict `connect-src 'self'` /
   `script-src 'self'` already cover it — no PostHog origin is added to the CSP. If you ever
   switch back to hitting PostHog directly, you must instead allow the host in `connect-src`.
+  `/ingest` is deliberately **unauthenticated** — it sits outside `/api/`, so the
+  deny-by-default gate lets it through; analytics and error events fire before sign-in. It
+  forwards only to `POSTHOG_HOST`, never follows upstream redirects, and re-emits no
+  `Set-Cookie`/`Access-Control-*`/`Location` headers.

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -35,6 +35,13 @@ Project → Settings → Environment Variables (Production + Preview):
 | `ALLOWED_ORIGINS` | `https://<your-app>.vercel.app` |
 | `COOKIE_SECURE` | `true` |
 | `DATABASE_URL` | the `sslmode=require` Postgres URL |
+| `VITE_PUBLIC_POSTHOG_KEY` | PostHog project API key (`phc_…`) |
+| `VITE_PUBLIC_POSTHOG_HOST` | PostHog ingestion host, e.g. `https://us.i.posthog.com` |
+
+> **PostHog is all-or-nothing and build-time.** Missing either var skips `posthog.init()`, so
+> the deploy ships with no analytics *and* no error tracking (uncaught exceptions, unhandled
+> promise rejections, React render errors). `VITE_*` vars are baked into the bundle at build
+> time — adding them takes effect on the next deploy, not on the running one.
 
 > **`SPENDING_EMAILS` fails closed.** Omit it and the Spending section disappears for everyone —
 > the nav item is hidden and `/api/spending/*` returns 403, including for accounts in

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -36,13 +36,15 @@ Project → Settings → Environment Variables (Production + Preview):
 | `COOKIE_SECURE` | `true` |
 | `DATABASE_URL` | the `sslmode=require` Postgres URL |
 | `VITE_PUBLIC_POSTHOG_KEY` | PostHog project API key (`phc_…`) |
-| `VITE_PUBLIC_POSTHOG_HOST` | PostHog ingestion host, e.g. `https://us.i.posthog.com` |
+| `VITE_PUBLIC_POSTHOG_HOST` | PostHog host, e.g. `https://us.i.posthog.com` — used as `ui_host` (toolbar links) and to gate `posthog.init()`; events go through the same-origin `/ingest` proxy, not here |
+| `POSTHOG_HOST` | Server-side upstream the `/ingest` proxy forwards to — same region host as above (`https://us.i.posthog.com`). Defaults to that if unset |
 
-> **PostHog is all-or-nothing and build-time.** Missing either var skips `posthog.init()`, so
-> the deploy ships with no analytics *and* no error tracking (uncaught exceptions, unhandled
-> promise rejections, React render errors). `VITE_*` vars are baked into the bundle at build
-> time — adding them takes effect on the next deploy, not on the running one. Setting the vars
-> is not sufficient: the same host must also be allowed in the CSP `connect-src` — see
+> **PostHog is all-or-nothing and build-time.** Missing either `VITE_*` var skips
+> `posthog.init()`, so the deploy ships with no analytics *and* no error tracking (uncaught
+> exceptions, unhandled promise rejections, React render errors). `VITE_*` vars are baked into
+> the bundle at build time — adding them takes effect on the next deploy, not on the running
+> one. No CSP change is needed: the SPA posts to the same-origin `/ingest` reverse proxy
+> (`server/main.py`), which `connect-src 'self'` / `script-src 'self'` already cover — see
 > [Security ops → Headers](#security-ops).
 
 > **`SPENDING_EMAILS` fails closed.** Omit it and the Spending section disappears for everyone —
@@ -110,8 +112,9 @@ auth work — the endpoint is auth-protected either way.
   the API and the static SPA. CSP allows `accounts.google.com` for Google Identity Services
   (which ships no SRI hash — origin pin instead) and inline styles for React/GIS;
   `script-src` stays strict.
-- **PostHog needs a CSP allowance (required deploy step)**: `connect-src` in `_CSP`
-  (`server/main.py`) currently lists only `'self' https://accounts.google.com`. Add the
-  `VITE_PUBLIC_POSTHOG_HOST` origin (e.g. `https://us.i.posthog.com`) to `connect-src`, or
-  proxy PostHog same-origin — otherwise the browser blocks every request to it and both
-  product analytics *and* error tracking silently send nothing in production.
+- **PostHog is proxied same-origin (no CSP host needed)**: posthog-js posts to `/ingest`
+  (same origin), which the FastAPI reverse proxy in `server/main.py` forwards to `POSTHOG_HOST`
+  (ingestion) and its `*-assets` host (the lazily-loaded exception-autocapture/recorder
+  bundles). Because the traffic is first-party, the strict `connect-src 'self'` /
+  `script-src 'self'` already cover it — no PostHog origin is added to the CSP. If you ever
+  switch back to hitting PostHog directly, you must instead allow the host in `connect-src`.

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -41,7 +41,9 @@ Project → Settings → Environment Variables (Production + Preview):
 > **PostHog is all-or-nothing and build-time.** Missing either var skips `posthog.init()`, so
 > the deploy ships with no analytics *and* no error tracking (uncaught exceptions, unhandled
 > promise rejections, React render errors). `VITE_*` vars are baked into the bundle at build
-> time — adding them takes effect on the next deploy, not on the running one.
+> time — adding them takes effect on the next deploy, not on the running one. Setting the vars
+> is not sufficient: the same host must also be allowed in the CSP `connect-src` — see
+> [Security ops → Headers](#security-ops).
 
 > **`SPENDING_EMAILS` fails closed.** Omit it and the Spending section disappears for everyone —
 > the nav item is hidden and `/api/spending/*` returns 403, including for accounts in
@@ -104,6 +106,12 @@ auth work — the endpoint is auth-protected either way.
   `web/.env.example` → `web/.env.local`. Run API (`uvicorn api.main:app --port 8000`) +
   `npm run dev` (Vite proxies `/api` → 8000, same-origin cookie works).
 - **Headers**: HTTP security headers (CSP/HSTS/X-Content-Type-Options/X-Frame-Options/
-  Referrer-Policy) are set by FastAPI middleware (API) and `vercel.json` (static HTML).
-  CSP allows `accounts.google.com` for Google Identity Services (which ships no SRI hash —
-  origin pin instead) and inline styles for React/GIS; `script-src` stays strict.
+  Referrer-Policy) are set by the FastAPI middleware in `server/main.py`, which serves both
+  the API and the static SPA. CSP allows `accounts.google.com` for Google Identity Services
+  (which ships no SRI hash — origin pin instead) and inline styles for React/GIS;
+  `script-src` stays strict.
+- **PostHog needs a CSP allowance (required deploy step)**: `connect-src` in `_CSP`
+  (`server/main.py`) currently lists only `'self' https://accounts.google.com`. Add the
+  `VITE_PUBLIC_POSTHOG_HOST` origin (e.g. `https://us.i.posthog.com`) to `connect-src`, or
+  proxy PostHog same-origin — otherwise the browser blocks every request to it and both
+  product analytics *and* error tracking silently send nothing in production.

--- a/README.md
+++ b/README.md
@@ -80,7 +80,8 @@ PYTHONPATH=. .venv/bin/python scripts/snapshot_from_statements.py --dbs 202606 -
 | `migrations/` | Alembic schema |
 | `scripts/seed.py` | reference-data seed |
 | `scripts/snapshot_from_statements.py` | net-worth snapshot from statements (`--all-new` delta) |
-| `api/` | FastAPI |
+| `server/` | FastAPI app (`main.py`) — serves `/api/*` and the built SPA |
+| `api/index.py` | Vercel entrypoint — re-exports `server.main:app` |
 | `web/` | React (Vite) app |
 
 ## Status

--- a/aidlc-docs/construction/auth/functional-design/auth-design.md
+++ b/aidlc-docs/construction/auth/functional-design/auth-design.md
@@ -68,7 +68,7 @@ Browser                         Vercel /api (FastAPI)               Google
 | `DATABASE_URL` | api | managed Postgres, TLS (`sslmode=require`) |
 
 ## Deploy artifacts
-- `vercel.json` — build SPA (`web/`) + python fn (`api/index.py`); route `/api/*`→fn, else SPA fallback.
+- No `vercel.json` — Vercel framework detection picks up `api/index.py` (re-exports `server.main:app`) as the single Python fn; the `[tool.vercel.scripts]` build hook in `pyproject.toml` builds the SPA into `web/dist`, which FastAPI serves same-origin (all routes, `/api/*` and SPA alike, go through the fn).
 - `requirements.txt` — pinned: sqlalchemy, psycopg[binary], fastapi, pydantic-settings, python-dotenv, **google-auth, PyJWT**.
 - Postgres → Neon/Vercel Postgres (TLS + encryption at rest). Set `DATABASE_URL`.
 - Price refresh: blocking external fetch → timeout risk on serverless. Keep endpoint (auth-protected) + document Vercel Cron + `maxDuration`. Out of auth scope.

--- a/aidlc-docs/construction/auth/functional-design/auth-design.md
+++ b/aidlc-docs/construction/auth/functional-design/auth-design.md
@@ -34,9 +34,9 @@ Browser                         Vercel /api (FastAPI)               Google
 ## Backend components
 | File | Role |
 |---|---|
-| `api/auth.py` (new) | auth config, Google verify, session mint/verify, `require_user` dep, router, auth-event logging |
-| `api/main.py` (edit) | lock CORS, security-headers mw, deny-by-default auth gate mw, include auth router, generic errors |
-| `api/index.py` (new) | Vercel ASGI entry: `from api.main import app` |
+| `server/auth.py` (new) | auth config, Google verify, session mint/verify, `require_user` dep, router, auth-event logging |
+| `server/main.py` (edit) | lock CORS, security-headers mw, deny-by-default auth gate mw, include auth router, generic errors |
+| `api/index.py` (new) | Vercel ASGI entry: `from server.main import app` |
 
 ### Routes
 - `POST /api/auth/google` — body `{credential: str}` (max-len bound). Verify → set cookie → return `{email,name}`. **Public** (login entry). Rate-limited.

--- a/aidlc-docs/construction/build-and-test/integration-test-instructions.md
+++ b/aidlc-docs/construction/build-and-test/integration-test-instructions.md
@@ -7,7 +7,7 @@ Tests the API ↔ DB ↔ live-portfolio compute path end to end.
 docker compose up -d db
 PYTHONPATH=. .venv/bin/alembic upgrade head
 PYTHONPATH=. .venv/bin/python scripts/seed_networth.py
-PYTHONPATH=. .venv/bin/uvicorn api.main:app --port 8000
+PYTHONPATH=. .venv/bin/uvicorn server.main:app --port 8000
 ```
 
 ## Scenarios (executed this run, port 8011/8012)

--- a/aidlc-docs/construction/networth/code/summary.md
+++ b/aidlc-docs/construction/networth/code/summary.md
@@ -32,7 +32,7 @@ PYTHONPATH=. .venv/bin/python scripts/seed_networth.py
 # tests
 PYTHONPATH=. .venv/bin/python tests/test_networth.py
 # api + web
-PYTHONPATH=. .venv/bin/uvicorn api.main:app --reload --port 8000
+PYTHONPATH=. .venv/bin/uvicorn server.main:app --reload --port 8000
 cd web && npm run dev
 ```
 

--- a/api/index.py
+++ b/api/index.py
@@ -4,7 +4,7 @@ and every request — /api/* and the static SPA alike — goes through this func
 import os
 import sys
 
-# ensure the repo root is importable so `api.*` and `portfolio.*` resolve in the lambda
+# ensure the repo root is importable so `server.*` and `portfolio.*` resolve in the lambda
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from server.main import app  # noqa: E402,F401  (re-exported for the Vercel runtime)

--- a/api/index.py
+++ b/api/index.py
@@ -1,5 +1,6 @@
 """Vercel serverless entrypoint. Vercel's @vercel/python runtime serves the ASGI
-`app` exported here; vercel.json routes all /api/* requests to this function."""
+`app` exported here; framework detection finds this file (there is no vercel.json)
+and every request — /api/* and the static SPA alike — goes through this function."""
 import os
 import sys
 

--- a/portfolio/config.py
+++ b/portfolio/config.py
@@ -25,6 +25,10 @@ class Settings(BaseSettings):
     spending_emails: str = ""            # comma-separated; empty => nobody (fail closed)
     allowed_origins: str = "http://localhost:5173,http://localhost:8000"  # CORS
     cookie_secure: bool = True           # set false for local http dev
+    # PostHog ingestion host the /ingest reverse proxy forwards to (server/main.py). The SPA
+    # posts analytics + error events same-origin, so this keeps them off the CSP allow-list.
+    # Match the region of the frontend's VITE_PUBLIC_POSTHOG_HOST.
+    posthog_host: str = "https://us.i.posthog.com"
     dev_auth_bypass: bool = False        # skip Google auth — LOCAL dev only (see auth_bypass_active)
 
     # --- spend classification: NL->predicate compile (server-side, once per rule) ---

--- a/server/main.py
+++ b/server/main.py
@@ -709,6 +709,11 @@ def classify_rule_delete(rule_id: int):
 # (analytics/error events fire before and without a session).
 _PH_INGEST = settings.posthog_host.rstrip("/")
 _PH_ASSETS = _PH_INGEST.replace(".i.posthog.com", "-assets.i.posthog.com")
+if _PH_ASSETS == _PH_INGEST:
+    # the replace was a no-op (custom or self-hosted POSTHOG_HOST), so /ingest/static/* goes to
+    # the ingestion host and the lazily-loaded bundles 404 — error tracking silently disabled
+    log.warning("POSTHOG_HOST=%s has no matching *-assets host; /ingest/static/* bundles "
+                "(exception-autocapture, surveys, recorder) will likely 404", _PH_INGEST)
 # Allow-list, not a deny-list: these are the only upstream response headers safe to re-emit
 # from our own origin. Notably excluded are Set-Cookie (a third party must not set cookies on
 # the session domain), Access-Control-* (would let any cross-origin page read /ingest/*),
@@ -738,6 +743,9 @@ async def posthog_proxy(path: str, request: Request):
     headers = {}
     if ct := request.headers.get("content-type"):
         headers["Content-Type"] = ct
+    # without this PostHog sees python-requests/... and may filter the event as bot traffic
+    if ua := request.headers.get("user-agent"):
+        headers["User-Agent"] = ua
     # preserve the caller's IP so PostHog geoip still resolves through the proxy
     xff = request.headers.get("x-forwarded-for") or (request.client.host if request.client else "")
     if xff:

--- a/server/main.py
+++ b/server/main.py
@@ -8,6 +8,7 @@ requires a valid session cookie (deny-by-default gate below). See server/auth.py
 import logging
 import os
 import sys
+from http import cookiejar
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 import requests
@@ -716,6 +717,18 @@ _PH_ASSETS = _PH_INGEST.replace(".i.posthog.com", "-assets.i.posthog.com")
 _PH_KEEP_HEADERS = {"content-type", "cache-control", "etag", "vary"}
 # reused across invocations for connection pooling — posthog-js fires several calls per page
 _ph_session = requests.Session()
+
+
+class _BlockAllCookies(cookiejar.DefaultCookiePolicy):
+    """Refuse to store or send any cookie. The pooled session is shared by every visitor, so a
+    live jar would replay one caller's PostHog cookies on behalf of all the others."""
+    def set_ok(self, cookie, request): return False
+    def return_ok(self, cookie, request): return False
+    def domain_return_ok(self, domain, request): return False
+    def path_return_ok(self, path, request): return False
+
+
+_ph_session.cookies.set_policy(_BlockAllCookies())
 
 
 @app.api_route("/ingest/{path:path}", methods=["GET", "POST"])

--- a/server/main.py
+++ b/server/main.py
@@ -38,7 +38,8 @@ if settings.auth_bypass_active:
 # under /api/ is denied by default by the gate middleware (SECURITY-08).
 _PUBLIC_PATHS = {"/api/auth/google", "/api/auth/me", "/api/auth/logout", "/api/health"}
 
-# HTML security headers, also set on static responses via vercel.json for prod.
+# HTML security headers for both the API and the static SPA — this middleware is the only
+# place they are set (there is no vercel.json).
 # script-src stays strict (no unsafe-inline) — the XSS-relevant directive. style-src
 # allows inline because React inline styles + the Google button need it (documented
 # exception, SECURITY-04). accounts.google.com is allowed for Google Identity Services

--- a/server/main.py
+++ b/server/main.py
@@ -10,11 +10,13 @@ import os
 import sys
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
-from fastapi import FastAPI, Query, Request
+import requests
+from fastapi import FastAPI, Query, Request, Response
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 from fastapi.staticfiles import StaticFiles
 from sqlalchemy import text
+from starlette.concurrency import run_in_threadpool
 
 from portfolio.config import settings
 
@@ -694,6 +696,39 @@ def classify_rule_delete(rule_id: int):
         raise HTTPException(409, str(e))                        # has classified spends
     except ValueError as e:
         raise HTTPException(404, str(e))
+
+
+# ---------------- PostHog same-origin reverse proxy ----------------
+# posthog-js posts analytics + error-tracking traffic to same-origin "/ingest" instead of the
+# PostHog cloud host, so it is covered by the strict CSP's `connect-src 'self'` /
+# `script-src 'self'` with no third-party origin to allow-list. Ingestion calls go to
+# POSTHOG_HOST; the lazily-loaded JS bundles under /static/ (exception-autocapture, surveys,
+# recorder) go to the matching *-assets host, mirroring PostHog's own proxy guidance.
+# Public by design: /ingest isn't under /api/, so the deny-by-default auth gate lets it through
+# (analytics/error events fire before and without a session).
+_PH_INGEST = settings.posthog_host.rstrip("/")
+_PH_ASSETS = _PH_INGEST.replace(".i.posthog.com", "-assets.i.posthog.com")
+# recomputed by requests/Starlette for the decoded body — copying upstream's would corrupt it
+_PH_DROP_HEADERS = {"content-encoding", "content-length", "transfer-encoding", "connection"}
+
+
+@app.api_route("/ingest/{path:path}", methods=["GET", "POST"])
+async def posthog_proxy(path: str, request: Request):
+    upstream = _PH_ASSETS if path.startswith("static/") else _PH_INGEST
+    body = await request.body()
+    headers = {}
+    if ct := request.headers.get("content-type"):
+        headers["Content-Type"] = ct
+    # preserve the caller's IP so PostHog geoip still resolves through the proxy
+    xff = request.headers.get("x-forwarded-for") or (request.client.host if request.client else "")
+    if xff:
+        headers["X-Forwarded-For"] = xff
+    r = await run_in_threadpool(
+        lambda: requests.request(request.method, f"{upstream}/{path}",
+                                 params=request.url.query, data=body or None,
+                                 headers=headers, timeout=10))
+    out = {k: v for k, v in r.headers.items() if k.lower() not in _PH_DROP_HEADERS}
+    return Response(content=r.content, status_code=r.status_code, headers=out)
 
 
 # serve the built frontend (web/dist) if present

--- a/server/main.py
+++ b/server/main.py
@@ -708,8 +708,14 @@ def classify_rule_delete(rule_id: int):
 # (analytics/error events fire before and without a session).
 _PH_INGEST = settings.posthog_host.rstrip("/")
 _PH_ASSETS = _PH_INGEST.replace(".i.posthog.com", "-assets.i.posthog.com")
-# recomputed by requests/Starlette for the decoded body — copying upstream's would corrupt it
-_PH_DROP_HEADERS = {"content-encoding", "content-length", "transfer-encoding", "connection"}
+# Allow-list, not a deny-list: these are the only upstream response headers safe to re-emit
+# from our own origin. Notably excluded are Set-Cookie (a third party must not set cookies on
+# the session domain), Access-Control-* (would let any cross-origin page read /ingest/*),
+# Location (never redirect our origin to a PostHog-chosen URL) and the framing/length headers
+# that requests+Starlette recompute for the decoded body.
+_PH_KEEP_HEADERS = {"content-type", "cache-control", "etag", "vary"}
+# reused across invocations for connection pooling — posthog-js fires several calls per page
+_ph_session = requests.Session()
 
 
 @app.api_route("/ingest/{path:path}", methods=["GET", "POST"])
@@ -723,11 +729,17 @@ async def posthog_proxy(path: str, request: Request):
     xff = request.headers.get("x-forwarded-for") or (request.client.host if request.client else "")
     if xff:
         headers["X-Forwarded-For"] = xff
-    r = await run_in_threadpool(
-        lambda: requests.request(request.method, f"{upstream}/{path}",
-                                 params=request.url.query, data=body or None,
-                                 headers=headers, timeout=10))
-    out = {k: v for k, v in r.headers.items() if k.lower() not in _PH_DROP_HEADERS}
+    try:
+        # allow_redirects=False: an upstream 3xx must not make the server fetch a PostHog-chosen URL
+        r = await run_in_threadpool(
+            lambda: _ph_session.request(request.method, f"{upstream}/{path}",
+                                        params=request.url.query, data=body or None,
+                                        headers=headers, timeout=10, allow_redirects=False))
+    except requests.RequestException as e:
+        # best-effort analytics: a PostHog blip must not become an app 500 / error-level log
+        log.warning("posthog proxy upstream failed path=%s: %s", path, e)
+        return Response(status_code=502)
+    out = {k: v for k, v in r.headers.items() if k.lower() in _PH_KEEP_HEADERS}
     return Response(content=r.content, status_code=r.status_code, headers=out)
 
 

--- a/tests/test_posthog_proxy.py
+++ b/tests/test_posthog_proxy.py
@@ -65,6 +65,14 @@ def test_client_ip_is_forwarded_for_geoip(monkeypatch):
     assert seen["headers"]["X-Forwarded-For"] == "203.0.113.9"
 
 
+def test_browser_user_agent_is_forwarded(monkeypatch):
+    """Otherwise PostHog sees python-requests/... and may drop the event as bot traffic."""
+    seen = _stub(monkeypatch)
+    with TestClient(main.app) as c:
+        c.post("/ingest/e/", headers={"User-Agent": "Mozilla/5.0 (Macintosh) Chrome/140"})
+    assert seen["headers"]["User-Agent"] == "Mozilla/5.0 (Macintosh) Chrome/140"
+
+
 def test_unsafe_upstream_headers_are_not_re_emitted(monkeypatch):
     """Set-Cookie / CORS / Location from PostHog must not become headers of OUR origin."""
     _stub(monkeypatch, _Resp(headers={

--- a/tests/test_posthog_proxy.py
+++ b/tests/test_posthog_proxy.py
@@ -1,0 +1,105 @@
+"""Same-origin PostHog proxy tests — /ingest/{path} in server/main.py.
+
+The proxy exists so posthog-js can post analytics + error events first-party and stay inside
+the strict CSP (`connect-src 'self'`), so these pin both halves: the CSP carries no PostHog
+host, and the route forwards to the right upstream without re-emitting the response headers a
+third party must not control on our origin. Upstream is stubbed — no network, no DB.
+"""
+import requests
+from fastapi.testclient import TestClient
+
+from server import main
+
+
+class _Resp:
+    def __init__(self, status=200, content=b"ok", headers=None):
+        self.status_code, self.content = status, content
+        self.headers = headers or {"Content-Type": "application/json"}
+
+
+def _stub(monkeypatch, resp=None, boom=None):
+    """Capture the outbound request the proxy makes instead of hitting PostHog."""
+    seen = {}
+
+    def fake_request(method, url, **kw):
+        seen.update(method=method, url=url, **kw)
+        if boom:
+            raise boom
+        return resp or _Resp()
+
+    monkeypatch.setattr(main._ph_session, "request", fake_request)
+    return seen
+
+
+def test_csp_has_no_posthog_host():
+    """The payoff of proxying: the CSP is left untouched — 'self' covers /ingest."""
+    assert "posthog" not in main._CSP
+    assert "connect-src 'self' https://accounts.google.com" in main._CSP
+
+
+def test_ingestion_path_goes_to_posthog_host(monkeypatch):
+    seen = _stub(monkeypatch)
+    with TestClient(main.app) as c:
+        r = c.post("/ingest/e/?ver=1.407.2", content=b"payload",
+                   headers={"Content-Type": "application/json"})
+    assert r.status_code == 200
+    assert seen["url"] == f"{main._PH_INGEST}/e/"
+    assert seen["params"] == "ver=1.407.2"
+    assert seen["data"] == b"payload"
+    assert seen["headers"]["Content-Type"] == "application/json"
+    # never chase a PostHog-chosen redirect target from our own server
+    assert seen["allow_redirects"] is False
+
+
+def test_static_bundles_go_to_the_assets_host(monkeypatch):
+    seen = _stub(monkeypatch)
+    with TestClient(main.app) as c:
+        c.get("/ingest/static/exception-autocapture.js")
+    assert seen["url"] == "https://us-assets.i.posthog.com/static/exception-autocapture.js"
+
+
+def test_client_ip_is_forwarded_for_geoip(monkeypatch):
+    seen = _stub(monkeypatch)
+    with TestClient(main.app) as c:
+        c.post("/ingest/e/", headers={"X-Forwarded-For": "203.0.113.9"})
+    assert seen["headers"]["X-Forwarded-For"] == "203.0.113.9"
+
+
+def test_unsafe_upstream_headers_are_not_re_emitted(monkeypatch):
+    """Set-Cookie / CORS / Location from PostHog must not become headers of OUR origin."""
+    _stub(monkeypatch, _Resp(headers={
+        "Content-Type": "application/json", "Cache-Control": "no-store", "ETag": "W/abc",
+        "Set-Cookie": "ph_session=1; Path=/", "Access-Control-Allow-Origin": "*",
+        "Location": "https://evil.example/",
+    }))
+    with TestClient(main.app) as c:
+        r = c.post("/ingest/e/")
+    assert r.headers["cache-control"] == "no-store" and r.headers["etag"] == "W/abc"
+    for banned in ("set-cookie", "access-control-allow-origin", "location"):
+        assert banned not in {k.lower() for k in r.headers}
+
+
+def test_upstream_failure_is_502_not_500(monkeypatch):
+    _stub(monkeypatch, boom=requests.ConnectionError("posthog unreachable"))
+    with TestClient(main.app) as c:
+        r = c.post("/ingest/e/")
+    assert r.status_code == 502   # analytics blip, not an app error
+
+
+def test_upstream_status_is_passed_through(monkeypatch):
+    _stub(monkeypatch, _Resp(status=401, content=b'{"detail":"bad token"}'))
+    with TestClient(main.app) as c:
+        r = c.post("/ingest/e/")
+    assert (r.status_code, r.content) == (401, b'{"detail":"bad token"}')
+
+
+def test_proxy_is_public_and_never_sends_cookies_upstream(monkeypatch):
+    """Events fire before login, so /ingest sits outside the deny-by-default /api/ gate — and
+    the pooled session is shared by every visitor, so no caller's cookies may leak upstream."""
+    seen = _stub(monkeypatch)
+    with TestClient(main.app) as c:
+        c.cookies.set("session", "someone-elses-session")
+        r = c.post("/ingest/e/")
+    assert r.status_code == 200                       # not 401 from the auth gate
+    assert "Cookie" not in seen["headers"]
+    assert main._ph_session.cookies.get_policy().set_ok(None, None) is False

--- a/web/.env.example
+++ b/web/.env.example
@@ -1,3 +1,9 @@
-# copy to web/.env.local for local dev; on Vercel set this in Project > Settings > Environment Variables
+# copy to web/.env.local for local dev; on Vercel set these in Project > Settings > Environment Variables
 # must match the backend GOOGLE_CLIENT_ID (Vite only exposes vars prefixed VITE_)
 VITE_GOOGLE_CLIENT_ID=xxxxxxxx.apps.googleusercontent.com
+
+# --- PostHog (product analytics + error tracking) ---
+# Both must be set or posthog.init() is skipped entirely: no events AND no exception capture
+# (uncaught errors, unhandled promise rejections, React render errors). Baked in at build time.
+VITE_PUBLIC_POSTHOG_KEY=phc_xxxxxxxx
+VITE_PUBLIC_POSTHOG_HOST=https://us.i.posthog.com

--- a/web/src/ErrorBoundary.jsx
+++ b/web/src/ErrorBoundary.jsx
@@ -15,7 +15,14 @@ export default class ErrorBoundary extends React.Component {
   }
 
   componentDidCatch(error, info) {
-    posthog.captureException(error, { react_component_stack: info?.componentStack });
+    // posthog.init() is skipped when the VITE_PUBLIC_POSTHOG_* vars are absent (normal in
+    // local dev), so reporting is best-effort: never let it throw out of componentDidCatch,
+    // which would unmount the very fallback this boundary exists to show.
+    try {
+      posthog.captureException(error, { react_component_stack: info?.componentStack });
+    } catch {
+      // reporting is optional; the fallback UI is not
+    }
   }
 
   render() {

--- a/web/src/ErrorBoundary.jsx
+++ b/web/src/ErrorBoundary.jsx
@@ -1,0 +1,33 @@
+import React from "react";
+import posthog from "posthog-js";
+
+// React swallows render/lifecycle errors, so they never reach PostHog's
+// window.onerror hook. This boundary forwards them explicitly and shows a
+// fallback instead of an unmounted (blank) tree.
+export default class ErrorBoundary extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = { failed: false };
+  }
+
+  static getDerivedStateFromError() {
+    return { failed: true };
+  }
+
+  componentDidCatch(error, info) {
+    posthog.captureException(error, { react_component_stack: info?.componentStack });
+  }
+
+  render() {
+    if (this.state.failed) {
+      return (
+        <div className="card" style={{ margin: 24 }}>
+          <h3>Something went wrong</h3>
+          <p>The page hit an unexpected error. Try reloading.</p>
+          <button onClick={() => window.location.reload()}>Reload</button>
+        </div>
+      );
+    }
+    return this.props.children;
+  }
+}

--- a/web/src/main.jsx
+++ b/web/src/main.jsx
@@ -3,6 +3,7 @@ import { createRoot } from "react-dom/client";
 import posthog from "posthog-js";
 import App from "./App.jsx";
 import AuthGate from "./auth.jsx";
+import ErrorBoundary from "./ErrorBoundary.jsx";
 import "./styles.css";
 
 const POSTHOG_KEY = import.meta.env.VITE_PUBLIC_POSTHOG_KEY;
@@ -27,11 +28,15 @@ if (POSTHOG_KEY && POSTHOG_HOST) {
   posthog.init(POSTHOG_KEY, {
     api_host: POSTHOG_HOST,
     defaults: "2026-05-30",
+    // Autocapture uncaught errors + unhandled promise rejections into PostHog error tracking.
+    capture_exceptions: true,
   });
 }
 
 createRoot(document.getElementById("root")).render(
-  <AuthGate>
-    <App />
-  </AuthGate>
+  <ErrorBoundary>
+    <AuthGate>
+      <App />
+    </AuthGate>
+  </ErrorBoundary>
 );

--- a/web/src/main.jsx
+++ b/web/src/main.jsx
@@ -26,7 +26,11 @@ if (!POSTHOG_HOST && import.meta.env.DEV) {
 
 if (POSTHOG_KEY && POSTHOG_HOST) {
   posthog.init(POSTHOG_KEY, {
-    api_host: POSTHOG_HOST,
+    // Post to the same-origin reverse proxy (server/main.py /ingest/*) so analytics + error
+    // events are first-party — covered by the strict CSP with no PostHog host to allow-list.
+    // ui_host keeps toolbar/links pointing at the real PostHog app.
+    api_host: window.location.origin + "/ingest",
+    ui_host: POSTHOG_HOST,
     defaults: "2026-05-30",
     // Autocapture uncaught errors + unhandled promise rejections into PostHog error tracking.
     capture_exceptions: true,

--- a/web/src/modules/portfolio/Overview.jsx
+++ b/web/src/modules/portfolio/Overview.jsx
@@ -12,7 +12,7 @@ export default function Overview() {
   useEffect(() => { get("/api/return").then(setRet).catch(() => setRet({})); }, []);
   useEffect(() => { get("/api/options").then(setOpt).catch(() => setOpt({})); }, []);
   if (!d) return <div className="loading">Loading…</div>;
-  if (d.error) return <div className="loading">API not reachable. Start: uvicorn api.main:app</div>;
+  if (d.error) return <div className="loading">API not reachable. Start: uvicorn server.main:app</div>;
 
   const pie = (obj) => Object.entries(obj).map(([k, v]) => ({ name: k, value: v.mv_sgd }));
   const mkt = pie(d.by_market), acct = pie(d.by_account).filter((x) => x.value > 0);

--- a/web/vite.config.js
+++ b/web/vite.config.js
@@ -4,5 +4,5 @@ import react from "@vitejs/plugin-react";
 export default defineConfig({
   plugins: [react()],
   build: { outDir: "dist" },
-  server: { proxy: { "/api": "http://localhost:8000" } },
+  server: { proxy: { "/api": "http://localhost:8000", "/ingest": "http://localhost:8000" } },
 });


### PR DESCRIPTION
## Intent

Trivial follow-up fix promised during the previous run's document gate: an earlier fix-review finding (document-2) flagged that web/src/modules/portfolio/Overview.jsx line 15 shows a user-facing 'API not reachable' error hint telling the user to run 'uvicorn api.main:app', which no longer exists — the FastAPI app is server.main:app. The document step couldn't fix it because it's a JSX code string, not a doc, so it was deferred to a code change. This one-line change updates the string to 'uvicorn server.main:app', consistent with the README/auth-design/DEPLOY.md entrypoint corrections already made in this branch. No behavior change; frontend build verified.

## What Changed

- Wired PostHog into the SPA: `main.jsx` initializes with `capture_exceptions: true`, and a new `ErrorBoundary` forwards React render/lifecycle errors via `captureException` (best-effort, wrapped in try/catch) while rendering a reload fallback instead of a blank tree.
- Added a same-origin `/ingest/{path}` reverse proxy in `server/main.py` so analytics and error events stay first-party under the strict CSP — no third-party host to allow-list. It routes `static/*` to the `*-assets` host, forwards `Content-Type`/`User-Agent`/`X-Forwarded-For`, blocks all cookies on the pooled session, allow-lists response headers (dropping `Set-Cookie`, `Access-Control-*`, `Location`), disables redirect following, returns 502 on upstream failure, and warns at import time when `POSTHOG_HOST` has no matching assets host. Covered by new `tests/test_posthog_proxy.py`; Vite dev server proxies `/ingest` alongside `/api`.
- Documented the new `POSTHOG_HOST` / `VITE_PUBLIC_POSTHOG_*` env vars and the CSP/assets-host constraint in `.env.example`, `web/.env.example`, and `DEPLOY.md`, and corrected stale `api.main:app` entrypoint references to `server.main:app` across README, auth design, integration-test instructions, and the user-facing "API not reachable" hint in `Overview.jsx`.

The review gate flagged four issues (dropped User-Agent, silent assets-host fallback, unauthenticated relay surface, stale test-instruction entrypoint); the first, second, and fourth were auto-fixed and re-checked clean. The document gate left one info note: historical `aidlc-docs`/`PLAN.md` records still name the pre-rename `api/main.py`, deliberately unchanged as dated artifacts rather than operative instructions.

## Risk Assessment

✅ Low: The fix round is three narrow, precisely-scoped changes (forward User-Agent, add an import-time warning, correct two runnable doc commands) that resolve the prior findings without altering proxy semantics, and are covered by an added test.

## Testing

`Started the real FastAPI app with the exact command the hint recommends (uvicorn server.main:app) on an isolated port with an unreachable DB so /api/overview returns 500, ran the vite dev server against it, and drove Chrome to Portfolio > Overview — the rendered page shows "API not reachable. Start: uvicorn server.main:app" (screenshot captured); temporarily reverting the line reproduced the old "uvicorn api.main:app" text for a before/after pair, and the file was restored to a clean tree. Also confirmed the hint is actionable (from server.main import app resolves to the FastAPI "Portfolio API"; import api.main raises ModuleNotFoundError) and that npm run build succeeds with the corrected string present in the emitted bundle. No repo test covers this string, so validation was targeted browser/manual verification; everything passed and transient artifacts (temp venv, node_modules, dist, evidence-only vite config, background servers) were removed afterwards.`

- Evidence: Overview error state after fix (rendered app) (local file: <code>/var/folders/1d/5_kyvlg52yxg82k8gn5dxtcw0000gn/T/no-mistakes-evidence/01KYEBQ90S3H6T8QKZV8NQYKJ2/overview-api-unreachable-hint.png</code>)
- Evidence: Overview error state before fix (stale api.main hint) (local file: <code>/var/folders/1d/5_kyvlg52yxg82k8gn5dxtcw0000gn/T/no-mistakes-evidence/01KYEBQ90S3H6T8QKZV8NQYKJ2/overview-hint-BEFORE-stale-api-main.png</code>)
<details>
<summary>Evidence: Entrypoint check: old hint target missing, new one resolves</summary>

<code>$ python -c &#34;import api.main&#34; # OLD hint target&#10;ModuleNotFoundError: No module named &#39;api.main&#39;&#10;&#10;$ python -c &#34;from server.main import app; print(...)&#34; # NEW hint target&#10;FastAPI - Portfolio API</code>

```text
$ PYTHONPATH=. .venv-test/bin/python -c "import api.main"   # the OLD hint target
  File "<string>", line 1, in <module>
ModuleNotFoundError: No module named 'api.main'

$ PYTHONPATH=. .venv-test/bin/python -c "from server.main import app; print(app.title)"   # the NEW hint target
FastAPI - Portfolio API
```
</details>
<details>
<summary>Evidence: uvicorn server.main:app startup + failing /api/overview</summary>

<code>INFO: Application startup complete.&#10;INFO: Uvicorn running on http://127.0.0.1:8123 (Press CTRL+C to quit)&#10;INFO: 127.0.0.1 - &#34;GET /api/overview HTTP/1.1&#34; 500 Internal Server Error</code>

```text
2026-07-26 13:19:55,569 WARNING api ⚠️  DEV_AUTH_BYPASS active — auth gate DISABLED, every request is 'dev@localhost'. Local dev only; this is force-off on Vercel.
INFO:     Started server process [74196]
INFO:     Waiting for application startup.
INFO:     Application startup complete.
INFO:     Uvicorn running on http://127.0.0.1:8123 (Press CTRL+C to quit)
INFO:     127.0.0.1:62436 - "GET /api/overview HTTP/1.1" 500 Internal Server Error
INFO:     127.0.0.1:62477 - "GET /api/overview HTTP/1.1" 500 Internal Server Error
INFO:     127.0.0.1:62534 - "GET /api/overview HTTP/1.1" 500 Internal Server Error
```
</details>
<details>
<summary>Evidence: Production bundle contains corrected hint</summary>

```text
$ npm run build && grep -o "API not reachable. Start: uvicorn [a-z.:]*" dist/assets/*.js
✓ built in 516ms
API not reachable. Start: uvicorn server.main:app
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 4 issues found → auto-fixed ✅</summary>

- ⚠️ `server/main.py:738` - The /ingest proxy builds a fresh outbound header dict containing only Content-Type and X-Forwarded-For, so the browser&#39;s User-Agent is dropped and PostHog receives `python-requests/2.34.2` for every event. PostHog&#39;s ingestion-side bot detection matches python-requests-style user agents and its reverse-proxy guidance calls for preserving the original UA, so proxied analytics and error events risk being silently filtered as bot traffic or losing server-side UA-derived attribution. Forward the incoming `user-agent` header alongside X-Forwarded-For.
- ℹ️ `server/main.py:711` - _PH_ASSETS is derived by a literal `.i.posthog.com` -&gt; `-assets.i.posthog.com` string replace on POSTHOG_HOST. Any value not matching that exact shape (a custom ingest domain, or `https://eu.posthog.com`) makes the replace a no-op, so /ingest/static/* requests are forwarded to the ingestion host, 404, and posthog-js never loads exception-autocapture.js — error tracking, the headline feature of this branch, is silently disabled with no log or startup warning. Consider validating the host shape at import time or logging a warning when the assets host equals the ingest host.
- ℹ️ `server/main.py:734` - /ingest/{path:path} is intentionally unauthenticated (documented) and pins the upstream netloc, so it is not an SSRF vector, but it accepts an arbitrary path, query, and body with no allow-list, size cap, or rate limit and holds a 10s upstream timeout per call. Anyone can use the deployed origin as a free relay to PostHog, consuming Vercel function invocations. Narrowing the accepted paths (e.g. `e/`, `i/v0/`, `flags`, `decide`, `array/`, `static/`) would bound abuse without changing posthog-js behavior.
- ℹ️ `aidlc-docs/construction/build-and-test/integration-test-instructions.md:10` - This branch corrected the stale `uvicorn api.main:app` entrypoint in README.md, DEPLOY.md, auth-design.md, and Overview.jsx, but the runnable command in integration-test-instructions.md still says `uvicorn api.main:app`, which no longer exists (the app is server.main:app, per Makefile:57). Same defect class as the intent commit; left unfixed a reader following these instructions gets an import error.

🔧 Fix: forward UA in posthog proxy, warn on assets host, fix docs
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`PYTHONPATH=. .venv-test/bin/uvicorn server.main:app --port 8123` (real backend started with the command named in the hint, DB pointed at an unreachable host)</code>
- <code>`curl -s -o /dev/null -w &#39;%{http_code}&#39; http://localhost:8123/api/auth/me` -&gt; 200 and `/api/overview` -&gt; 500 (drives the Overview error branch)</code>
- <code>`npx vite --config vite.config.evidence.mjs --port 5174` + `chrome-devtools-axi open http://localhost:5174/`, `snapshot`, `screenshot`</code>
- <code>`PYTHONPATH=. python -c &#34;import api.main&#34;` -&gt; ModuleNotFoundError vs `python -c &#34;from server.main import app&#34;` -&gt; FastAPI &#39;Portfolio API&#39;</code>
- <code>`npm run build` in web/ then `grep -o &#39;API not reachable. Start: uvicorn [a-z.:]*&#39; dist/assets/*.js`</code>
- <code>Temporarily reverted Overview.jsx:15 to `api.main:app` for the before screenshot, then `git checkout -- web/src/modules/portfolio/Overview.jsx` and confirmed `git status --porcelain` clean</code>

</details>

<details>
<summary>⚠️ **Document** - 1 info</summary>

- ℹ️ `PLAN.md:172` - Historical aidlc-docs artifacts and PLAN.md still name the pre-rename `api/main.py` (PLAN.md:172 roadmap row, aidlc-docs/inception/plans/execution-plan.md:8,20, aidlc-docs/construction/plans/networth-code-generation-plan.md:31, aidlc-docs/construction/networth/code/summary.md:12,41, aidlc-docs/audit.md). Left as-is: these are dated records of past runs, not operative instructions, and the branch already fixed every runnable command and current-state description (README layout table, auth-design, integration-test-instructions, networth run command). A follow-up could decide once whether aidlc-docs history is frozen or kept current; doing it here would be a broad unrelated rewrite.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
