### PR TITLE
feat: show dividends in SGD

### DIFF
--- a/DIVIDENDS.md
+++ b/DIVIDENDS.md
@@ -34,7 +34,23 @@ gaps:
 Units held at each ex-date are replayed from the CPF/SRS ledger; `gross = units × rate`.
 Totals: **CPF SGD 17,648**; **SRS SGD 8,620 + EUR 7,803**.
 
-## Totals (native currency, not FX-converted)
+## Display currency
+
+The `dividend` table stores the **native** amount the statement paid (`gross` + `currency`) —
+that never changes. Every read shape adds a `gross_sgd` converted at the latest FX rate
+(`portfolio.money.to_sgd`), and the UI leads with SGD everywhere, because the rest of the app
+(cost basis, market value, P/L, Net) is SGD and a native-currency dividend column made HKD
+199k read as SGD 199k. The native amount stays visible — muted underneath the SGD figure in the
+Dividends detail + security history, and as the row tooltip in Holdings — so any figure can
+still be reconciled against the statement. Per-unit rates (declared and implied) stay
+**native**: a declared rate is a statement fact, not a converted one.
+
+Latest FX is applied to all years (historical FX is not stored), so prior-year SGD figures are
+an approximation — the `SGD · latest FX` pill in the UI says so. A currency with no row in
+`fx_rate` is never passed through at 1:1: `/api/dividend-details` returns `gross_sgd: null` and
+flags the row `no FX rate for <CCY>`; the other endpoints raise (BR4, no silent fallback).
+
+## Totals (native currency, as paid)
 
 **By market**
 - **HK: HKD ~199,877** (the dividend engine — HK REITs/telcos: 01310 51k, 01523 49k, 00010 31k, 01038 22k, 00101 19k …)
@@ -53,6 +69,8 @@ Totals: **CPF SGD 17,648**; **SRS SGD 8,620 + EUR 7,803**.
 ## Per-dividend detail (qty held + declared rate)
 
 `GET /api/dividend-details` returns one row per payment with:
+- **gross** (native, as paid) and **gross_sgd** (latest FX; null + flagged when the currency has
+  no rate). `total_sgd` sums the converted amounts across all rows.
 - **declared rate** (`amount_per_unit`) — the per-share rate stated in the statement.
   Captured where the PDF prints it: CDP (`… <qty> units @ SGD <rate>`) and Moomoo
   (`… CASH DIVIDEND @ <CCY> <rate>` / US `<qty> SHARES DIVIDENDS`). Tiger / FSM / the
@@ -72,7 +90,9 @@ Totals: **CPF SGD 17,648**; **SRS SGD 8,620 + EUR 7,803**.
 
 - **Currency**: Tiger has no dividend-currency column → inferred from market (HK→HKD,
   SG→SGD, US→USD). The EUR REIT (SET/Cromwell→Stoneweg) Tiger payouts are therefore
-  labelled SGD; FSM's EUR ones are correct. Refine when prices/FX land.
+  labelled SGD; FSM's EUR ones are correct. Refine when prices/FX land. **Now that gross_sgd
+  converts off that label, those rows convert at 1:1 instead of the EUR rate — understated by
+  the EUR/SGD spread.** Fixing the inferred currency fixes the conversion for free.
 - **US withholding tax**: Tiger `Paid` amounts are taken as received (likely net of WHT);
   a separate `Withholding Tax` section exists to net gross vs net later.
 - **ADQU (Accordia Golf) SGD 28,264 on 2020-10-15** looks like a delisting/special capital

--- a/portfolio/dividends.py
+++ b/portfolio/dividends.py
@@ -11,7 +11,10 @@ return math; that difference is deliberate and stays there. This module is the p
 attribution view.)
 
 Every public function accepts an optional Session (`s`) and routes through db.session_scope.
