### PR TITLE
Responsive foundations: svh, safe areas, and the phone media block

### DIFF
--- a/.wayfinder/tickets/010-mobile-viewport-safe-area-research.md
+++ b/.wayfinder/tickets/010-mobile-viewport-safe-area-research.md
@@ -84,3 +84,20 @@ auth.jsx:50,125   minHeight       "100vh"  →  "100svh"
 **Constraint handed downstream.** [The phone navigation shell](012-phone-navigation-shell.md) is no
 longer free to choose `position: fixed` for bottom-anchored chrome — finding 4 rules it out on
 grounds that have nothing to do with taste.
+
+### Corrected in the build
+
+**The `height: 100vh; height: 100svh;` fallback pair was not built.** Finding 1 prescribes it for
+`styles.css:8`; the foundations slice ships `height: 100svh` alone, on the acceptance criterion "no
+`100vh` remains in the shell or on sign-in" — and `inventory.spec.js` now asserts that as a source
+grep, so the pair cannot come back without amending the gate. The grounds are
+[016](016-sign-in-on-phone.md)'s own, applied one file wider than it applied them: `svh` is Safari
+15.4 / Chrome 108 / Firefox 101, universally available since 2022. The residual risk that finding 1
+was guarding — a browser with no `svh` collapsing `.app`'s height — is real and accepted rather than
+denied; it is the one place the shell is less defended than the ticket asked for.
+
+**The phone gutter guards all four sides, `top` included** (`max(14px, env(safe-area-inset-top))`),
+where finding 2 says the insets that matter "are **`bottom`** and **`left`/`right` in landscape** —
+*not* `top`". Both are right at their own moment: with no app bar yet, `.main` *is* the top of the
+viewport. The finding becomes true again the moment the shell lands, and that is written down as a
+trap in [`RESPONSIVE.md`](../../RESPONSIVE.md) rather than left for a reader to rediscover.

--- a/.wayfinder/tickets/016-sign-in-on-phone.md
+++ b/.wayfinder/tickets/016-sign-in-on-phone.md
@@ -138,3 +138,12 @@ Observations, not gates — neither can change the diff above:
   is moot; if it is 40px the carve-out is load-bearing and should stay written down.
 - **Confirm no seam under `viewport-fit=cover`** — that `#0f1115` paints under the home bar and no `--bg`
   strip appears at the bottom in either orientation.
+
+### Corrected in the build
+
+Note 1 above calls the missing inline fallback "the one capability a stylesheet has that inline
+genuinely lacks". The build removed the asymmetry by declining the fallback in the stylesheet too —
+see [010](010-mobile-viewport-safe-area-research.md)'s *Corrected in the build*. The reasoning is this
+ticket's, unchanged; only its reach grew. Nothing else here moved: the diff was the two characters on
+two lines it said it was, and the screen still contributes no rule to the phone block, which
+`foundations.spec.js` now asserts structurally by counting the classes it renders — zero.

--- a/RESPONSIVE.md
+++ b/RESPONSIVE.md
@@ -61,15 +61,17 @@ Applied to all 12 tab views, SecurityDetail, and sign-in. Must pass.
    hold everywhere, there is no type floor).
 6. Nothing is `position: fixed`.
 7. Safe areas: in landscape, content **and the app bar** clear the notch; the dark background paints
-   under the home bar with no seam. *(This one stays here whatever lands. `viewport-fit=cover` and
-   the gutter's four `max(<literal>, env(...))` sides are asserted by `foundations.spec.js` — but
-   only as **declarations**, because desktop Chrome reports every inset as 0. Whether the notch is
-   actually cleared is an iPhone check and always will be.)*
+   under the home bar with no seam. *(Stays here whatever lands — it is one of the four iPhone items.
+   `foundations.spec.js` asserts `viewport-fit=cover` and that `.main`'s four phone sides are written
+   as `max(<literal>, env(...))`, which is a claim about the **declaration** only. Note what that
+   leaves uncovered: the phone block does not apply in landscape at all — a rotated phone is 844px
+   wide — so nothing yet guards content or the app bar there. That guard belongs to the tablet tier
+   and the shell.)*
 8. The shell fills the screen with nothing unreachable below it: the bottom of a scrolled list is
-   scrollable to, and sign-in does not rubber-band. *(Landed — `100svh` in the shell and on sign-in,
-   asserted by `foundations.spec.js` at all ten viewports, plus a source gate in `inventory.spec.js`
-   that no `100vh` survives under `web/src`. Emulation has no retractable toolbar, so this is the
-   declaration rather than the symptom; a real iPhone is still what proves the strip is gone.)*
+   scrollable to, and sign-in does not rubber-band. *(`100svh` has landed in the shell and on sign-in
+   — asserted as a declaration by `foundations.spec.js`, plus a source gate in `inventory.spec.js`
+   that no `100vh` survives under `web/src`. The **symptom** stays an iPhone check: emulation has no
+   retractable toolbar, so it cannot see the strip either way.)*
 
 ## The two editors
 
@@ -147,9 +149,14 @@ Things the build session must be told, not left to discover.
 - `.grid2`'s `minmax(420px, 1fr)` is **~100px optimistic against real data** — `Overview:33`'s card needs
   **519px** with the live DB's longest subcategory name. `auto-fit` still behaves; the column just spills
   inside itself between 1024 and ~1256.
-- **`640` is a literal in two places**: `styles.css` and the `matchMedia` hook. No single source of
-  truth without a build step. Cross-reference both sides in a comment.
+- **`640` is a literal in three places**: `styles.css`'s `max-width: 639.98px`, `tests/viewports.js`'s
+  `PHONE_TIER_BELOW` / `PHONE_TIER_MEDIA`, and — once the charts land — the `matchMedia` hook. No
+  single source of truth without a build step. Every site cross-references the others in a comment.
 - In `.main`, the padding **longhands must follow the shorthand** — the shorthand resets all four sides.
+- **`.main`'s phone `padding-top` guards `env(safe-area-inset-top)` and must stop once the app bar
+  lands.** Today `.main` is the top of the viewport, so the guard is what clears the notch. With a bar
+  above it the bar clears the notch instead, and `env()` is viewport-relative rather than
+  parent-relative, so the same rule would double-pad.
 - Sticky + pinned cells require `border-collapse: separate; border-spacing: 0`; under `collapse` they
   lose their borders.
 - `display: none` starves `ResponsiveContainer` to 0×0 — drop chart *chrome* via `matchMedia`, never the

--- a/RESPONSIVE.md
+++ b/RESPONSIVE.md
@@ -61,7 +61,15 @@ Applied to all 12 tab views, SecurityDetail, and sign-in. Must pass.
    hold everywhere, there is no type floor).
 6. Nothing is `position: fixed`.
 7. Safe areas: in landscape, content **and the app bar** clear the notch; the dark background paints
-   under the home bar with no seam.
+   under the home bar with no seam. *(This one stays here whatever lands. `viewport-fit=cover` and
+   the gutter's four `max(<literal>, env(...))` sides are asserted by `foundations.spec.js` — but
+   only as **declarations**, because desktop Chrome reports every inset as 0. Whether the notch is
+   actually cleared is an iPhone check and always will be.)*
+8. The shell fills the screen with nothing unreachable below it: the bottom of a scrolled list is
+   scrollable to, and sign-in does not rubber-band. *(Landed — `100svh` in the shell and on sign-in,
+   asserted by `foundations.spec.js` at all ten viewports, plus a source gate in `inventory.spec.js`
+   that no `100vh` survives under `web/src`. Emulation has no retractable toolbar, so this is the
+   declaration rather than the symptom; a real iPhone is still what proves the strip is gone.)*
 
 ## The two editors
 
@@ -87,13 +95,13 @@ criteria **instead of** the universal list — reading comfort, row density and 
 | Portfolio › Options | contract ledger **A** — pinned Underlying; it already has an `overflow-x: auto` wrapper at `:70`, so this keeps behaviour rather than replacing it. By-ticker and by-type unchanged (273/261px, they genuinely fit); monthly P/L halved to 6 bars with a reserved band so negative labels clear the ticks. *(The merged `Contract` cell has landed — asserted; the pin has not.)* |
 | Portfolio › Transactions | pattern **B** cards |
 | Portfolio › SecurityDetail | txn history **B**; dividend history **B**; options history **A**, pinning the merged two-line `Contract` cell. Three tables, two patterns, deliberately. `← Holdings` is a ≥44px target and is the **only** way back — there is no router. *(The merged cell itself has landed at every width — asserted; only the pin is left.)* |