-Amounts are native currency until annual(), which converts to SGD through portfolio.money.
+Every read shape carries **both** amounts: `gross` in the payment's native currency (what the
+statement said) and `gross_sgd` converted at latest FX through portfolio.money — the rest of
+the app reports SGD, so dividends must be comparable without mental FX. `annual()` is SGD-only
+(it sums across currencies, so a native figure would be meaningless).
 
 Run: PYTHONPATH=. .venv/bin/python -m pytest tests/test_dividends.py -q
 """
@@ -59,8 +62,11 @@ def implied_rate(gross, qty):
 # ---------------- read shapes (formerly the /api/dividend* handlers) ----------------
 
 def summary(s=None):
-    """Gross by market/currency, plus the 50 most recent payments — the /api/dividends view."""
+    """Gross by market/currency, plus the 50 most recent payments — the /api/dividends view.
+
+    Each row carries `gross` (native) and `gross_sgd` (latest FX)."""
     with session_scope(s) as s:
+        fx = fx_map(s)
         by = _rows(s,
             "SELECT s.market, d.currency, round(sum(d.gross)) gross, count(*) n "
             "FROM dividend d LEFT JOIN security s ON s.id=d.security_id "
@@ -71,14 +77,24 @@ def summary(s=None):
             "FROM dividend d JOIN account a ON a.id=d.account_id "
             "LEFT JOIN security s ON s.id=d.security_id "
             "WHERE d.pay_date IS NOT NULL ORDER BY d.pay_date DESC LIMIT 50")
+    for r in by + recent:
+        r["gross"] = _f(r["gross"])
+        r["gross_sgd"] = round(to_sgd(r["gross"] or 0, r["currency"], fx), 2)
+    by.sort(key=lambda r: -r["gross_sgd"])              # SGD-comparable ordering
     return {"by_market": by, "recent": recent}
 
 
 def details(s=None):
     """Per-dividend detail: declared per-share rate + units held at pay date (replayed from
     the ledger) + implied rate (gross/units). Flags rows where the rate can't be determined
-    (no position data, missing date, or unmapped ticker) for manual input."""
+    (no position data, missing date, or unmapped ticker) for manual input.
+
+    Gross is reported both native (`gross`) and in SGD (`gross_sgd`, latest FX). Rates stay
+    native — a declared per-unit rate is a statement fact, not a converted figure. A currency
+    with no FX rate becomes a flagged row (gross_sgd=None) rather than an endpoint-wide error,
+    so one unpriced currency can't blank the whole tab."""
     with session_scope(s) as s:
+        fx = fx_map(s)
         divs = _rows(s,
             "SELECT d.id, d.pay_date, a.id account_id, a.name account, a.funding_bucket bucket, "
             "d.security_id, COALESCE(sec.name, d.source_file) name, sec.canonical_ticker ticker, "
@@ -109,9 +125,15 @@ def details(s=None):
             flags.append("no date")
         if declared is None and implied is None:
             flags.append("qty unknown — needs manual input")
+        try:
+            gross_sgd = round(to_sgd(gross, d["currency"], fx), 2)
+        except ValueError:
+            gross_sgd = None
+            flags.append(f"no FX rate for {d['currency']}")
         out.append({
             "id": d["id"], "pay_date": d["pay_date"], "account": d["account"],
-            "name": d["name"], "ticker": d["ticker"], "gross": gross, "currency": d["currency"],
+            "name": d["name"], "ticker": d["ticker"], "gross": gross,
+            "gross_sgd": gross_sgd, "currency": d["currency"],
             "qty": qty, "qty_source": ("statement" if stated else ("ledger" if held else None)),
             "declared_rate": declared, "implied_rate": implied,
             "rate": declared if declared is not None else implied,
@@ -119,7 +141,8 @@ def details(s=None):
             "flags": flags,
         })
     out.sort(key=_date_key("pay_date"), reverse=True)
-    return {"rows": out, "flagged": sum(1 for r in out if r["flags"]), "total": len(out)}
+    return {"rows": out, "flagged": sum(1 for r in out if r["flags"]), "total": len(out),
+            "total_sgd": round(sum(r["gross_sgd"] or 0 for r in out), 2)}
 
 
 def annual(s=None):

--- a/server/main.py
+++ b/server/main.py
@@ -22,7 +22,8 @@ from starlette.concurrency import run_in_threadpool
 from portfolio.config import settings
 
 from server import auth
-from portfolio.db import SessionLocal
+from portfolio.db import SessionLocal, fx_map
+from portfolio.money import to_sgd
 from portfolio.performance import alloc_by_account, compute, empty_group, rollup
 from portfolio import spending
 from portfolio import dividends
@@ -252,6 +253,7 @@ def holding(ticker: str, bucket: str = "cash"):
         "JOIN account a ON a.id=d.account_id JOIN security sec ON sec.id=d.security_id "
         "WHERE sec.canonical_ticker=:tk AND a.name = ANY(:accts) ORDER BY d.pay_date",
         {"tk": ticker, "accts": accts})