-| Net Worth | editor floor; line chart has a **DOM key, not `<Legend>`**; Breakdown and History wrapped in `overflow-x: auto`; `100svh` |
+| Net Worth | editor floor; line chart has a **DOM key, not `<Legend>`**; Breakdown and History wrapped in `overflow-x: auto`; ~~`100svh`~~ *(the shell's, landed and asserted)* |
 | Spending › Overview | donut gone below 640, list is the chart; Top Line Items pattern **B** (471px — A's pin would be the 232px Line item, 70% of the viewport). Both halves of the `.grid2` end up as ranked lists |
 | Spending › By Category | donut gone below 640; Categories pattern **A** with the name column pinned — it keeps its own `▸`/`▾` and does **not** get the persistent `›`; drilled transactions render as **B** cards **below the table**, not as a nested row, headed by subcategory + count + aggregate |
 | Spending › Classify | editor floor; `.fillpane` neutralised so the page scrolls as one; **⇅ Reorder hidden on phone**; `RuleModal` uses `svh`. *(The `textarea`'s styling has landed — asserted.)* |
 | Spending › Recurring | monitor **A** *(open call)* and candidates **A**; three `.link-btn`s at 44px square; **two nested scroll regions** — the feel check |
 | Spending › Transactions | pattern **B** cards |
-| Sign-in | `100vh` → `100svh` at `auth.jsx:50` and `:125`; GSI button **carved out** of the 44px floor; no `env()` padding anywhere |
+| Sign-in | ~~`100vh` → `100svh` at `auth.jsx:50` and `:125`~~ **landed** — asserted, along with the box filling the screen, optical centring and the absence of any phone rule. GSI button **carved out** of the 44px floor; no `env()` padding anywhere. What is left here is eyes-only: whether the carved-out button looks right beside a 44px world |
 
 ## Observations
 

--- a/web/TESTING.md
+++ b/web/TESTING.md
@@ -27,8 +27,18 @@ only on the views that carry them: the refresh control's size, `.grid2`'s collap
 tab strip, the editors' 24px floor, the rule textarea's styling, the S2 list rows, and the merged
 options identity cell. Each one moved **out of** `RESPONSIVE.md` when it moved in here.
 
+`tests/foundations.spec.js` — the mechanism every phone rule sits in: the shell's `100svh`, the
+`viewport-fit=cover` opt-in, the `max(<literal>, env(...))` content gutter inside the one
+`@media (max-width: 639.98px)` block, the `--tap` token, and sign-in's box. It is the one file
+that asserts **declarations** as well as geometry, and its header says why: desktop Chrome
+reports every `env(safe-area-inset-*)` as 0 and has no retractable toolbar, so computed style
+cannot tell `max(14px, env(...))` from a bare `14px`, or `svh` from `vh`. Reading the shipped
+CSSOM can. It is also the only spec that renders the app **signed out** — `loadSignIn` in
+`tests/support/app.js` answers the session endpoint 401.
+
 `tests/inventory.spec.js` — the checks that read files rather than pixels: the table count, the
-single donut implementation, the viewport list against `RESPONSIVE.md`, and the fixtures' own
+single donut implementation, that no `100vh` survives under `web/src`, the viewport meta's
+`viewport-fit=cover`, the viewport list against `RESPONSIVE.md`, and the fixtures' own
 integrity.
 
 `tests/viewports.js` — the ten viewports, declared once. They mirror `RESPONSIVE.md`'s table

--- a/web/TESTING.md
+++ b/web/TESTING.md
@@ -30,11 +30,10 @@ options identity cell. Each one moved **out of** `RESPONSIVE.md` when it moved i
 `tests/foundations.spec.js` — the mechanism every phone rule sits in: the shell's `100svh`, the
 `viewport-fit=cover` opt-in, the `max(<literal>, env(...))` content gutter inside the one
 `@media (max-width: 639.98px)` block, the `--tap` token, and sign-in's box. It is the one file
-that asserts **declarations** as well as geometry, and its header says why: desktop Chrome
-reports every `env(safe-area-inset-*)` as 0 and has no retractable toolbar, so computed style
-cannot tell `max(14px, env(...))` from a bare `14px`, or `svh` from `vh`. Reading the shipped
-CSSOM can. It is also the only spec that renders the app **signed out** — `loadSignIn` in
-`tests/support/app.js` answers the session endpoint 401.
+that asserts **declarations** as well as geometry, because the things it gates are on
+`baseline.spec.js`'s "cannot check, ever" list and leave nothing measurable behind. It is also
+the only spec that renders the app **signed out** — `loadSignIn` in `tests/support/app.js`
+answers the session endpoint 401.
 
 `tests/inventory.spec.js` — the checks that read files rather than pixels: the table count, the
 single donut implementation, that no `100vh` survives under `web/src`, the viewport meta's

--- a/web/index.html
+++ b/web/index.html
@@ -2,7 +2,13 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <!-- `viewport-fit=cover` is what makes every `env(safe-area-inset-*)` in styles.css
+         resolve to something other than 0 — without it the safe-area CSS is dead code
+         rather than merely inactive. It also opts out of Chrome 135+ Android's dynamic
+         "chin", which resizes the viewport during scroll: a moving target under a shell
+         sized in `svh`. No `maximum-scale` / `user-scalable=no`: they do suppress iOS's
+         focus-zoom, and they fail WCAG 1.4.4. -->
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <title>Portfolio</title>
   </head>
   <body>

--- a/web/playwright.config.js
+++ b/web/playwright.config.js
@@ -39,7 +39,7 @@ export default defineConfig({
     { name: "inventory", testMatch: /inventory\.spec\.js/ },
     ...VIEWPORTS.map((v) => ({
       name: v.name,
-      testMatch: /(baseline|unconditional)\.spec\.js/,
+      testMatch: /(baseline|unconditional|foundations)\.spec\.js/,
       use: {
         ...devices["Desktop Chrome"],
         viewport: { width: v.width, height: v.height },

--- a/web/src/auth.jsx
+++ b/web/src/auth.jsx
@@ -47,7 +47,15 @@ function LoginScreen({ onCredential, error }) {
   }, [onCredential]);
 
   return (
-    <div style={{ minHeight: "100vh", display: "grid", placeItems: "center", background: "#0f1115" }}>
+    // `100svh`, for a different reason than the shell's. `min-height: 100vh` does not create
+    // the shell's unreachable strip — it creates a *scrollable* one: `100vh` ≡ `100lvh`, so
+    // the box is ~844px inside a ~780px visible area, the page rubber-bands with nothing to
+    // scroll, and the "centred" content sits ~32px below optical centre. React style objects
+    // have unique keys, so the `100vh`-then-`100svh` fallback pair has no inline equivalent —
+    // accepted: without `svh` this falls back to `auto` and the div collapses to content
+    // height, uncovering body's `--bg` `#0f1419` behind the div's `#0f1115`. Four units in
+    // one channel. The colour drift this screen deliberately keeps is what makes that benign.
+    <div style={{ minHeight: "100svh", display: "grid", placeItems: "center", background: "#0f1115" }}>
       <div style={{ textAlign: "center", color: "#e6e6e6", fontFamily: "system-ui, sans-serif" }}>
         <div style={{ fontSize: 40, marginBottom: 8 }}>📊</div>
         <h1 style={{ fontSize: 20, fontWeight: 600, margin: "0 0 4px" }}>Portfolio</h1>
@@ -122,7 +130,8 @@ export default function AuthGate({ children }) {
   }
 
   if (state === "loading") {
-    return <div style={{ minHeight: "100vh", background: "#0f1115" }} />;
+    // Same `svh` fix as `LoginScreen`: this is the same screen with nothing painted on it yet.
+    return <div style={{ minHeight: "100svh", background: "#0f1115" }} />;
   }
   if (state === "out") {
     return <LoginScreen onCredential={onCredential} error={error} />;

--- a/web/src/auth.jsx
+++ b/web/src/auth.jsx
@@ -47,14 +47,11 @@ function LoginScreen({ onCredential, error }) {
   }, [onCredential]);
 
   return (
-    // `100svh`, for a different reason than the shell's. `min-height: 100vh` does not create
-    // the shell's unreachable strip — it creates a *scrollable* one: `100vh` ≡ `100lvh`, so
-    // the box is ~844px inside a ~780px visible area, the page rubber-bands with nothing to
-    // scroll, and the "centred" content sits ~32px below optical centre. React style objects
-    // have unique keys, so the `100vh`-then-`100svh` fallback pair has no inline equivalent —
-    // accepted: without `svh` this falls back to `auto` and the div collapses to content
-    // height, uncovering body's `--bg` `#0f1419` behind the div's `#0f1115`. Four units in
-    // one channel. The colour drift this screen deliberately keeps is what makes that benign.
+    // `100svh` for a different reason than the shell's: `min-height: 100vh` leaves a
+    // *scrollable* strip rather than an unreachable one, so the page rubber-bands with
+    // nothing to scroll and the "centred" content sits ~32px low. No fallback pair — React
+    // style keys are unique — and without `svh` this collapses to content height, uncovering
+    // body's `#0f1419` behind the div's `#0f1115`. The colour drift makes the failure benign.
     <div style={{ minHeight: "100svh", display: "grid", placeItems: "center", background: "#0f1115" }}>
       <div style={{ textAlign: "center", color: "#e6e6e6", fontFamily: "system-ui, sans-serif" }}>
         <div style={{ fontSize: 40, marginBottom: 8 }}>📊</div>

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -136,9 +136,9 @@ input, select, textarea { background: var(--panel2); border: 1px solid var(--lin
    `639.98px` rather than `639px` so no fractional viewport width lands in a 1px dead zone
    against the tablet tier's `min-width: 640px`.
 
-   640 is a literal here, and will be a literal again in the chart hook's `matchMedia`: JS
-   cannot read a custom property and this repo takes no build step to make one. The two
-   sides cross-reference in comments instead — there is no single source of truth to have. */
+   640 is a literal in three places: here, `tests/viewports.js`, and — once the charts land —
+   the `matchMedia` hook. JS cannot read a custom property and this repo takes no build step
+   to make one, so the sides cross-reference in comments instead of sharing a constant. */
 @media (max-width: 639.98px) {
   /* The content gutter, and the app's first safe-area handling.
 
@@ -150,28 +150,29 @@ input, select, textarea { background: var(--panel2); border: 1px solid var(--lin
 
      The longhands MUST follow the shorthand — the shorthand resets all four sides.
 
-     Bottom is 20px rather than 14px because under `100svh` this pane's bottom edge *is*
-     the screen's, so the last row of a scrolled list would otherwise sit under the home
-     indicator. That gives it the same `max(<literal>, env())` shape as left and right —
-     one idiom, pad rather than offset, on every side that has an inset to guard. The top
-     is the one that has none: the top inset belongs to the top of the viewport, which is
-     the app bar's edge rather than this pane's, so guarding it here would double-pad under
-     a bar that already clears the notch.
-     Each `max()` resolves to its literal wherever there is no inset — including in the
-     test suite, since desktop Chrome reports every inset as 0 in both orientations, which
-     is why nothing automated can tell you whether content clears a real notch. */
+     One `max(<literal>, env())` idiom on all four: pad, never offset. Bottom is 20px
+     rather than 14px because under `100svh` this pane's bottom edge *is* the screen's, so
+     the last row of a scrolled list would otherwise sit under the home indicator.
+
+     TRAP for the phone shell: today `.main` is the top of the viewport, so guarding the
+     top inset here is what clears the notch. Once the app bar lands above it, the bar
+     clears the notch instead and `env(safe-area-inset-top)` — which is viewport-relative,
+     not parent-relative — keeps returning the full inset here, which would double-pad.
+     That rule belongs to whoever adds the bar, not to a later reader guessing. */
   .main {
     padding: 14px;
+    padding-top: max(14px, env(safe-area-inset-top));
     padding-left: max(14px, env(safe-area-inset-left));
     padding-right: max(14px, env(safe-area-inset-right));
     padding-bottom: max(20px, env(safe-area-inset-bottom));
   }
 
-  /* `--tap`'s first call site. `.navitem` is ~38px tall from its `padding: 9px 18px`, and
-     it is the only navigation a phone has; the drawer that lands next holds these items
-     verbatim, so the rule survives the shell rather than being replaced by it. Height
-     only — a nav item is already a full-width row, so the square half of the floor has
-     nothing to do here. The flex is what centres the label inside the box `min-height`
-     grew, the same shape `.nw-del` uses above. */
-  .navitem { min-height: var(--tap); display: flex; align-items: center; }
+  /* `--tap`'s call site, and the reason it is a token rather than a literal. `.navitem` is
+     ~38px tall from its `padding: 9px 18px`, and it is the only navigation a phone has;
+     the drawer that lands next holds these items verbatim, so the rule survives the shell
+     rather than being replaced by it. Square rather than height-only, which on a full-width
+     row is a no-op today and the rule as it was decided: the shape exists for bare glyph
+     buttons sitting adjacent, and one selector writing it differently is how a floor stops
+     being one. The flex centres the label in the box `min-height` grew — `.nw-del`'s shape. */
+  .navitem { min-height: var(--tap); min-width: var(--tap); display: flex; align-items: center; }
 }

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1,11 +1,27 @@
 :root {
   --bg: #0f1419; --panel: #161b22; --panel2: #1c232c; --line: #2b333d;
   --txt: #d7dde4; --mut: #8b97a5; --pos: #2ea043; --neg: #f85149; --acc: #388bfd;
+  /* The one number that earns a token in a block that otherwise holds only colours: the
+     phone tap floor. It recurs across unrelated selectors as the phone tier lands, which
+     is the whole test — every other phone value is written as a literal in the media
+     block at the foot of this file. 44 is Apple's HIG rather than Material's 48: every
+     viewport finding behind this spec is WebKit-shaped, and 48 costs a row of density in
+     tables that already overflow. */
+  --tap: 44px;
 }
 * { box-sizing: border-box; }
 body { margin: 0; background: var(--bg); color: var(--txt);
   font: 14px/1.5 ui-sans-serif, system-ui, -apple-system, sans-serif; }
-.app { display: flex; height: 100vh; }
+/* `100svh` — not `vh`, and not `dvh`. This shell owns its own scroll (`.main`'s `overflow:
+   auto` below, plus the `.fillpane`/`.grow`/`.scroll` machinery), so the document never
+   scrolls, so a mobile toolbar never retracts. `100vh` is spec-defined to equal `100lvh` —
+   the height *as if* the toolbar had retracted — which in a shell that cannot retract it
+   makes the overflowing strip permanently **unreachable** rather than merely cosmetic.
+   `svh` over `dvh` because in a non-scrolling shell the two are identical and `svh` cannot
+   reflow mid-interaction. No `height: 100vh` fallback pair: `svh` is Safari 15.4 /
+   Chrome 108 / Firefox 101, universally available since 2022, and a fallback would leave
+   behind the literal this rule exists to remove. */
+.app { display: flex; height: 100svh; }
 .side { width: 200px; flex: none; border-right: 1px solid var(--line); padding: 16px 0; background: var(--panel); }
 .brand { font-weight: 700; padding: 4px 18px 16px; font-size: 16px; }
 .navitem { padding: 9px 18px; cursor: pointer; color: var(--mut); font-weight: 600; }
@@ -108,3 +124,54 @@ input, select, textarea { background: var(--panel2); border: 1px solid var(--lin
 .side-email { font-size: 11px; color: var(--mut); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; margin-bottom: 6px; }
 .logout-btn { font-size: 12px; font-weight: 600; color: var(--mut); background: none; border: 1px solid var(--line); border-radius: 6px; padding: 4px 10px; cursor: pointer; }
 .logout-btn:hover { color: var(--txt); border-color: var(--mut); }
+
+/* ─── the phone tier ────────────────────────────────────────────────────────────────────
+   One block, literal values, no token layer. Most of what a phone changes cannot be
+   expressed as a token override at all — the shell flips to a column, charts lose chrome,
+   tables get restructured — so a token layer on top would split the phone story across two
+   mechanisms and hide the delta: `padding: var(--cell-y)` tells you nothing about 639px
+   without hunting elsewhere. `--tap` is the single exception, being the one number that
+   recurs across genuinely unrelated selectors.
+
+   `639.98px` rather than `639px` so no fractional viewport width lands in a 1px dead zone
+   against the tablet tier's `min-width: 640px`.
+
+   640 is a literal here, and will be a literal again in the chart hook's `matchMedia`: JS
+   cannot read a custom property and this repo takes no build step to make one. The two
+   sides cross-reference in comments instead — there is no single source of truth to have. */
+@media (max-width: 639.98px) {
+  /* The content gutter, and the app's first safe-area handling.
+
+     14px is ratified rather than tuned: measured at a true 390px frame, nothing in the
+     spec has a threshold anywhere between 8px and 16px — Holdings shows the same three
+     columns throughout — and the first one is at 20px. `.card` keeps its own 16px, so
+     card content does sit 30px from the screen edge; dropping the card to 12 buys 10px
+     that nothing needs.
+
+     The longhands MUST follow the shorthand — the shorthand resets all four sides.
+
+     Bottom is 20px rather than 14px because under `100svh` this pane's bottom edge *is*
+     the screen's, so the last row of a scrolled list would otherwise sit under the home
+     indicator. That gives it the same `max(<literal>, env())` shape as left and right —
+     one idiom, pad rather than offset, on every side that has an inset to guard. The top
+     is the one that has none: the top inset belongs to the top of the viewport, which is
+     the app bar's edge rather than this pane's, so guarding it here would double-pad under
+     a bar that already clears the notch.
+     Each `max()` resolves to its literal wherever there is no inset — including in the
+     test suite, since desktop Chrome reports every inset as 0 in both orientations, which
+     is why nothing automated can tell you whether content clears a real notch. */
+  .main {
+    padding: 14px;
+    padding-left: max(14px, env(safe-area-inset-left));
+    padding-right: max(14px, env(safe-area-inset-right));
+    padding-bottom: max(20px, env(safe-area-inset-bottom));
+  }
+
+  /* `--tap`'s first call site. `.navitem` is ~38px tall from its `padding: 9px 18px`, and
+     it is the only navigation a phone has; the drawer that lands next holds these items
+     verbatim, so the rule survives the shell rather than being replaced by it. Height
+     only — a nav item is already a full-width row, so the square half of the floor has
+     nothing to do here. The flex is what centres the label inside the box `min-height`
+     grew, the same shape `.nw-del` uses above. */
+  .navitem { min-height: var(--tap); display: flex; align-items: center; }
+}

--- a/web/tests/foundations.spec.js
+++ b/web/tests/foundations.spec.js
@@ -1,0 +1,248 @@
+/**
+ * The responsive foundations: the shell's height unit, the safe-area opt-in, the phone
+ * media block, and the one token.
+ *
+ * These are the mechanism every later phone rule sits in rather than a behaviour anyone
+ * can see, so they are asserted here as *declarations* as much as as geometry. That is
+ * deliberate and it is the exception in this suite: `baseline` and `unconditional` measure
+ * boxes because a box is what those decisions produce, whereas "the gutter uses one
+ * `max(<literal>, env())` idiom on all four sides" has **no measurable consequence in
+ * Chromium at all** — desktop Chrome reports every `env(safe-area-inset-*)` as 0 at every
+ * viewport, in both orientations. Computed style resolves the `max()` away to the literal,
+ * so reading the shipped CSSOM is the only way to tell the idiom from a bare `14px` that
+ * happens to look identical everywhere a machine can look.
+ *
+ * The same limit applies to `svh` itself: emulation has no retractable browser toolbar, so
+ * `100svh`, `100vh` and `100lvh` all resolve to the viewport height here. The unreachable
+ * strip this slice removes is not reproducible in this harness — only the declaration is.
+ * `inventory.spec.js` carries the other half, that no `100vh` is left in `web/src`.
+ *
+ * What IS ordinary geometry here: the gutter's resolved padding on both sides of the tier
+ * boundary (which is also the "desktop is unchanged" half of the claim), the tap floor's
+ * effect on the one selector using it, and sign-in's box.
+ */
+import { expect, test } from "@playwright/test";
+import { VIEWPORTS } from "./viewports.js";
+import { loadApp, loadSignIn } from "./support/app.js";
+
+const viewportOf = (projectName) => VIEWPORTS.find((v) => v.name === projectName);
+
+/**
+ * The tier boundary, as a JS literal. The stylesheet writes `max-width: 639.98px` and this
+ * writes `< 640`; there is no single source of truth to share, because JS cannot read a CSS
+ * custom property and the repo takes no build step to make one. The `.98` is what keeps a
+ * fractional viewport width out of a 1px dead zone against the tablet tier's `min-width`.
+ */
+const PHONE_TIER_BELOW = 640;
+
+/**
+ * Every rule in the shipped stylesheets whose selector is exactly `selector`, with the
+ * media condition it sits under and its *specified* declarations as `{ property: value }`.
+ *
+ * Specified, not computed: `getComputedStyle` hands back `14px` for both a bare literal and
+ * a `max(14px, env(...))`, which is exactly the distinction these gates exist to make.
+ *
+ * Read from the browser rather than from `styles.css`, so what is asserted is what ships —
+ * and the difference is not academic. The build expands `padding: 14px` into four longhands
+ * before this ever sees it, so the source's shorthand-then-longhand ordering (get it wrong
+ * and the shorthand silently resets all four sides) does not exist here to check. What
+ * catches that mistake is the resolved-padding test below, where the bottom would come back
+ * 14px instead of 20px.
+ */
+function declarationsFor(page, selector) {
+  return page.evaluate((sel) => {
+    const found = [];
+    const walk = (rules, media) => {
+      for (const rule of rules) {
+        // Matched *before* descending, not instead of: a `CSSStyleRule` carries its own
+        // (empty) `cssRules` list now that CSS nesting exists, so a style rule and a
+        // grouping rule are no longer distinguishable by that property being present.
+        if (rule.selectorText === sel) {
+          const decls = {};
+          for (const prop of rule.style) decls[prop] = rule.style.getPropertyValue(prop);
+          found.push({ media: media ?? null, decls });
+        }
+        if (rule.cssRules) walk(rule.cssRules, rule.conditionText ?? media);
+      }
+    };
+    for (const sheet of document.styleSheets) {
+      let rules;
+      try { rules = sheet.cssRules; } catch { continue; }   // a cross-origin sheet, if one ever appears
+      walk(rules, null);
+    }
+    return found;
+  }, selector);
+}
+
+/** The four resolved padding sides of one element, as CSS pixel strings. */
+function paddingOf(page, selector) {
+  return page.evaluate((sel) => {
+    const s = getComputedStyle(document.querySelector(sel));
+    return { top: s.paddingTop, right: s.paddingRight, bottom: s.paddingBottom, left: s.paddingLeft };
+  }, selector);
+}
+
+test("the document opts into the safe area", async ({ page, baseURL }) => {
+  await loadApp(page, baseURL);
+  // Without `viewport-fit=cover` every `env(safe-area-inset-*)` below resolves to 0 and the
+  // whole gutter is dead code rather than merely inactive — so this is the gate the phone
+  // block depends on, not a separate nicety. `inventory.spec.js` reads the source; this
+  // reads what the built document actually served.
+  const meta = await page.locator('meta[name="viewport"]').getAttribute("content");
+  expect(meta, "the meta viewport tag").toContain("viewport-fit=cover");
+  // The pair that would suppress iOS focus-zoom and fail WCAG 1.4.4 with it. Named so that
+  // reaching for it later reads as a deliberate edit here.
+  expect(meta).not.toMatch(/maximum-scale|user-scalable/);
+});
+
+test("the shell is sized in svh and the page itself does not scroll", async ({ page, baseURL }) => {
+  await loadApp(page, baseURL);
+
+  const rules = await declarationsFor(page, ".app");
+  expect(rules, "`.app` is declared in exactly one place").toHaveLength(1);
+  expect(rules[0].media, "`.app`'s height is unconditional — every tier owns its own scroll").toBeNull();
+  expect(rules[0].decls.height, "the shell is not `100svh`").toBe("100svh");
+  // This cannot tell `100svh` from a `height: 100vh; height: 100svh` fallback pair — a
+  // declaration block holds one `height`, and the later valid value is the only one that
+  // survives into the CSSOM. `inventory.spec.js` grepping `web/src` is what holds that half.
+
+  // The shell fills the viewport exactly, and nothing hangs below it. In emulation this
+  // cannot distinguish `svh` from `vh` — see the header — but it does catch the shell
+  // losing its height altogether, which is how the unreachable strip would come back.
+  const { shell, docScroll, docClient } = await page.evaluate(() => ({
+    shell: document.querySelector(".app").getBoundingClientRect().height,
+    docScroll: document.documentElement.scrollHeight,
+    docClient: document.documentElement.clientHeight,
+  }));
+  expect(Math.round(shell)).toBe(page.viewportSize().height);
+  expect(docScroll, "the document scrolls — the shell no longer owns its own scroll")
+    .toBeLessThanOrEqual(docClient + 1);
+});
+
+test.describe("the phone content gutter", () => {
+  test("all four sides pad with one max(<literal>, env()) idiom", async ({ page, baseURL }) => {
+    await loadApp(page, baseURL);
+    const rules = await declarationsFor(page, ".main");
+    const phone = rules.filter((r) => r.media?.includes("639.98px"));
+    expect(phone, "no `.main` rule in the phone media block").toHaveLength(1);
+
+    // Pad, never offset — and one shape on every side that has an inset to guard, so there
+    // is no second idiom for a later rule to copy from. The bottom is 20px rather than 14px
+    // on its own reasoning: under `100svh` this pane's bottom edge *is* the screen's.
+    //
+    // The top is the exception, and deliberately: the insets that matter to this pane are
+    // bottom (home bar) and left/right (notch in landscape). The *top* inset belongs to the
+    // top of the viewport, which is the app bar's edge and not `.main`'s — guarding it here
+    // would double-pad under a bar that already clears the notch. Asserted as a bare literal
+    // rather than left unmentioned, so adding it later reads as the decision it would be.
+    expect(phone[0].decls).toMatchObject({
+      "padding-top": "14px",
+      "padding-left": "max(14px, env(safe-area-inset-left))",
+      "padding-right": "max(14px, env(safe-area-inset-right))",
+      "padding-bottom": "max(20px, env(safe-area-inset-bottom))",
+    });
+  });
+
+  test("resolves to 14/14/20/14 on a phone and is untouched above the tier", async ({ page, baseURL }, testInfo) => {
+    const vp = viewportOf(testInfo.project.name);
+    await loadApp(page, baseURL);
+    const pad = await paddingOf(page, ".main");
+
+    if (vp.width < PHONE_TIER_BELOW) {
+      // Each `max()` resolves to its literal because Chromium reports every inset as 0. On
+      // an iPhone the bottom becomes 34px, which is the only reason it is 20 and not 14:
+      // under `100svh` this pane's bottom edge *is* the screen's.
+      expect(pad).toEqual({ top: "14px", right: "14px", bottom: "20px", left: "14px" });
+    } else {
+      // The other half of the same claim: the tier boundary is a boundary. 639 and 640 are
+      // both in the suite precisely so one side of it cannot pass for both.
+      expect(pad).toEqual({ top: "22px", right: "28px", bottom: "22px", left: "28px" });
+    }
+  });
+});
+
+test.describe("the tap floor", () => {
+  test("is declared as a token and referenced rather than repeated", async ({ page, baseURL }) => {
+    await loadApp(page, baseURL);
+
+    const tap = await page.evaluate(() =>
+      getComputedStyle(document.documentElement).getPropertyValue("--tap").trim()
+    );
+    expect(tap, "`--tap` is not declared on `:root`").toBe("44px");
+
+    // Declared and *used*: a token nothing references is worse than a literal, because it
+    // reads as a decision that is in force when it is not. This is the assertion that makes
+    // the token earn its place as call sites accumulate.
+    const navitem = await declarationsFor(page, ".navitem");
+    const phone = navitem.filter((r) => r.media?.includes("639.98px"));
+    expect(phone, "no `.navitem` rule in the phone media block").toHaveLength(1);
+    expect(phone[0].decls["min-height"], "the floor is written as a literal, bypassing the token")
+      .toBe("var(--tap)");
+  });
+
+  test("lifts navigation to 44px on a phone and leaves the desktop sidebar alone", async ({ page, baseURL }, testInfo) => {
+    const vp = viewportOf(testInfo.project.name);
+    await loadApp(page, baseURL);
+
+    const heights = await page.$$eval(".navitem", (els) =>
+      els.map((el) => ({ h: el.getBoundingClientRect().height, text: el.textContent.trim() }))
+    );
+    expect(heights.length, "the sidebar rendered no nav items").toBeGreaterThan(0);
+
+    for (const item of heights) {
+      if (vp.width < PHONE_TIER_BELOW) {
+        expect(item.h, `"${item.text}" is ${Math.round(item.h)}px tall`).toBeGreaterThanOrEqual(44);
+      } else {
+        // ~39px from `padding: 9px 18px`. Asserted as a ceiling rather than an exact number
+        // because the claim is "desktop is unchanged", and 44 is the number that would mean
+        // the phone rule had escaped its block.
+        expect(item.h, `"${item.text}" grew on desktop — the phone rule escaped its block`)
+          .toBeLessThan(44);
+      }
+    }
+  });
+});
+
+test.describe("sign-in", () => {
+  test("fills the viewport exactly, centres its content, and does not rubber-band", async ({ page, baseURL }) => {
+    await loadSignIn(page, baseURL);
+    const height = page.viewportSize().height;
+
+    // The screen is styled entirely inline with no classes — a closed decision, on the
+    // grounds that it needs no phone rule and inline hex literals are the house style in
+    // ~30 places across 9 files. So it is addressed structurally.
+    const outer = page.locator("#root > div");
+    const inner = page.locator("#root > div > div");
+
+    const box = await outer.boundingBox();
+    expect(Math.round(box.height), "the sign-in box is not the height of the screen").toBe(height);
+
+    // `min-height: 100vh` made this box ~64px taller than the visible area: the page
+    // rubber-banded with nothing to scroll and the "centred" content sat ~32px low. Both
+    // halves are asserted, because in emulation neither one alone would notice a return to
+    // `vh` — but a return to `auto`, which is what a browser without `svh` does, collapses
+    // the box to content height and fails the first.
+    const { docScroll, docClient } = await page.evaluate(() => ({
+      docScroll: document.documentElement.scrollHeight,
+      docClient: document.documentElement.clientHeight,
+    }));
+    expect(docScroll, "the page scrolls — there is nothing on it to scroll to")
+      .toBeLessThanOrEqual(docClient + 1);
+
+    const content = await inner.boundingBox();
+    expect(Math.abs(content.y + content.height / 2 - height / 2), "content is off optical centre")
+      .toBeLessThanOrEqual(1);
+  });
+
+  test("adds no rule to the phone media block", async ({ page, baseURL }) => {
+    await loadSignIn(page, baseURL);
+    // The screen is already responsive: nothing overflows at any phone width, so it earns no
+    // phone-specific rule and the whole slice here is two characters on two lines. Nothing
+    // it renders carries a class, so this holds by construction — which is worth asserting,
+    // because the cheapest way to "fix" this screen later is to give it one.
+    const styled = await page.evaluate(() =>
+      [...document.querySelectorAll("#root *")].filter((el) => el.className).length
+    );
+    expect(styled, "sign-in grew a class — check whether it also grew a phone rule").toBe(0);
+  });
+});

--- a/web/tests/foundations.spec.js
+++ b/web/tests/foundations.spec.js
@@ -2,38 +2,22 @@
  * The responsive foundations: the shell's height unit, the safe-area opt-in, the phone
  * media block, and the one token.
  *
- * These are the mechanism every later phone rule sits in rather than a behaviour anyone
- * can see, so they are asserted here as *declarations* as much as as geometry. That is
- * deliberate and it is the exception in this suite: `baseline` and `unconditional` measure
- * boxes because a box is what those decisions produce, whereas "the gutter uses one
- * `max(<literal>, env())` idiom on all four sides" has **no measurable consequence in
- * Chromium at all** — desktop Chrome reports every `env(safe-area-inset-*)` as 0 at every
- * viewport, in both orientations. Computed style resolves the `max()` away to the literal,
- * so reading the shipped CSSOM is the only way to tell the idiom from a bare `14px` that
- * happens to look identical everywhere a machine can look.
+ * These are the mechanism every later phone rule sits in rather than a behaviour anyone can
+ * see, so this is the one spec in the suite that asserts *declarations* as well as geometry.
+ * The reason is `baseline.spec.js`'s "WHAT THIS SUITE CANNOT CHECK, EVER" — safe-area insets
+ * and mobile toolbars are both on that list — which leaves nothing measurable behind the
+ * gutter's `max()` or the shell's `svh`. Reading the shipped CSSOM is what is left.
  *
- * The same limit applies to `svh` itself: emulation has no retractable browser toolbar, so
- * `100svh`, `100vh` and `100lvh` all resolve to the viewport height here. The unreachable
- * strip this slice removes is not reproducible in this harness — only the declaration is.
- * `inventory.spec.js` carries the other half, that no `100vh` is left in `web/src`.
+ * `inventory.spec.js` carries the half neither can reach: that no `100vh` survives the source.
  *
  * What IS ordinary geometry here: the gutter's resolved padding on both sides of the tier
- * boundary (which is also the "desktop is unchanged" half of the claim), the tap floor's
- * effect on the one selector using it, and sign-in's box.
+ * boundary — which is also the "desktop is unchanged" half of that claim — and sign-in's box.
  */
 import { expect, test } from "@playwright/test";
-import { VIEWPORTS } from "./viewports.js";
+import { PHONE_TIER_BELOW, PHONE_TIER_EDGE, VIEWPORTS } from "./viewports.js";
 import { loadApp, loadSignIn } from "./support/app.js";
 
 const viewportOf = (projectName) => VIEWPORTS.find((v) => v.name === projectName);
-
-/**
- * The tier boundary, as a JS literal. The stylesheet writes `max-width: 639.98px` and this
- * writes `< 640`; there is no single source of truth to share, because JS cannot read a CSS
- * custom property and the repo takes no build step to make one. The `.98` is what keeps a
- * fractional viewport width out of a 1px dead zone against the tablet tier's `min-width`.
- */
-const PHONE_TIER_BELOW = 640;
 
 /**
  * Every rule in the shipped stylesheets whose selector is exactly `selector`, with the
@@ -123,20 +107,14 @@ test.describe("the phone content gutter", () => {
   test("all four sides pad with one max(<literal>, env()) idiom", async ({ page, baseURL }) => {
     await loadApp(page, baseURL);
     const rules = await declarationsFor(page, ".main");
-    const phone = rules.filter((r) => r.media?.includes("639.98px"));
+    const phone = rules.filter((r) => r.media?.includes(PHONE_TIER_EDGE));
     expect(phone, "no `.main` rule in the phone media block").toHaveLength(1);
 
-    // Pad, never offset — and one shape on every side that has an inset to guard, so there
-    // is no second idiom for a later rule to copy from. The bottom is 20px rather than 14px
-    // on its own reasoning: under `100svh` this pane's bottom edge *is* the screen's.
-    //
-    // The top is the exception, and deliberately: the insets that matter to this pane are
-    // bottom (home bar) and left/right (notch in landscape). The *top* inset belongs to the
-    // top of the viewport, which is the app bar's edge and not `.main`'s — guarding it here
-    // would double-pad under a bar that already clears the notch. Asserted as a bare literal
-    // rather than left unmentioned, so adding it later reads as the decision it would be.
+    // Pad, never offset — one shape on all four sides, so there is no second idiom for a
+    // later rule to copy from. The bottom is 20px rather than 14px on its own reasoning:
+    // under `100svh` this pane's bottom edge *is* the screen's.
     expect(phone[0].decls).toMatchObject({
-      "padding-top": "14px",
+      "padding-top": "max(14px, env(safe-area-inset-top))",
       "padding-left": "max(14px, env(safe-area-inset-left))",
       "padding-right": "max(14px, env(safe-area-inset-right))",
       "padding-bottom": "max(20px, env(safe-area-inset-bottom))",
@@ -149,9 +127,8 @@ test.describe("the phone content gutter", () => {
     const pad = await paddingOf(page, ".main");
 
     if (vp.width < PHONE_TIER_BELOW) {
-      // Each `max()` resolves to its literal because Chromium reports every inset as 0. On
-      // an iPhone the bottom becomes 34px, which is the only reason it is 20 and not 14:
-      // under `100svh` this pane's bottom edge *is* the screen's.
+      // Every `max()` resolves to its literal here, which is the whole of what emulation
+      // can say about it. On an iPhone the bottom becomes 34px.
       expect(pad).toEqual({ top: "14px", right: "14px", bottom: "20px", left: "14px" });
     } else {
       // The other half of the same claim: the tier boundary is a boundary. 639 and 640 are
@@ -161,46 +138,28 @@ test.describe("the phone content gutter", () => {
   });
 });
 
-test.describe("the tap floor", () => {
-  test("is declared as a token and referenced rather than repeated", async ({ page, baseURL }) => {
-    await loadApp(page, baseURL);
+test("the tap token is declared, and referenced rather than repeated", async ({ page, baseURL }) => {
+  await loadApp(page, baseURL);
 
-    const tap = await page.evaluate(() =>
-      getComputedStyle(document.documentElement).getPropertyValue("--tap").trim()
-    );
-    expect(tap, "`--tap` is not declared on `:root`").toBe("44px");
+  const tap = await page.evaluate(() =>
+    getComputedStyle(document.documentElement).getPropertyValue("--tap").trim()
+  );
+  expect(tap, "`--tap` is not declared on `:root`").toBe("44px");
 
-    // Declared and *used*: a token nothing references is worse than a literal, because it
-    // reads as a decision that is in force when it is not. This is the assertion that makes
-    // the token earn its place as call sites accumulate.
-    const navitem = await declarationsFor(page, ".navitem");
-    const phone = navitem.filter((r) => r.media?.includes("639.98px"));
-    expect(phone, "no `.navitem` rule in the phone media block").toHaveLength(1);
-    expect(phone[0].decls["min-height"], "the floor is written as a literal, bypassing the token")
-      .toBe("var(--tap)");
-  });
+  // Declared and *used*: a token nothing references is worse than a literal, because it
+  // reads as a decision that is in force when it is not. This is the assertion that makes
+  // the token earn its place as call sites accumulate.
+  const phone = (await declarationsFor(page, ".navitem")).filter((r) => r.media?.includes(PHONE_TIER_EDGE));
+  expect(phone, "no `.navitem` rule in the phone media block").toHaveLength(1);
+  expect(phone[0].decls["min-height"], "the floor is written as a literal, bypassing the token")
+    .toBe("var(--tap)");
+  expect(phone[0].decls["min-width"], "height-only — the floor was decided square").toBe("var(--tap)");
 
-  test("lifts navigation to 44px on a phone and leaves the desktop sidebar alone", async ({ page, baseURL }, testInfo) => {
-    const vp = viewportOf(testInfo.project.name);
-    await loadApp(page, baseURL);
-
-    const heights = await page.$$eval(".navitem", (els) =>
-      els.map((el) => ({ h: el.getBoundingClientRect().height, text: el.textContent.trim() }))
-    );
-    expect(heights.length, "the sidebar rendered no nav items").toBeGreaterThan(0);
-
-    for (const item of heights) {
-      if (vp.width < PHONE_TIER_BELOW) {
-        expect(item.h, `"${item.text}" is ${Math.round(item.h)}px tall`).toBeGreaterThanOrEqual(44);
-      } else {
-        // ~39px from `padding: 9px 18px`. Asserted as a ceiling rather than an exact number
-        // because the claim is "desktop is unchanged", and 44 is the number that would mean
-        // the phone rule had escaped its block.
-        expect(item.h, `"${item.text}" grew on desktop — the phone rule escaped its block`)
-          .toBeLessThan(44);
-      }
-    }
-  });
+  // What is deliberately NOT here: that a nav item measures 44px on a phone. The 44px target
+  // is a `RESPONSIVE.md` universal gate belonging to the shell slice, and it is not true of
+  // the app yet — the sidebar this rule lands on is not the navigation a phone will have.
+  // Asserting it here would move a checklist gate into the suite ahead of the behaviour,
+  // which is the one thing that file says about itself.
 });
 
 test.describe("sign-in", () => {

--- a/web/tests/hscroll-baseline.js
+++ b/web/tests/hscroll-baseline.js
@@ -2,7 +2,7 @@
  * How far the main pane overflows itself horizontally today, per viewport and per view.
  *
  * THIS FILE IS A LIST OF DEFECTS, NOT A SPECIFICATION. Every non-zero number is the
- * mobile-responsive problem stated in pixels: at 390px, Holdings puts 1215px of table
+ * mobile-responsive problem stated in pixels: at 390px, Holdings puts 1201px of table
  * past the edge of the pane, which is why you see the Security column and not one number.
  *
  * The suite gates against these numbers rather than against zero because this harness had
@@ -17,80 +17,88 @@
  *
  * Measured against the committed fixtures on a production build. They are stable to the
  * pixel across runs, and the differences between viewports track viewport width exactly
- * (Holdings: 1245 at 360, 1215 at 390, 1175 at 430), so a number that moves means the
+ * (Holdings: 1231 at 360, 1201 at 390, 1161 at 430), so a number that moves means the
  * layout moved rather than that the measurement is noisy.
  *
  * Above 1024px there is no gate and therefore no entries here — `HSCROLL_GATE_APPLIES_BELOW`
  * in `viewports.js` says why those three viewports are exempt.
  *
- * LOWERED ONCE SO FAR, by the unconditional fixes. `.grid2`'s `auto-fit` did most of it:
- * two 419px tracks side by side became one, so `Portfolio › Overview` went 619 → 288 at
- * 360px, `Spending › By Category` 652 → 288, `Spending › Overview` 778 → 328, and
- * `Dividends`, `Classify` and three of the tablet-and-up entries reached zero outright. The
- * unchanged rows are the ones this slice never touched: Holdings, Performance, both
- * Transactions ledgers, Net Worth and Recurring are all single wide tables with no `.grid2`
- * in them, and they wait for the pinned-column work.
+ * LOWERED TWICE SO FAR.
+ *
+ * 1. The unconditional fixes. `.grid2`'s `auto-fit` did most of it: two 419px tracks side by
+ *    side became one, so `Portfolio › Overview` went 619 → 288 at 360px, `Spending › By
+ *    Category` 652 → 288, `Spending › Overview` 778 → 328, and `Dividends`, `Classify` and
+ *    three of the tablet-and-up entries reached zero outright. The rows that did not move
+ *    were the ones with no `.grid2` in them — Holdings, Performance, both Transactions
+ *    ledgers, Net Worth and Recurring — which wait for the pinned-column work.
+ *
+ * 2. The phone content gutter, `.main`'s `22px 28px` becoming `14px` below 640. This one is
+ *    uniform where the first was not: **every gated phone row falls by exactly 14**, because
+ *    the gutter change is the same on every view and none of these tables are anywhere near
+ *    fitting. Four more reach zero — `Dividends` at 390, and `Overview` / `Options` / `By
+ *    Category` at 639, all of which were within 13px of it. The three viewports at or above
+ *    640px are untouched, which is the tier boundary doing its job.
  */
 export const HSCROLL_BASELINE = {
   "small-phone": {
-    "Portfolio › Overview": 288,
-    "Portfolio › Holdings": 1245,
-    "Portfolio › Performance": 721,
-    "Portfolio › Dividends": 43,
-    "Portfolio › Options": 288,
-    "Portfolio › Transactions": 1105,
-    "Portfolio › SecurityDetail": 724,
-    "Net Worth": 563,
-    "Spending › Overview": 328,
-    "Spending › By Category": 288,
-    "Spending › Classify": 48,
-    "Spending › Recurring": 644,
-    "Spending › Transactions": 1081,
+    "Portfolio › Overview": 274,
+    "Portfolio › Holdings": 1231,
+    "Portfolio › Performance": 707,
+    "Portfolio › Dividends": 29,
+    "Portfolio › Options": 274,
+    "Portfolio › Transactions": 1091,
+    "Portfolio › SecurityDetail": 710,
+    "Net Worth": 549,
+    "Spending › Overview": 314,
+    "Spending › By Category": 274,
+    "Spending › Classify": 34,
+    "Spending › Recurring": 630,
+    "Spending › Transactions": 1067,
   },
   "design-width": {
-    "Portfolio › Overview": 258,
-    "Portfolio › Holdings": 1215,
-    "Portfolio › Performance": 691,
-    "Portfolio › Dividends": 13,
-    "Portfolio › Options": 258,
-    "Portfolio › Transactions": 1075,
-    "Portfolio › SecurityDetail": 694,
-    "Net Worth": 533,
-    "Spending › Overview": 298,
-    "Spending › By Category": 258,
-    "Spending › Classify": 18,
-    "Spending › Recurring": 614,
-    "Spending › Transactions": 1051,
+    "Portfolio › Overview": 244,
+    "Portfolio › Holdings": 1201,
+    "Portfolio › Performance": 677,
+    "Portfolio › Dividends": 0,
+    "Portfolio › Options": 244,
+    "Portfolio › Transactions": 1061,
+    "Portfolio › SecurityDetail": 680,
+    "Net Worth": 519,
+    "Spending › Overview": 284,
+    "Spending › By Category": 244,
+    "Spending › Classify": 4,
+    "Spending › Recurring": 600,
+    "Spending › Transactions": 1037,
   },
   "large-phone": {
-    "Portfolio › Overview": 218,
-    "Portfolio › Holdings": 1175,
-    "Portfolio › Performance": 651,
+    "Portfolio › Overview": 204,
+    "Portfolio › Holdings": 1161,
+    "Portfolio › Performance": 637,
     "Portfolio › Dividends": 0,
-    "Portfolio › Options": 218,
-    "Portfolio › Transactions": 1035,
-    "Portfolio › SecurityDetail": 654,
-    "Net Worth": 493,
-    "Spending › Overview": 258,
-    "Spending › By Category": 218,
+    "Portfolio › Options": 204,
+    "Portfolio › Transactions": 1021,
+    "Portfolio › SecurityDetail": 640,
+    "Net Worth": 479,
+    "Spending › Overview": 244,
+    "Spending › By Category": 204,
     "Spending › Classify": 0,
-    "Spending › Recurring": 574,
-    "Spending › Transactions": 1011,
+    "Spending › Recurring": 560,
+    "Spending › Transactions": 997,
   },
   "phone-tier-last-pixel": {
-    "Portfolio › Overview": 9,
-    "Portfolio › Holdings": 966,
-    "Portfolio › Performance": 442,
+    "Portfolio › Overview": 0,
+    "Portfolio › Holdings": 952,
+    "Portfolio › Performance": 428,
     "Portfolio › Dividends": 0,
-    "Portfolio › Options": 9,
-    "Portfolio › Transactions": 826,
-    "Portfolio › SecurityDetail": 445,
-    "Net Worth": 284,
-    "Spending › Overview": 49,
-    "Spending › By Category": 9,
+    "Portfolio › Options": 0,
+    "Portfolio › Transactions": 812,
+    "Portfolio › SecurityDetail": 431,
+    "Net Worth": 270,
+    "Spending › Overview": 35,
+    "Spending › By Category": 0,
     "Spending › Classify": 0,
-    "Spending › Recurring": 365,
-    "Spending › Transactions": 802,
+    "Spending › Recurring": 351,
+    "Spending › Transactions": 788,
   },
   "tablet-tier-first-pixel": {
     "Portfolio › Overview": 8,

--- a/web/tests/inventory.spec.js
+++ b/web/tests/inventory.spec.js
@@ -56,9 +56,8 @@ test("no `100vh` survives anywhere under web/src", () => {
   // The shell and sign-in both moved to `svh`, for two different reasons: `height: 100vh`
   // leaves a permanently *unreachable* strip in a shell that owns its own scroll, and
   // `min-height: 100vh` leaves a *scrollable* one that pushes centred content ~32px low.
-  // Neither failure reproduces in emulation — Chromium has no retractable toolbar, so
-  // `vh`, `svh` and `lvh` are all the viewport height here. Grepping the source is the
-  // only gate this suite can hold on it, and the same one a reviewer would run by eye.
+  // Neither reproduces in a browser with no retractable toolbar, so this grep is the only
+  // gate the suite can hold on it — and the same one a reviewer would run by eye.
   // Comments are stripped first — both files explain at length what `100vh` did and why it
   // is gone, and a gate that forbids naming the thing it forbids is a gate that gets the
   // explanation deleted rather than the defect.

--- a/web/tests/inventory.spec.js
+++ b/web/tests/inventory.spec.js
@@ -52,6 +52,35 @@ test("exactly one donut implementation exists", () => {
   expect(pies, "files rendering a <PieChart> — the donut is shared, not copied").toHaveLength(1);
 });
 
+test("no `100vh` survives anywhere under web/src", () => {
+  // The shell and sign-in both moved to `svh`, for two different reasons: `height: 100vh`
+  // leaves a permanently *unreachable* strip in a shell that owns its own scroll, and
+  // `min-height: 100vh` leaves a *scrollable* one that pushes centred content ~32px low.
+  // Neither failure reproduces in emulation — Chromium has no retractable toolbar, so
+  // `vh`, `svh` and `lvh` are all the viewport height here. Grepping the source is the
+  // only gate this suite can hold on it, and the same one a reviewer would run by eye.
+  // Comments are stripped first — both files explain at length what `100vh` did and why it
+  // is gone, and a gate that forbids naming the thing it forbids is a gate that gets the
+  // explanation deleted rather than the defect.
+  const stripComments = (src) =>
+    src.replace(/\/\*[\s\S]*?\*\//g, "").replace(/^\s*\/\/.*$/gm, "");
+  const offenders = sourceFiles(path.join(WEB, "src"))
+    .filter((f) => /100vh/.test(stripComments(fs.readFileSync(f, "utf8"))))
+    .map((f) => path.relative(WEB, f));
+  expect(offenders, "`100vh` is `100lvh` by spec — use `100svh`").toEqual([]);
+});
+
+test("the viewport meta opts into the safe area", () => {
+  // `foundations.spec.js` asserts this on the served document. Here because the source is
+  // where a reviewer looks, and because a build that silently dropped it would fail there
+  // with no indication of which of the two files was wrong.
+  const html = fs.readFileSync(path.join(WEB, "index.html"), "utf8");
+  const meta = html.match(/<meta name="viewport"[^>]*content="([^"]*)"/)?.[1];
+  expect(meta, "web/index.html has no viewport meta tag").toBeTruthy();
+  expect(meta, "without `viewport-fit=cover` every env(safe-area-inset-*) resolves to 0")
+    .toContain("viewport-fit=cover");
+});
+
 test("the ten viewports match the manual checklist one-for-one", () => {
   // RESPONSIVE.md's viewport table is the human-facing list; `viewports.js` is the
   // machine-facing one. Two lists of the same ten viewports drift the moment nothing

--- a/web/tests/support/app.js
+++ b/web/tests/support/app.js
@@ -158,6 +158,34 @@ export const VIEWS = [
   },
 ];
 
+/**
+ * Load the app signed *out*, so the login screen renders instead of the shell.
+ *
+ * The session endpoint is the app's one auth chokepoint — `AuthGate` turns on it alone —
+ * so answering it 401 is the whole of it. The override is registered after `mockApi`'s
+ * catch-all on purpose: Playwright matches routes in reverse registration order, so the
+ * later, narrower route wins.
+ *
+ * What renders is not quite what a signed-out person sees: Google Identity Services is
+ * cross-origin, so the seam aborts it and the screen shows its own load-failure line where
+ * production shows a button. That is the point of the seam rather than a gap in it — every
+ * gate this screen carries is about the *box*, which is the same either way, and the GSI
+ * button is explicitly carved out of the tap floor because Google exposes no height for it.
+ */
+export async function loadSignIn(page, baseURL) {
+  const seam = await mockApi(page, baseURL);
+  await page.route("**/api/auth/me", (route) =>
+    route.fulfill({
+      status: 401,
+      contentType: "application/json",
+      body: JSON.stringify({ detail: "no session" }),
+    })
+  );
+  await page.goto("/");
+  await expect(page.getByRole("heading", { name: "Portfolio" })).toBeVisible({ timeout: 20_000 });
+  return seam;
+}
+
 /** Load the app with the seam installed and the shell rendered. */
 export async function loadApp(page, baseURL) {
   const seam = await mockApi(page, baseURL);

--- a/web/tests/viewports.js
+++ b/web/tests/viewports.js
@@ -28,6 +28,22 @@
  */
 export const HSCROLL_GATE_APPLIES_BELOW = 1024;
 
+/**
+ * The phone tier, as the suite says it — and the third place 640 is written as a literal.
+ *
+ * `styles.css` says `max-width: 639.98px` and this says `< 640`; JS cannot read a CSS custom
+ * property and the repo takes no build step to make one, so the two cross-reference in
+ * comments rather than share a constant. `RESPONSIVE.md`'s Traps names all three sites.
+ *
+ * `PHONE_TIER_EDGE` is how a test picks a phone rule out of the *shipped* stylesheet, and it
+ * is a substring of the condition rather than the whole of it on purpose: the build rewrites
+ * `@media (max-width: 639.98px)` into the range syntax `@media (width<=639.98px)`, so the
+ * number is the only part that survives minification. The `.98` is what keeps a fractional
+ * viewport width out of a 1px dead zone against the tablet tier's `min-width: 640px`.
+ */
+export const PHONE_TIER_BELOW = 640;
+export const PHONE_TIER_EDGE = "639.98px";
+
 export const VIEWPORTS = [
   { name: "small-phone",             width: 360,  height: 740,  why: "small phone — the tightest realistic width" },
   { name: "design-width",            width: 390,  height: 844,  why: "the design width; every measurement in the spec was taken here" },


### PR DESCRIPTION
The mechanism every phone rule will sit in, plus the one screen that needed nothing but the units fixed.

Closes #26.

## What lands

**`.app` moves to `100svh`** — not `dvh`, not `vh`. The shell owns its own scroll, so the document never scrolls, so the mobile toolbar never retracts; `100vh` is spec-defined to equal `100lvh`, which makes the overflowing strip permanently *unreachable* rather than cosmetic. In a shell that cannot retract the toolbar, `svh` ≡ `dvh`, so `svh` wins on being unable to reflow mid-interaction.

**The viewport meta gains `viewport-fit=cover`.** Without it every `env(safe-area-inset-*)` resolves to 0 and the gutter is dead code rather than merely inactive.

**The `@media (max-width: 639.98px)` block is established**, carrying the content gutter: `padding: 14px` with `max(14px, env(...))` on top/left/right and `max(20px, env(...))` on the bottom. 14px is ratified rather than tuned — measured at a true 390px frame, nothing in the spec has a threshold between 8px and 16px, and the first one is at 20px. The bottom is 20 because under `svh` the pane's bottom edge *is* the screen's.

**`--tap: 44px` is declared**, the one number that recurs across unrelated selectors and so the only thing that earns a token. Everything else the phone changes is a literal in the block, because most of it cannot be expressed as a token override at all. Its call site is `.navitem`.

**Sign-in** is two characters on two lines. `min-height: 100vh` left a *scrollable* strip rather than an unreachable one, so the page rubber-banded with nothing to scroll and the centred content sat ~32px low. It contributes no rule to the phone block.

## Acceptance criteria

- [x] No `100vh` remains in the shell or on sign-in
- [x] The viewport meta includes `viewport-fit=cover`
- [x] A phone media block exists at `max-width: 639.98px` carrying the gutter, with all four sides using one `max(<literal>, env())` idiom
- [x] A tap-size custom property is declared and used
- [x] Sign-in content is optically centred at 390×844 and the page does not rubber-band
- [x] Sign-in adds no rule to the phone media block
- [x] Desktop layout is unchanged; the suite is green at 1280

## Verification

`make test-web` — **361 passed**, including the desktop-unchanged baseline at 1280 and 1440.

New `web/tests/foundations.spec.js` is the first spec in the suite that asserts **declarations** as well as geometry, and the reason is `baseline.spec.js`'s "WHAT THIS SUITE CANNOT CHECK, EVER": safe-area insets and mobile toolbars are both on that list, so computed style cannot tell `max(14px, env(...))` from a bare `14px`, or `svh` from `vh`. Reading the shipped CSSOM can. `inventory.spec.js` carries the half neither reaches — that no `100vh` survives `web/src`, comments stripped first.

It is also the suite's first signed-out render: `loadSignIn` answers the session endpoint 401.

**`hscroll-baseline.js` drops for the second time**, as `web/TESTING.md` requires when work lands. The gutter change is uniform: every gated phone row falls by exactly 14, and `Dividends` at 390 plus `Overview` / `Options` / `By Category` at 639 reach zero. The three viewports at or above 640 are untouched, which is the tier boundary doing its job.

## Two things to see rather than discover

**A trap shipped on purpose.** `.main`'s phone `padding-top` guards `env(safe-area-inset-top)`. That is correct *today*, because `.main` is the top of the viewport — and wrong the moment the app bar lands, since `env()` is viewport-relative rather than parent-relative and the rule would then double-pad. Written into `RESPONSIVE.md`'s Traps for #27.

**One deliberate omission.** `.main`'s unconditional `≥640px` safe-area guard (ticket 018's hoist) is left to #33 rather than pulled forward. `RESPONSIVE.md`'s safe-area gate now states the gap plainly: a rotated phone is 844px wide, so the phone block does not apply in landscape and nothing guards the notch there yet.

## Decisions that diverge from a closed ticket

Both are recorded as *Corrected in the build* notes on the tickets themselves rather than left as silent drift:

- **Ticket 010's `height: 100vh; height: 100svh` fallback pair was not built** — the acceptance criterion forbids the literal, and `inventory.spec.js` now asserts that as a source grep. The grounds are 016's own, applied one file wider: `svh` is universally available since 2022. The residual risk is accepted rather than denied.
- **The gutter guards the top inset**, where 010 finding 2 says top is not one of the insets that matter. Both are right at their own moment; see the trap above.