+    fx = fx_map(s)
     s.close()
     if bucket == "cash":                               # CDP trades from cdp-stocks (priced)
         from portfolio.performance import cdp_transactions
@@ -264,6 +266,8 @@ def holding(ticker: str, bucket: str = "cash"):
     # enrich each dividend with qty held at pay date + declared rate per unit.
     # prefer statement-stated values; fall back to ledger replay / implied (gross/qty).
     # units_at / implied_rate are the shared pay_date attribution primitives (see dividends.py).
+    # gross_sgd mirrors the rest of the detail view (cost/MV/P/L are all SGD); the native
+    # gross + rate stay alongside it because they are what the statement actually said.
     for x in divs:
         units = _f(x["units"])
         if units is None:
@@ -275,6 +279,7 @@ def holding(ticker: str, bucket: str = "cash"):
             rate = dividends.implied_rate(x["gross"], units)
         x["units"] = units
         x["rate"] = rate
+        x["gross_sgd"] = round(to_sgd(_f(x["gross"]) or 0, x["currency"], fx), 2)
     # option trades on this underlying (wheel income), only for the cash bucket
     options = []
     if bucket == "cash":

--- a/tests/test_dividends.py
+++ b/tests/test_dividends.py
@@ -17,7 +17,7 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
 from portfolio import dividends
-from portfolio.models import Account, Base, Dividend, Security, Txn
+from portfolio.models import Account, Base, Dividend, FxRate, Security, Txn
 
 D = dt.date
 
@@ -65,13 +65,16 @@ class TestDetails(unittest.TestCase):
     def tearDown(self):
         self.s.close()
 
-    def _div(self, pay, gross, *, sec=1, declared=None, units=None):
+    def _div(self, pay, gross, *, sec=1, declared=None, units=None, ccy="SGD"):
         self._d += 1
         self.s.add(Dividend(account_id=1, security_id=sec, pay_date=pay, kind="cash",
                             gross=Decimal(str(gross)),
                             amount_per_unit=None if declared is None else Decimal(str(declared)),
                             units=None if units is None else Decimal(str(units)),
-                            currency="SGD", source_file="unmapped-src", dedup_hash=f"h{self._d}"))
+                            currency=ccy, source_file="unmapped-src", dedup_hash=f"h{self._d}"))
+
+    def _fx(self, ccy, rate):
+        self.s.add(FxRate(date=D(2024, 6, 1), currency=ccy, rate_to_sgd=Decimal(str(rate))))
 
     def _buy(self, day, qty):
         self._d += 1
@@ -110,6 +113,43 @@ class TestDetails(unittest.TestCase):
         self.assertIn("no date", r["flags"])
         self.assertIn("qty unknown — needs manual input", r["flags"])
         self.assertIsNone(r["rate"])
+
+    def test_foreign_gross_is_converted_to_sgd_alongside_the_native_amount(self):
+        # the rest of the app reports SGD; a native-only dividend column made HKD 1,000 look
+        # like SGD 1,000. Native stays for statement reconciliation.
+        self._fx("HKD", 0.17)
+        self._div(D(2024, 6, 1), 1000, declared=1, units=1000, ccy="HKD")
+        self.s.commit()
+        r = self._by_gross(dividends.details(self.s))[1000.0]
+        self.assertEqual(r["currency"], "HKD")
+        self.assertEqual(r["gross"], 1000.0)                  # untouched
+        self.assertEqual(r["gross_sgd"], 170.0)
+        self.assertEqual(r["rate"], 1.0)                      # declared rate stays native
+        self.assertEqual(r["flags"], [])
+
+    def test_sgd_needs_no_fx_row(self):
+        # SGD is intentionally absent from fx_rate — it must not be flagged as unpriced.
+        self._div(D(2024, 6, 1), 80, declared=1, units=80)
+        self.s.commit()
+        r = self._by_gross(dividends.details(self.s))[80.0]
+        self.assertEqual(r["gross_sgd"], 80.0)
+        self.assertEqual(r["flags"], [])
+
+    def test_currency_with_no_fx_rate_is_flagged_not_silently_passed_through(self):
+        self._div(D(2024, 6, 1), 500, declared=1, units=500, ccy="EUR")   # no EUR fx row
+        self.s.commit()
+        res = dividends.details(self.s)
+        r = self._by_gross(res)[500.0]
+        self.assertIsNone(r["gross_sgd"])                      # never 500 unconverted
+        self.assertIn("no FX rate for EUR", r["flags"])
+        self.assertEqual(res["total_sgd"], 0)                  # excluded, not counted at 1:1
+
+    def test_total_sgd_sums_the_converted_amounts(self):
+        self._fx("HKD", 0.17)
+        self._div(D(2024, 6, 1), 1000, declared=1, units=1000, ccy="HKD")  # 170
+        self._div(D(2024, 7, 1), 30, declared=1, units=30)                 # 30
+        self.s.commit()
+        self.assertEqual(dividends.details(self.s)["total_sgd"], 200.0)
 
     def test_rows_sorted_pay_date_desc_nulls_first(self):
         # newest-first (reverse=True) over _date_key, which sorts null dates last ascending ->

--- a/web/src/modules/portfolio/Dividends.jsx
+++ b/web/src/modules/portfolio/Dividends.jsx
@@ -10,10 +10,11 @@ export default function Dividends() {
   const [onlyFlagged, setOnlyFlagged] = useState(false);
   useEffect(() => {
     get("/api/dividends-annual").then(setAnn).catch(() => setAnn({ years: [], buckets: [], matrix: {}, totals: {} }));
-    get("/api/dividend-details").then(setDet).catch(() => setDet({ rows: [], flagged: 0, total: 0 }));
+    get("/api/dividend-details").then(setDet).catch(() => setDet({ rows: [], flagged: 0, total: 0, total_sgd: 0 }));
   }, []);
   if (!ann) return <div className="loading">Loading…</div>;
   const rows = det ? (onlyFlagged ? det.rows.filter((r) => r.flags.length) : det.rows) : [];
+  const shownSgd = rows.reduce((a, r) => a + (r.gross_sgd || 0), 0);
   const years = ann.years;                                   // newest → oldest
   // YoY % vs the next (older) year
   const yoy = (y, i) => {
@@ -75,7 +76,9 @@ export default function Dividends() {
 
       <div className="card">
         <h3>Dividend Detail — qty held &amp; declared rate&nbsp;
-          {det && <span className="pill">{det.total} payments</span>}
+          <span className="pill">SGD · latest FX</span>
+          {det && <span className="pill" style={{ marginLeft: 6 }}>{det.total} payments</span>}
+          {det && <span className="pill" style={{ marginLeft: 6 }}>{sgd(shownSgd)}</span>}
           {det && det.flagged > 0 &&
             <span className="pill" style={{ marginLeft: 6, color: "var(--neg)" }}>{det.flagged} need manual input</span>}
           <label style={{ marginLeft: 12, fontWeight: 400, fontSize: ".8em" }}>
@@ -87,7 +90,11 @@ export default function Dividends() {
           <table>
             <thead><tr>
               <th className="l">Date</th><th className="l">Security</th><th className="l">Acct</th>
-              <th>Qty held</th><th>Declared /unit</th><th>Implied /unit</th><th>Gross</th><th className="l">Status</th>
+              <th>Qty held</th>
+              <th title="per-unit rate as stated on the statement — native currency">Declared /u</th>
+              <th title="gross ÷ qty held — native currency">Implied /u</th>
+              <th title="converted at latest FX; native amount shown underneath">Gross SGD</th>
+              <th className="l">Status</th>
             </tr></thead>
             <tbody>
               {rows.map((r) => (
@@ -97,9 +104,13 @@ export default function Dividends() {
                   <td className="l mut">{r.account}</td>
                   <td>{r.qty == null ? "—" : fmt(r.qty, 0)}
                     {r.qty_source === "ledger" && <span className="mut" style={{ fontSize: ".75em" }}> (led)</span>}</td>
-                  <td className={r.declared_rate == null ? "mut" : "pos"}>{r.declared_rate == null ? "—" : fmt(r.declared_rate, 4)}</td>
-                  <td className="mut">{r.implied_rate == null ? "—" : fmt(r.implied_rate, 4)}</td>
-                  <td>{money(r.gross, r.currency, 2)}</td>
+                  <td className={r.declared_rate == null ? "mut" : "pos"}>{money(r.declared_rate, r.currency, 4)}</td>
+                  <td className="mut">{money(r.implied_rate, r.currency, 4)}</td>
+                  {/* native stacked under the SGD figure, not beside it — inline doubled the
+                      column width and pushed the table into a horizontal scroll */}
+                  <td>{money(r.gross_sgd, "SGD", 2)}
+                    {r.currency !== "SGD" &&
+                      <div className="mut" style={{ fontSize: ".75em" }}>{money(r.gross, r.currency, 2)}</div>}</td>
                   <td className="l">
                     {r.flags.length
                       ? <span className="pill" style={{ color: "var(--neg)" }}>{r.flags.join("; ")}</span>

--- a/web/src/modules/portfolio/Holdings.jsx
+++ b/web/src/modules/portfolio/Holdings.jsx
@@ -62,7 +62,10 @@ function DataRow({ r, onClick, max }) {
       <td>{closed ? <span className="mut">—</span> : sgd(r.mv_sgd)}</td>
       <td className={cls(pl)} title={closed ? "realised P/L" : "unrealised P/L"}>
         {pl == null ? <span className="mut">n/a</span> : sgd(pl)}</td>
-      <td className="pos">{r.income_native ? money(r.income_native, r.currency, 0) : "—"}</td>
+      {/* SGD like the Cost/MV/P/L columns it sits between (and like Net, which folds it in);
+          the native amount stays as the tooltip for statement reconciliation. */}
+      <td className="pos" title={r.income_native ? `${money(r.income_native, r.currency, 2)} native` : undefined}>
+        {r.income_sgd ? sgd(r.income_sgd) : "—"}</td>
       <td className={cls(r.options_pl_sgd)} title="realised options (wheel) P/L">
         {r.options_pl_sgd ? sgd(r.options_pl_sgd) : "—"}</td>
       <NetCell net={net} partial={partial} max={max} />
@@ -95,10 +98,11 @@ export default function Holdings() {
     const subtotal = (rs) => rs.reduce((a, r) => {
       a.mv += r.status === "closed" ? 0 : (r.mv_sgd || 0);
       a.pl += plOf(r) || 0;
+      a.inc += r.income_sgd || 0;
       a.opt += r.options_pl_sgd || 0;
       a.net += netOf(r).net;
       return a;
-    }, { mv: 0, pl: 0, opt: 0, net: 0 });
+    }, { mv: 0, pl: 0, inc: 0, opt: 0, net: 0 });
     return [...m.entries()]
       .map(([key, rs]) => ({ key, label: key, rows: rs, ...subtotal(rs) }))
       .sort((a, b) => b.mv - a.mv);
@@ -138,7 +142,9 @@ export default function Holdings() {
         <thead><tr>
           <th className="l">Security</th><th className="l">Bucket</th><th className="l">Mkt</th>
           <th>Units</th><th>Avg Cost</th><th>Price</th>
-          <th>Cost (SGD)</th><th>MV (SGD)</th><th>P/L</th><th>Dividends</th><th>Options P/L</th>
+          <th>Cost (SGD)</th><th>MV (SGD)</th><th>P/L</th>
+          <th title="converted at latest FX; hover a row for the native amount">Dividends (SGD)</th>
+          <th>Options P/L</th>
           <th title="total P/L incl dividends + option premiums">Net</th><th>XIRR</th>
         </tr></thead>
         <tbody>
@@ -155,7 +161,7 @@ export default function Holdings() {
                     </td>
                     <td>{sgd(g.mv)}</td>
                     <td className={cls(g.pl)}>{sgd(g.pl)}</td>
-                    <td></td>
+                    <td className="pos">{g.inc ? sgd(g.inc) : ""}</td>
                     <td className={cls(g.opt)}>{g.opt ? sgd(g.opt) : ""}</td>
                     <td className={cls(g.net)} style={{ fontWeight: 700 }}>{sgd(g.net)}</td>
                     <td></td>

--- a/web/src/modules/portfolio/SecurityDetail.jsx
+++ b/web/src/modules/portfolio/SecurityDetail.jsx
@@ -12,7 +12,9 @@ export default function SecurityDetail({ ticker, bucket, onBack }) {
   if (!d) return <div className="loading">Loading {ticker}…</div>;
   if (d.error || !d.summary) return <div className="loading">No data for {ticker}. <a onClick={onBack} style={{ cursor: "pointer", color: "var(--acc)" }}>← back</a></div>;
   const s = d.summary;
-  const divTotal = d.dividends.reduce((a, x) => a + Number(x.gross || 0), 0);
+  // SGD, like every other tile — a native sum would be wrong anyway for a security paid in
+  // more than one currency (e.g. an EUR REIT with SGD-settled lots).
+  const divTotalSgd = d.dividends.reduce((a, x) => a + Number(x.gross_sgd || 0), 0);
   const opts = d.options || [];
   const optPlSgd = opts.reduce((a, t) => a + (t.close_date ? Number(t.realized_sgd || 0) : 0), 0);
 
@@ -35,7 +37,7 @@ export default function SecurityDetail({ ticker, bucket, onBack }) {
         <Tile lbl="Cost Basis" val={s.cost_basis_sgd == null ? "n/a" : sgd(s.cost_basis_sgd)} />
         <Tile lbl="Market Value" val={sgd(s.mv_sgd)} />
         <Tile lbl="Unrealised P/L" val={s.unrealised_pl_sgd == null ? "n/a" : sgd(s.unrealised_pl_sgd)} cls={cls(s.unrealised_pl_sgd)} />
-        <Tile lbl="Dividends" val={money(divTotal, d.dividends[0]?.currency || s.currency, 0)} cls="pos" />
+        <Tile lbl="Dividends" val={sgd(divTotalSgd)} cls="pos" />
         {opts.length > 0 && <Tile lbl="Options P/L" val={sgd(optPlSgd)} cls={cls(optPlSgd)} />}
         <Tile lbl="XIRR" val={s.xirr == null ? "—" : pct(s.xirr)} cls={cls(s.xirr)} />
       </div>
@@ -65,12 +67,15 @@ export default function SecurityDetail({ ticker, bucket, onBack }) {
       </div>
 
       <div className="card">
-        <h3>Dividend history ({d.dividends.length})</h3>
+        <h3>Dividend history ({d.dividends.length})
+          <span className="pill" style={{ marginLeft: 8 }}>{sgd(divTotalSgd)} · latest FX</span></h3>
         {d.dividends.length === 0 ? <p className="mut">No dividends recorded.</p> : (
           <table>
             <thead><tr>
               <th className="l">Date</th><th className="l">Account</th><th className="l">Kind</th>
-              <th>Qty held</th><th>Rate/unit</th><th>Amount</th>
+              <th>Qty held</th>
+              <th title="per-unit rate as stated on the statement — native currency">Rate/unit</th>
+              <th title="converted at latest FX; native amount shown underneath">Amount (SGD)</th>
             </tr></thead>
             <tbody>
               {d.dividends.map((x, i) => (
@@ -80,7 +85,9 @@ export default function SecurityDetail({ ticker, bucket, onBack }) {
                   <td className="l">{x.kind}</td>
                   <td className="mut">{x.units == null ? "—" : fmt(x.units, 2)}</td>
                   <td className="mut">{money(x.rate, x.currency, 4)}</td>
-                  <td className="pos">{money(x.gross, x.currency, 2)}</td>
+                  <td className="pos">{money(x.gross_sgd, "SGD", 2)}
+                    {x.currency !== "SGD" &&
+                      <div className="mut" style={{ fontSize: ".75em" }}>{money(x.gross, x.currency, 2)}</div>}</td>
                 </tr>
               ))}
             </tbody>


### PR DESCRIPTION
Dividends were the only figures the app reported in native currency. HKD 208k sat in the same
Holdings column as SGD market value and read as SGD 208k; the security-detail Dividends tile
summed gross across currencies and labelled the total with the first row's currency.

Everything now leads with SGD. The native amount stays visible so any figure can still be
reconciled against the statement.

## API

`gross_sgd` (latest FX) alongside the untouched native `gross` on every dividend read shape —
`summary()`, `details()`, and the per-holding history in `/api/holding`. `details()` also
returns `total_sgd`.

Per-unit rates stay **native**: a declared rate is a statement fact, not a converted figure.

A currency with no `fx_rate` row is never passed through at 1:1 — `details()` returns
`gross_sgd: null` and flags the row `no FX rate for <CCY>` (one unpriced currency can't blank
the whole tab); the other callers keep the loud `to_sgd` failure per BR4.

## Web

- **Holdings** — the Dividends column was `income_native`, wedged between MV (SGD) and P/L and
  sitting next to Net, which already folds the SGD figure in. Now `income_sgd`, native as the
  row tooltip. The group subtotal row fills that cell instead of leaving it blank.
- **Dividends tab / security history** — SGD gross with the native amount stacked muted
  underneath (inline doubled the column width and forced a horizontal scroll). Rates keep their
  currency symbol, so `HK$0.2851` can't be read as SGD. Card headers gain the `SGD · latest FX`
  pill and a running SGD total.
- **Security detail** — the Dividends tile sums `gross_sgd`.

## Verification

258 tests pass; 4 new cover the conversion, SGD-without-an-fx-row, the unpriced-currency flag,
and `total_sgd`.

Checked live against the real DB: `details.total_sgd` 199,920.85 reconciles with the annual
matrix (199,920.79) and the by-market SGD sums; HKD 208,007 → S$34,217. Dividends, Holdings and
the HKBN detail page were screenshotted — HKBN reads S$8,404 in all three.

## Worth knowing

- Prior years convert at **today's** FX (historical FX isn't stored). The existing
  `SGD · latest FX` pill now applies to more of the page.
- The known Tiger currency-inference gap now has a numeric consequence: the EUR REIT payouts
  labelled SGD convert at 1:1 instead of the EUR rate, so they're understated by the spread.
  Documented in DIVIDENDS.md — fixing the inferred currency fixes the conversion for free.
