### PR TITLE
The phone navigation shell

### DIFF
--- a/RESPONSIVE.md
+++ b/RESPONSIVE.md
@@ -56,22 +56,28 @@ Applied to all 12 tab views, SecurityDetail, and sign-in. Must pass.
    editor floor has landed and is asserted by `unconditional.spec.js`; it is not checked here any
    more. Recurring's three `.link-btn`s take their width from the 44px rule rather than twice, so
    they are still this line's business.)*
-4. Navigation reachable from every screen: drawer opens, scrim tap closes it, the tab `<select>` works.
+4. ~~Navigation reachable from every screen: drawer opens, scrim tap closes it, the tab `<select>`
+   works.~~ **Landed** — `shell.spec.js` asserts the drawer, the scrim, the picker and the app bar,
+   and the suite now *drives* every phone viewport through them, so all thirteen views being
+   reachable at 390×844 is asserted thirteen times over in `baseline.spec.js` rather than once here.
 5. `input`, `select`, `textarea` render at **16px on phone** (nothing else changes size — 11px labels
-   hold everywhere, there is no type floor).
-6. Nothing is `position: fixed`.
+   hold everywhere, there is no type floor). *(The tab picker's own 16px has landed and is asserted;
+   every other form control on a phone is still this line's business.)*
+6. ~~Nothing is `position: fixed`.~~ **Landed** — asserted at all ten viewports across all thirteen
+   views by `baseline.spec.js`, and again by `shell.spec.js` with the drawer *open*, which is the
+   state the two candidates for fixed positioning actually exist in.
 7. Safe areas: in landscape, content **and the app bar** clear the notch; the dark background paints
    under the home bar with no seam. *(Stays here whatever lands — it is one of the four iPhone items.
-   `foundations.spec.js` asserts `viewport-fit=cover` and that `.main`'s four phone sides are written
-   as `max(<literal>, env(...))`, which is a claim about the **declaration** only. Note what that
-   leaves uncovered: the phone block does not apply in landscape at all — a rotated phone is 844px
-   wide — so nothing yet guards content or the app bar there. That guard belongs to the tablet tier
-   and the shell.)*
+   The suite asserts `viewport-fit=cover` and the **declarations**: `.main`'s three remaining phone
+   sides and — since the shell landed — the app bar's `max(12px, env(...))` and `.main`'s
+   `max(28px, env(...))`, both written **unconditionally**, because a rotated phone is 844px wide and
+   exits the phone block. What none of that can say is whether a real notch is actually cleared.)*
 8. The shell fills the screen with nothing unreachable below it: the bottom of a scrolled list is
    scrollable to, and sign-in does not rubber-band. *(`100svh` has landed in the shell and on sign-in
    — asserted as a declaration by `foundations.spec.js`, plus a source gate in `inventory.spec.js`
-   that no `100vh` survives under `web/src`. The **symptom** stays an iPhone check: emulation has no
-   retractable toolbar, so it cannot see the strip either way.)*
+   that no `100vh` survives under `web/src`; `shell.spec.js` adds the phone column and the pane
+   scrolling to its own end. The **symptom** stays an iPhone check: emulation has no retractable
+   toolbar, so it cannot see the strip either way.)*
 
 ## The two editors
 
@@ -153,10 +159,25 @@ Things the build session must be told, not left to discover.
   `PHONE_TIER_BELOW` / `PHONE_TIER_MEDIA`, and — once the charts land — the `matchMedia` hook. No
   single source of truth without a build step. Every site cross-references the others in a comment.
 - In `.main`, the padding **longhands must follow the shorthand** — the shorthand resets all four sides.
-- **`.main`'s phone `padding-top` guards `env(safe-area-inset-top)` and must stop once the app bar
-  lands.** Today `.main` is the top of the viewport, so the guard is what clears the notch. With a bar
-  above it the bar clears the notch instead, and `env()` is viewport-relative rather than
-  parent-relative, so the same rule would double-pad.
+- ~~**`.main`'s phone `padding-top` guards `env(safe-area-inset-top)` and must stop once the app bar
+  lands.**~~ **Discharged** by the shell: the pane's top is a bare `14px` now and the app bar carries
+  `max(0px, env(safe-area-inset-top))` instead. `shell.spec.js` asserts both halves, so putting the
+  guard back fails rather than silently double-padding.
+- **The app bar's inset guards are unconditional, and must stay that way.** They read like phone rules
+  and belong in the phone block by instinct — but a rotated phone is 844px wide and *exits* that block,
+  and landscape is the only orientation where the notch is at the side. Same for `.main`'s
+  `max(28px, env(...))`. The *value* follows the width; the *guard* does not. The **drawer's**
+  guard is the exception and stays inside the block, because `position: absolute` and the transform
+  are in that rule too — the whole rule travels together when the tablet tier's height guard brings
+  it to 844×390. **`.side` as a *rail* — 640 and up — has no guard at all**, so in landscape above
+  the tier the notch cuts into the sidebar. That belongs to the tablet tier, not the shell.
+- **The app bar is `box-sizing: content-box`** against the app-wide `border-box`, so the top inset adds
+  to its 48px instead of eating it. 48px is the number the whole drawer-versus-bottom-bar trade was
+  decided on; under `border-box` a 47px inset would crush the bar to a line.
+- **`.tabs` is not only the navigation strip.** `ByCategory.jsx:95` borrows the class for its own view
+  header — an `<h3>` and a year `<select>` — with the border overridden inline. That is why the phone
+  rule that hides the strip is `.main > .tabs`; a bare `.tabs` deletes that heading and the year picker
+  with it, and the view still renders, so nothing fails loudly.
 - Sticky + pinned cells require `border-collapse: separate; border-spacing: 0`; under `collapse` they
   lose their borders.
 - `display: none` starves `ResponsiveContainer` to 0×0 — drop chart *chrome* via `matchMedia`, never the

--- a/web/TESTING.md
+++ b/web/TESTING.md
@@ -22,10 +22,17 @@ authority on what it asserts and, more importantly, **what it can never assert**
 before treating a green run as "verified on a phone"; it is not. Four things need a real
 iPhone and are named there.
 
-`tests/unconditional.spec.js` — the gates that hold at *every* width, checked at every width and
-only on the views that carry them: the refresh control's size, `.grid2`'s collapse, the wrapping
-tab strip, the editors' 24px floor, the rule textarea's styling, the S2 list rows, and the merged
-options identity cell. Each one moved **out of** `RESPONSIVE.md` when it moved in here.
+**Below 640px, "open a view" means different clicks**, and `tests/support/app.js` makes them:
+the hamburger, then the section in the drawer, then the tab in the `<select>`. Every spec keeps
+asking for `"Spending › Recurring"` and gets there the way a person on that viewport would. So
+the phone half of the whole suite depends on the navigation shell — which is why that ticket
+landed before the tables and the charts.
+
+`tests/unconditional.spec.js` — the gates that hold at *every* width, checked at every width their
+subject exists at, and only on the views that carry them: `.grid2`'s collapse, the wrapping tab
+strip, the editors' 24px floor, the rule textarea's styling, the S2 list rows, the merged options
+identity cell, and the labelled refresh control — that last one at 640 and up, because below it
+the label does not render at all. Each one moved **out of** `RESPONSIVE.md` when it moved in here.
 
 `tests/foundations.spec.js` — the mechanism every phone rule sits in: the shell's `100svh`, the
 `viewport-fit=cover` opt-in, the `max(<literal>, env(...))` content gutter inside the one
@@ -34,6 +41,13 @@ that asserts **declarations** as well as geometry, because the things it gates a
 `baseline.spec.js`'s "cannot check, ever" list and leave nothing measurable behind. It is also
 the only spec that renders the app **signed out** — `loadSignIn` in `tests/support/app.js`
 answers the session endpoint 401.
+
+`tests/shell.spec.js` — the phone navigation shell: the drawer and its scrim, the native tab
+picker at 16px, the icon-only refresh with its toast strip *displacing* content rather than
+covering it and then leaving on its own, the `100svh` column, and — at 640 and above — that
+none of it renders. It shares
+`foundations.spec.js`'s CSSOM reader (`tests/support/css.js`) for the two criteria that are
+about a notch and therefore have no geometric form in Chromium.
 
 `tests/inventory.spec.js` — the checks that read files rather than pixels: the table count, the
 single donut implementation, that no `100vh` survives under `web/src`, the viewport meta's

--- a/web/playwright.config.js
+++ b/web/playwright.config.js
@@ -39,7 +39,7 @@ export default defineConfig({
     { name: "inventory", testMatch: /inventory\.spec\.js/ },
     ...VIEWPORTS.map((v) => ({
       name: v.name,
-      testMatch: /(baseline|unconditional|foundations)\.spec\.js/,
+      testMatch: /(baseline|unconditional|foundations|shell)\.spec\.js/,
       use: {
         ...devices["Desktop Chrome"],
         viewport: { width: v.width, height: v.height },

--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import posthog from "posthog-js";
 import { post } from "./api.js";
 import { useAuth } from "./auth.jsx";
@@ -32,6 +32,30 @@ const SPEND_TABS = {
   Transactions: SpendTransactions,
 };
 
+/**
+ * Which tabs a section owns, for the phone app bar's picker. Net Worth has none, which is
+ * why the lookup can come back undefined rather than empty: an empty `<select>` is a
+ * control that does nothing, so the bar renders the section's name instead.
+ */
+const SECTION_TABS = { Portfolio: TABS, Spending: SPEND_TABS };
+
+/**
+ * How long refresh's status stays on screen, in ms — the prototype's number.
+ *
+ * Transient by design rather than by decoration. The drawer beat a bottom section bar on a
+ * vertical budget (48px against 147px, 181px with the home bar), and a status line that
+ * never leaves spends that budget for the rest of the session. It applies at every width,
+ * because the alternative is a `matchMedia` branch for a four-second string.
+ *
+ * Failures share the clock. "refresh failed: …" is not actionable where it sits — you
+ * retry by tapping the control again — so a second code path to keep it would buy nothing.
+ *
+ * `tests/shell.spec.js` cross-references this number rather than importing it: it is what
+ * lets that spec tell "the strip went because the section changed" from "the strip went
+ * because the clock ran out".
+ */
+const STATUS_MS = 4000;
+
 export default function App() {
   const [section, setSection] = useState("Portfolio");
   const [tab, setTab] = useState("Overview");
@@ -39,6 +63,10 @@ export default function App() {
   const [busy, setBusy] = useState(false);
   const [msg, setMsg] = useState("");
   const [ver, setVer] = useState(0);            // bump to remount active tab
+  // The whole state cost of the phone navigation shell. Below 640px the sidebar is an
+  // off-canvas drawer behind the app bar's `☰`; at every other width this is dead weight,
+  // because the rail is never hidden and nothing reads it.
+  const [drawerOpen, setDrawerOpen] = useState(false);
   const View = TABS[tab];
   const SpendView = SPEND_TABS[spendTab];
   const { user, logout } = useAuth() || {};
@@ -46,6 +74,12 @@ export default function App() {
   const canSpend = (user?.features || []).includes("spending");
   // Losing the capability mid-session must not leave the user staring at an empty pane.
   const activeSection = section === "Spending" && !canSpend ? "Portfolio" : section;
+
+  useEffect(() => {
+    if (!msg) return;
+    const t = setTimeout(() => setMsg(""), STATUS_MS);
+    return () => clearTimeout(t);
+  }, [msg]);
 
   async function refreshPrices() {
     setBusy(true);
@@ -65,17 +99,39 @@ export default function App() {
     }
   }
 
+  // One handler behind both section controls — the rail at desktop and the drawer on a
+  // phone are the same markup, so there is only ever one of these to keep in step.
+  function chooseSection(name) {
+    setSection(name);
+    setDrawerOpen(false);           // a no-op above 640px, where nothing opened
+    posthog.capture("section_navigated", { section: name });
+  }
+
+  // Likewise for the tab strip and the app bar's `<select>`: two controls, one code path,
+  // which is what keeps the analytics event from firing on one of them and not the other.
+  function chooseTab(name) {
+    if (activeSection === "Portfolio") {
+      setTab(name);
+      posthog.capture("portfolio_tab_changed", { tab: name });
+    } else {
+      setSpendTab(name);
+    }
+  }
+
   const navItem = (name, testid) => (
     <div className={"navitem" + (activeSection === name ? " on" : "")}
-         data-testid={testid} onClick={() => {
-           setSection(name);
-           posthog.capture("section_navigated", { section: name });
-         }}>{name}</div>
+         data-testid={testid} onClick={() => chooseSection(name)}>{name}</div>
   );
+
+  const barTabs = SECTION_TABS[activeSection];
+  const barTab = activeSection === "Portfolio" ? tab : spendTab;
+  // Refresh is a Portfolio control and stays one — the phone shell moves it, it does not
+  // promote it. Its status strip below the bar is gated on the same expression.
+  const canRefresh = activeSection === "Portfolio";
 
   return (
     <div className="app">
-      <div className="side">
+      <div className={"side" + (drawerOpen ? " on" : "")}>
         <div className="brand">📊 MyApp</div>
         {navItem("Portfolio", "nav-portfolio")}
         {navItem("Net Worth", "nav-networth")}
@@ -88,15 +144,46 @@ export default function App() {
           </div>
         )}
       </div>
+      {/* The drawer's dismissal. Absolutely positioned inside the shell rather than fixed
+          to the viewport, and `aria-hidden` because it duplicates `☰` and the section
+          items rather than offering anything of its own. */}
+      <div className={"scrim" + (drawerOpen ? " on" : "")} data-testid="scrim"
+           aria-hidden="true" onClick={() => setDrawerOpen(false)} />
+      {/* The phone app bar. In the markup at every width and `display: none` above 640px:
+          one component and one code path, rather than a `matchMedia` branch that would
+          make "desktop is unchanged" a claim about JS instead of about layout. */}
+      <div className="bar">
+        <button className="bar-btn" data-testid="menu" aria-label="Navigation menu"
+                aria-expanded={drawerOpen} onClick={() => setDrawerOpen((o) => !o)}>☰</button>
+        {barTabs
+          ? <select className="tabsel" data-testid="tabsel" aria-label="View"
+                    value={barTab} onChange={(e) => chooseTab(e.target.value)}>
+              {Object.keys(barTabs).map((t) => <option key={t} value={t}>{t}</option>)}
+            </select>
+          : <span className="bar-title">{activeSection}</span>}
+        {canRefresh && (
+          <button className="bar-btn" data-testid="bar-refresh" aria-label="Refresh prices"
+                  onClick={refreshPrices} disabled={busy}>{busy ? "…" : "↻"}</button>
+        )}
+      </div>
+      {/* Refresh's status on a phone: a strip *between* the bar and the pane, so it pushes
+          content down instead of covering the first row of it. A flex child of the shell,
+          never an overlay — which is also why it cannot collide with the home bar. Above
+          640px this is `display: none` and the same string renders in `.tabs-right`.
+
+          Gated on `canRefresh`, not on `msg` alone. `.refresh-msg` lives inside the
+          Portfolio branch, so at desktop leaving the section takes the message with it; the
+          same gate here is what stops "12 updated" sitting above Net Worth, reporting on a
+          control that is not on screen. `STATUS_MS` would clear it seconds later either
+          way — which is exactly why the gate has to be written rather than relied on. */}
+      {canRefresh && msg && <div className="toast" role="status">{msg}</div>}
       <div className="main">
         {activeSection === "Portfolio" && (
           <>
             <div className="tabs">
               {Object.keys(TABS).map((t) => (
-                <div key={t} className={"tab" + (t === tab ? " on" : "")} onClick={() => {
-                  setTab(t);
-                  posthog.capture("portfolio_tab_changed", { tab: t });
-                }}>
+                <div key={t} className={"tab" + (t === tab ? " on" : "")}
+                     onClick={() => chooseTab(t)}>
                   {t}
                 </div>
               ))}
@@ -115,7 +202,8 @@ export default function App() {
           <>
             <div className="tabs">
               {Object.keys(SPEND_TABS).map((t) => (
-                <div key={t} className={"tab" + (t === spendTab ? " on" : "")} onClick={() => setSpendTab(t)}>
+                <div key={t} className={"tab" + (t === spendTab ? " on" : "")}
+                     onClick={() => chooseTab(t)}>
                   {t}
                 </div>
               ))}

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -21,13 +21,79 @@ body { margin: 0; background: var(--bg); color: var(--txt);
    reflow mid-interaction. No `height: 100vh` fallback pair: `svh` is Safari 15.4 /
    Chrome 108 / Firefox 101, universally available since 2022, and a fallback would leave
    behind the literal this rule exists to remove. */
-.app { display: flex; height: 100svh; }
+/* `position: relative` is the shell's other job below 640px: the drawer and its scrim are
+   `absolute` *inside* it, never `fixed` to the viewport. Fixed chrome is what strands
+   itself under the iOS keyboard and under a retracting browser toolbar; containing it in a
+   shell that is already `100svh` makes both problems disappear without a line of JS. It
+   costs nothing above the tier — nothing else in the app positions against it. */
+.app { display: flex; height: 100svh; position: relative; }
 .side { width: 200px; flex: none; border-right: 1px solid var(--line); padding: 16px 0; background: var(--panel); }
 .brand { font-weight: 700; padding: 4px 18px 16px; font-size: 16px; }
 .navitem { padding: 9px 18px; cursor: pointer; color: var(--mut); font-weight: 600; }
 .navitem.on { color: var(--txt); background: var(--panel2); border-left: 3px solid var(--acc); }
 .navitem.dim { opacity: .4; cursor: default; font-weight: 500; font-size: 13px; }
-.main { flex: 1; padding: 22px 28px; overflow: auto; display: flex; flex-direction: column; min-width: 0; }
+/* The horizontal guard is unconditional while the *value* follows the width — 28px here,
+   14px in the phone block. A rotated phone is 844px wide and therefore exits that block
+   entirely, so a landscape guard written inside it would be dead in the one orientation it
+   exists for. The longhands MUST follow the shorthand; the shorthand resets all four. */
+.main { flex: 1; padding: 22px 28px;
+  padding-left: max(28px, env(safe-area-inset-left));
+  padding-right: max(28px, env(safe-area-inset-right));
+  overflow: auto; display: flex; flex-direction: column; min-width: 0; }
+
+/* ─── the phone shell's parts ───────────────────────────────────────────────────────────
+   The app bar, its toast strip and the drawer's scrim. All three render at every width and
+   are `display: none` above the phone tier: one component, no `matchMedia`, and "desktop
+   is unchanged" reduces to "these take no space" rather than to a claim about a JS branch.
+
+   Their safe-area guards are written HERE rather than in the phone block, and that is the
+   point. `env(safe-area-inset-left/right)` matters in landscape — the only orientation
+   where the notch is at the side — and a rotated phone is 844px wide. Guarding `.app`
+   instead was rejected: it insets the bar's *background* too, leaving an unpainted strip
+   down the side of the notch.
+
+   `content-box` on the bar so the top inset ADDS to it instead of eating it. Under the
+   app-wide `border-box`, `min-height: 48px` would swallow a 47px inset and crush the bar
+   to a line — and 48px is the number the whole drawer-versus-bottom-bar trade was decided
+   on (a bottom section bar costs 147px, 181px with the home bar: 21% of an 844px screen). */
+.bar { display: none; flex: none; align-items: center; gap: 10px;
+  background: var(--panel); border-bottom: 1px solid var(--line);
+  box-sizing: content-box; min-height: 48px;
+  padding-top: max(0px, env(safe-area-inset-top));
+  padding-left: max(12px, env(safe-area-inset-left));
+  padding-right: max(12px, env(safe-area-inset-right)); }
+/* `--tap`'s second call site, and the reason it is square: these are bare glyphs sitting
+   adjacent to a form control, which is the shape the token was declared for. 44 inside a
+   48px bar, so the floor costs the budget nothing. */
+.bar-btn { flex: none; display: flex; align-items: center; justify-content: center;
+  min-width: var(--tap); min-height: var(--tap);
+  background: var(--panel2); border: 1px solid var(--line); color: var(--txt);
+  border-radius: 8px; font: inherit; font-size: 18px; font-weight: 600; cursor: pointer; }
+.bar-btn:disabled { opacity: .5; cursor: default; }
+/* The tab picker. Six items beat a horizontally scrolling strip, which pushes options off
+   the edge with nothing to say they are there; the native control shows all of them in one
+   full-height sheet on one tap and inherits the platform's accessibility for free.
+   `font-size` is restated after `font: inherit` deliberately — the app's own form rule sets
+   `font: inherit`, which is exactly what would silently win the inherited 14px back, and at
+   14px iOS zooms the viewport to 16/14 = 114% on focus and does not zoom out again. */
+.tabsel { flex: 1; min-width: 0; min-height: var(--tap);
+  background: var(--panel2); border: 1px solid var(--line); color: var(--txt);
+  border-radius: 8px; padding: 0 10px; font: inherit; font-size: 16px; font-weight: 600; }
+/* Net Worth owns no tabs, so the picker's slot carries the section's name instead of an
+   empty control. It is also the only thing on a phone that names where you are — with the
+   drawer shut, `☰ [Overview ▾] ↻` is knowingly ambiguous between Portfolio and Spending,
+   which both own a tab called Overview. Accepted: you arrive at a view by tapping it. */
+.bar-title { flex: 1; min-width: 0; font-weight: 700; font-size: 16px;
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+/* Refresh's status, as a strip between the bar and the pane — and only for `STATUS_MS`;
+   `App.jsx` says why it leaves. Muted rather than the prototype's green: the same string
+   carries "refresh failed: …", and a success colour on a failure is worse than none. */
+.toast { display: none; flex: none; font-size: 12px; color: var(--mut);
+  background: var(--panel2); border-bottom: 1px solid var(--line);
+  padding: 8px 14px;
+  padding-left: max(14px, env(safe-area-inset-left));
+  padding-right: max(14px, env(safe-area-inset-right)); }
+.scrim { display: none; }
 /* A view that fills the main pane so a section inside it can own the vertical scroll. */
 .fillpane { flex: 1 1 auto; min-height: 0; display: flex; flex-direction: column; }
 .fillpane > .grow { flex: 1 1 auto; min-height: 0; display: flex; flex-direction: column; overflow: hidden; }
@@ -154,14 +220,15 @@ input, select, textarea { background: var(--panel2); border: 1px solid var(--lin
      rather than 14px because under `100svh` this pane's bottom edge *is* the screen's, so
      the last row of a scrolled list would otherwise sit under the home indicator.
 
-     TRAP for the phone shell: today `.main` is the top of the viewport, so guarding the
-     top inset here is what clears the notch. Once the app bar lands above it, the bar
-     clears the notch instead and `env(safe-area-inset-top)` — which is viewport-relative,
-     not parent-relative — keeps returning the full inset here, which would double-pad.
-     That rule belongs to whoever adds the bar, not to a later reader guessing. */
+     THE TOP INSET IS NO LONGER GUARDED HERE, and that is the shell landing rather than an
+     omission. `.main` used to be the top of the viewport, so this is where the notch was
+     cleared; the app bar sits above it now and clears the notch itself. Because
+     `env(safe-area-inset-top)` is viewport-relative rather than parent-relative it keeps
+     returning the full inset to a pane that no longer touches the top of the screen, so
+     leaving the guard here would pay for the notch twice and start the pane ~47px down.
+     The bottom still guards: under `100svh` this pane's bottom edge *is* the screen's. */
   .main {
     padding: 14px;
-    padding-top: max(14px, env(safe-area-inset-top));
     padding-left: max(14px, env(safe-area-inset-left));
     padding-right: max(14px, env(safe-area-inset-right));
     padding-bottom: max(20px, env(safe-area-inset-bottom));
@@ -175,4 +242,54 @@ input, select, textarea { background: var(--panel2); border: 1px solid var(--lin
      buttons sitting adjacent, and one selector writing it differently is how a floor stops
      being one. The flex centres the label in the box `min-height` grew — `.nw-del`'s shape. */
   .navitem { min-height: var(--tap); min-width: var(--tap); display: flex; align-items: center; }
+
+  /* ── the navigation shell ──
+     The shell becomes a column and the two bars become ordinary flex children of it. The
+     rail leaves the flow entirely — it is the drawer now — so `.main` is the only thing
+     left to take the width, and it stays the scroll owner it already was. */
+  .app { flex-direction: column; }
+  .bar { display: flex; }
+  .toast { display: block; }
+  /* The desktop strip goes whole, `.tabs-right` with it: the six tabs become the app bar's
+     `<select>` and Refresh becomes its icon. Nothing in that group needs a phone home.
+
+     `.main > .tabs`, not `.tabs`. `ByCategory.jsx:95` borrows this class for its own view
+     header — an `<h3>` and a year `<select>` — for the flex row and nothing else, with the
+     border overridden inline. It is nested inside the view, so the child combinator is what
+     separates the navigation strip from a heading that happens to reuse its layout. */
+  .main > .tabs { display: none; }
+
+  /* TODAY'S RAIL, RESTYLED — not a second navigation built beside it. There is exactly one
+     `.side` in the app, so "the drawer holds every item the sidebar holds" is a structural
+     fact rather than two lists somebody has to keep in step; brand, sections, the dimmed
+     Settings entry and the signed-in footer all arrive unchanged.
+
+     `absolute`, never `fixed` — see `.app`'s comment. `visibility` alongside the transform
+     because a panel that is only translated off-canvas is still in the focus order, which
+     is how a keyboard or switch user lands on items they cannot see; it animates because
+     `visibility` transitions discretely, flipping at the far end of the slide out.
+
+     The `env()` guard here stays INSIDE the block, unlike the app bar's. The bar renders
+     wherever it is turned on, so its guard has to outlive the width condition; the drawer
+     does not exist outside this rule at all — `position: absolute` and the transform are
+     in it too — so hoisting one declaration out of a rule the element depends on would
+     leave a guard for a rail. When the tablet tier brings this shell to 844×390 on its
+     height guard, the whole rule travels and the guard travels with it. */
+  .side { position: absolute; top: 0; bottom: 0; left: 0; z-index: 6; width: 246px;
+    display: flex; flex-direction: column; overflow-y: auto;
+    transform: translateX(-100%); visibility: hidden;
+    transition: transform .2s, visibility .2s;
+    padding-bottom: max(16px, env(safe-area-inset-bottom));
+    padding-left: max(0px, env(safe-area-inset-left)); }
+  .side.on { transform: none; visibility: visible; }
+  .scrim { display: block; position: absolute; inset: 0; z-index: 5;
+    background: rgba(0, 0, 0, .55); opacity: 0; visibility: hidden; pointer-events: none;
+    transition: opacity .18s, visibility .18s; }
+  .scrim.on { opacity: 1; visibility: visible; pointer-events: auto; }
+  /* `.side` is a flex column only here, so this is where `margin-top: auto` can sink the
+     footer to the bottom of the drawer. Above the tier it keeps its 24px. */
+  .side-user { margin-top: auto; }
+  /* Square, like every other call site of `--tap` — a floor one selector writes differently
+     stops being a floor. Free here: the label is already ~76px wide. */
+  .logout-btn { min-height: var(--tap); min-width: var(--tap); }
 }

--- a/web/tests/foundations.spec.js
+++ b/web/tests/foundations.spec.js
@@ -16,55 +16,9 @@
 import { expect, test } from "@playwright/test";
 import { PHONE_TIER_BELOW, PHONE_TIER_EDGE, VIEWPORTS } from "./viewports.js";
 import { loadApp, loadSignIn } from "./support/app.js";
+import { declarationsFor, paddingOf } from "./support/css.js";
 
 const viewportOf = (projectName) => VIEWPORTS.find((v) => v.name === projectName);
-
-/**
- * Every rule in the shipped stylesheets whose selector is exactly `selector`, with the
- * media condition it sits under and its *specified* declarations as `{ property: value }`.
- *
- * Specified, not computed: `getComputedStyle` hands back `14px` for both a bare literal and
- * a `max(14px, env(...))`, which is exactly the distinction these gates exist to make.
- *
- * Read from the browser rather than from `styles.css`, so what is asserted is what ships —
- * and the difference is not academic. The build expands `padding: 14px` into four longhands
- * before this ever sees it, so the source's shorthand-then-longhand ordering (get it wrong
- * and the shorthand silently resets all four sides) does not exist here to check. What
- * catches that mistake is the resolved-padding test below, where the bottom would come back
- * 14px instead of 20px.
- */
-function declarationsFor(page, selector) {
-  return page.evaluate((sel) => {
-    const found = [];
-    const walk = (rules, media) => {
-      for (const rule of rules) {
-        // Matched *before* descending, not instead of: a `CSSStyleRule` carries its own
-        // (empty) `cssRules` list now that CSS nesting exists, so a style rule and a
-        // grouping rule are no longer distinguishable by that property being present.
-        if (rule.selectorText === sel) {
-          const decls = {};
-          for (const prop of rule.style) decls[prop] = rule.style.getPropertyValue(prop);
-          found.push({ media: media ?? null, decls });
-        }
-        if (rule.cssRules) walk(rule.cssRules, rule.conditionText ?? media);
-      }
-    };
-    for (const sheet of document.styleSheets) {
-      let rules;
-      try { rules = sheet.cssRules; } catch { continue; }   // a cross-origin sheet, if one ever appears
-      walk(rules, null);
-    }
-    return found;
-  }, selector);
-}
-
-/** The four resolved padding sides of one element, as CSS pixel strings. */
-function paddingOf(page, selector) {
-  return page.evaluate((sel) => {
-    const s = getComputedStyle(document.querySelector(sel));
-    return { top: s.paddingTop, right: s.paddingRight, bottom: s.paddingBottom, left: s.paddingLeft };
-  }, selector);
-}
 
 test("the document opts into the safe area", async ({ page, baseURL }) => {
   await loadApp(page, baseURL);
@@ -83,9 +37,17 @@ test("the shell is sized in svh and the page itself does not scroll", async ({ p
   await loadApp(page, baseURL);
 
   const rules = await declarationsFor(page, ".app");
-  expect(rules, "`.app` is declared in exactly one place").toHaveLength(1);
-  expect(rules[0].media, "`.app`'s height is unconditional — every tier owns its own scroll").toBeNull();
-  expect(rules[0].decls.height, "the shell is not `100svh`").toBe("100svh");
+  const unconditional = rules.filter((r) => r.media === null);
+  expect(unconditional, "`.app`'s base rule").toHaveLength(1);
+  expect(unconditional[0].decls.height, "the shell is not `100svh`").toBe("100svh");
+
+  // The height is unconditional — every tier owns its own scroll, so no tier restates it.
+  // The phone tier *does* have a rule here now: the shell flips to a column so the app bar
+  // and its toast can be flex children of it. What that rule must not do is touch the
+  // height, which is the one thing about the shell that is the same everywhere.
+  for (const r of rules.filter((r) => r.media !== null)) {
+    expect(r.decls.height, `\`.app\` restates its height under \`${r.media}\``).toBeUndefined();
+  }
   // This cannot tell `100svh` from a `height: 100vh; height: 100svh` fallback pair — a
   // declaration block holds one `height`, and the later valid value is the only one that
   // survives into the CSSOM. `inventory.spec.js` grepping `web/src` is what holds that half.
@@ -104,22 +66,29 @@ test("the shell is sized in svh and the page itself does not scroll", async ({ p
 });
 
 test.describe("the phone content gutter", () => {
-  test("all four sides pad with one max(<literal>, env()) idiom", async ({ page, baseURL }) => {
-    await loadApp(page, baseURL);
-    const rules = await declarationsFor(page, ".main");
-    const phone = rules.filter((r) => r.media?.includes(PHONE_TIER_EDGE));
-    expect(phone, "no `.main` rule in the phone media block").toHaveLength(1);
+  test("pads with one max(<literal>, env()) idiom on every side that still has an edge",
+    async ({ page, baseURL }) => {
+      await loadApp(page, baseURL);
+      const rules = await declarationsFor(page, ".main");
+      const phone = rules.filter((r) => r.media?.includes(PHONE_TIER_EDGE));
+      expect(phone, "no `.main` rule in the phone media block").toHaveLength(1);
 
-    // Pad, never offset — one shape on all four sides, so there is no second idiom for a
-    // later rule to copy from. The bottom is 20px rather than 14px on its own reasoning:
-    // under `100svh` this pane's bottom edge *is* the screen's.
-    expect(phone[0].decls).toMatchObject({
-      "padding-top": "max(14px, env(safe-area-inset-top))",
-      "padding-left": "max(14px, env(safe-area-inset-left))",
-      "padding-right": "max(14px, env(safe-area-inset-right))",
-      "padding-bottom": "max(20px, env(safe-area-inset-bottom))",
+      // Pad, never offset — one shape, so there is no second idiom for a later rule to copy
+      // from. The bottom is 20px rather than 14px on its own reasoning: under `100svh` this
+      // pane's bottom edge *is* the screen's.
+      //
+      // THE TOP IS NOT HERE ANY MORE, and its absence is the assertion. The app bar landed
+      // above this pane, so the pane no longer touches the top of the screen — but
+      // `env(safe-area-inset-top)` is viewport-relative rather than parent-relative and
+      // would keep handing back the full inset, paying for the notch twice. The bar carries
+      // that guard now; `shell.spec.js` holds both halves of the handover.
+      expect(phone[0].decls).toMatchObject({
+        "padding-top": "14px",
+        "padding-left": "max(14px, env(safe-area-inset-left))",
+        "padding-right": "max(14px, env(safe-area-inset-right))",
+        "padding-bottom": "max(20px, env(safe-area-inset-bottom))",
+      });
     });
-  });
 
   test("resolves to 14/14/20/14 on a phone and is untouched above the tier", async ({ page, baseURL }, testInfo) => {
     const vp = viewportOf(testInfo.project.name);
@@ -155,11 +124,11 @@ test("the tap token is declared, and referenced rather than repeated", async ({ 
     .toBe("var(--tap)");
   expect(phone[0].decls["min-width"], "height-only — the floor was decided square").toBe("var(--tap)");
 
-  // What is deliberately NOT here: that a nav item measures 44px on a phone. The 44px target
-  // is a `RESPONSIVE.md` universal gate belonging to the shell slice, and it is not true of
-  // the app yet — the sidebar this rule lands on is not the navigation a phone will have.
-  // Asserting it here would move a checklist gate into the suite ahead of the behaviour,
-  // which is the one thing that file says about itself.
+  // What is deliberately NOT here: that a nav item measures 44px on a phone. That gate
+  // waited for the sidebar to become navigation a phone can actually reach, and now that it
+  // has, it lives in `shell.spec.js` — measured inside an open drawer, which is the only
+  // place the number means anything. This file keeps the half it owns: that the token is
+  // declared once and referenced rather than copied.
 });
 
 test.describe("sign-in", () => {

--- a/web/tests/hscroll-baseline.js
+++ b/web/tests/hscroll-baseline.js
@@ -23,7 +23,7 @@
  * Above 1024px there is no gate and therefore no entries here — `HSCROLL_GATE_APPLIES_BELOW`
  * in `viewports.js` says why those three viewports are exempt.
  *
- * LOWERED TWICE SO FAR.
+ * LOWERED THREE TIMES SO FAR.
  *
  * 1. The unconditional fixes. `.grid2`'s `auto-fit` did most of it: two 419px tracks side by
  *    side became one, so `Portfolio › Overview` went 619 → 288 at 360px, `Spending › By
@@ -38,67 +38,79 @@
  *    fitting. Four more reach zero — `Dividends` at 390, and `Overview` / `Options` / `By
  *    Category` at 639, all of which were within 13px of it. The three viewports at or above
  *    640px are untouched, which is the tier boundary doing its job.
+ *
+ * 3. The phone navigation shell. Uniform again, and by a much larger constant: **every gated
+ *    phone row falls by 200, or to zero where 200 was more than the whole overflow** —
+ *    because the 200px sidebar left the flow entirely. It is the drawer now, so `.main`
+ *    finally gets the whole width of the screen. This is the largest single drop the ratchet
+ *    will ever see and it buys back nothing structural: Holdings still puts 1001px of table
+ *    past the edge of the pane at 390, because a table that wants 1391px does not care that
+ *    the pane grew by 200. The pinned-column work is what moves those. The four rows that
+ *    fell short of the full 200 are exactly the four that hit the floor — `Dividends` (29)
+ *    and `Classify` (34) at 360, `Classify` (4) at 390, and `Spending › Overview` (35) at
+ *    639. The three viewports at or above 640px are untouched to the pixel, which is the
+ *    tier boundary doing its job for the second time.
  */
 export const HSCROLL_BASELINE = {
   "small-phone": {
-    "Portfolio › Overview": 274,
-    "Portfolio › Holdings": 1231,
-    "Portfolio › Performance": 707,
-    "Portfolio › Dividends": 29,
-    "Portfolio › Options": 274,
-    "Portfolio › Transactions": 1091,
-    "Portfolio › SecurityDetail": 710,
-    "Net Worth": 549,
-    "Spending › Overview": 314,
-    "Spending › By Category": 274,
-    "Spending › Classify": 34,
-    "Spending › Recurring": 630,
-    "Spending › Transactions": 1067,
+    "Portfolio › Overview": 74,
+    "Portfolio › Holdings": 1031,
+    "Portfolio › Performance": 507,
+    "Portfolio › Dividends": 0,
+    "Portfolio › Options": 74,
+    "Portfolio › Transactions": 891,
+    "Portfolio › SecurityDetail": 510,
+    "Net Worth": 349,
+    "Spending › Overview": 114,
+    "Spending › By Category": 74,
+    "Spending › Classify": 0,
+    "Spending › Recurring": 430,
+    "Spending › Transactions": 867,
   },
   "design-width": {
-    "Portfolio › Overview": 244,
-    "Portfolio › Holdings": 1201,
-    "Portfolio › Performance": 677,
+    "Portfolio › Overview": 44,
+    "Portfolio › Holdings": 1001,
+    "Portfolio › Performance": 477,
     "Portfolio › Dividends": 0,
-    "Portfolio › Options": 244,
-    "Portfolio › Transactions": 1061,
-    "Portfolio › SecurityDetail": 680,
-    "Net Worth": 519,
-    "Spending › Overview": 284,
-    "Spending › By Category": 244,
-    "Spending › Classify": 4,
-    "Spending › Recurring": 600,
-    "Spending › Transactions": 1037,
+    "Portfolio › Options": 44,
+    "Portfolio › Transactions": 861,
+    "Portfolio › SecurityDetail": 480,
+    "Net Worth": 319,
+    "Spending › Overview": 84,
+    "Spending › By Category": 44,
+    "Spending › Classify": 0,
+    "Spending › Recurring": 400,
+    "Spending › Transactions": 837,
   },
   "large-phone": {
-    "Portfolio › Overview": 204,
-    "Portfolio › Holdings": 1161,
-    "Portfolio › Performance": 637,
+    "Portfolio › Overview": 4,
+    "Portfolio › Holdings": 961,
+    "Portfolio › Performance": 437,
     "Portfolio › Dividends": 0,
-    "Portfolio › Options": 204,
-    "Portfolio › Transactions": 1021,
-    "Portfolio › SecurityDetail": 640,
-    "Net Worth": 479,
-    "Spending › Overview": 244,
-    "Spending › By Category": 204,
+    "Portfolio › Options": 4,
+    "Portfolio › Transactions": 821,
+    "Portfolio › SecurityDetail": 440,
+    "Net Worth": 279,
+    "Spending › Overview": 44,
+    "Spending › By Category": 4,
     "Spending › Classify": 0,
-    "Spending › Recurring": 560,
-    "Spending › Transactions": 997,
+    "Spending › Recurring": 360,
+    "Spending › Transactions": 797,
   },
   "phone-tier-last-pixel": {
     "Portfolio › Overview": 0,
-    "Portfolio › Holdings": 952,
-    "Portfolio › Performance": 428,
+    "Portfolio › Holdings": 752,
+    "Portfolio › Performance": 228,
     "Portfolio › Dividends": 0,
     "Portfolio › Options": 0,
-    "Portfolio › Transactions": 812,
-    "Portfolio › SecurityDetail": 431,
-    "Net Worth": 270,
-    "Spending › Overview": 35,
+    "Portfolio › Transactions": 612,
+    "Portfolio › SecurityDetail": 231,
+    "Net Worth": 70,
+    "Spending › Overview": 0,
     "Spending › By Category": 0,
     "Spending › Classify": 0,
-    "Spending › Recurring": 351,
-    "Spending › Transactions": 788,
+    "Spending › Recurring": 151,
+    "Spending › Transactions": 588,
   },
   "tablet-tier-first-pixel": {
     "Portfolio › Overview": 8,

--- a/web/tests/shell.spec.js
+++ b/web/tests/shell.spec.js
@@ -1,0 +1,427 @@
+/**
+ * The phone navigation shell: the drawer, the tab picker, the app bar and its toast.
+ *
+ * THIS IS THE TICKET THAT UNBLOCKS THE REST, and the suite says so structurally rather
+ * than in prose: `support/app.js`'s `openView` now branches on the viewport, so every
+ * gate in `baseline.spec.js` and `unconditional.spec.js` reaches its view on a phone
+ * through the drawer and the `<select>`. "All thirteen views are reachable at 390×844"
+ * is therefore not asserted here — it is asserted thirteen times over there, and would be
+ * a copy if it were also here. What is here is the shell itself.
+ *
+ * WHAT THIS FILE ASSERTS AS DECLARATIONS RATHER THAN GEOMETRY, and why. Two of the
+ * ticket's criteria are about a notch, and `baseline.spec.js`'s "cannot check, ever" list
+ * puts safe-area insets first: Chromium reports every `env(safe-area-inset-*)` as 0 at
+ * every viewport, in both orientations. So "the app bar clears the notch in landscape" has
+ * no geometric form here and is asserted the way `foundations.spec.js` asserts the gutter
+ * — by reading the shipped rule. See `support/css.js`.
+ *
+ * THE LANDSCAPE CRITERION, PRECISELY. A rotated phone is 844px wide and therefore *exits*
+ * the `max-width: 639.98px` block entirely, which is why the app bar's inset guard is
+ * written unconditionally rather than inside it. The height guard that will make the shell
+ * itself appear at 844×390 belongs to the tablet tier, not here; what this ticket owes is
+ * that the guard is already in place wherever the bar renders. Both halves are asserted
+ * below: the declaration is unconditional, and it is *not* in the phone block.
+ */
+import { expect, test } from "@playwright/test";
+import { PHONE_TIER_BELOW, PHONE_TIER_EDGE } from "./viewports.js";
+import {
+  VIEWS,
+  drawer,
+  fixedPositionedElements,
+  loadApp,
+  menuButton,
+  openView,
+  scrim,
+  tabSelect,
+} from "./support/app.js";
+import { declarationsFor } from "./support/css.js";
+
+/**
+ * How long refresh's status strip stays up, in ms.
+ *
+ * The fourth site a number is written twice because JS cannot read a constant out of the
+ * app it drives — `App.jsx`'s `STATUS_MS` is the other half, and the two cross-reference in
+ * comments the way `640` already does across three files. It is here so the section-gate
+ * assertion below can prove the strip left because the section changed rather than because
+ * the clock ran out.
+ */
+const STATUS_MS = 4000;
+
+const boxOf = (locator) => locator.evaluate((el) => {
+  const r = el.getBoundingClientRect();
+  return { x: r.x, y: r.y, w: r.width, h: r.height, right: r.right, bottom: r.bottom };
+});
+
+// ─── the phone tier ─────────────────────────────────────────────────────────────────────
+
+test.describe("below 640px the navigation is a drawer and a picker", () => {
+  // The `viewport` option fixture is the project's own size, which is what makes this read
+  // as "this group is the phone tier" rather than as a lookup into a table of names.
+  test.skip(
+    ({ viewport }) => viewport.width >= PHONE_TIER_BELOW,
+    "the phone tier only — above 640 the rail and the tab strip are the navigation"
+  );
+
+  test("the app bar replaces the rail and the strip", async ({ page, baseURL }) => {
+    await openView(page, baseURL, "Portfolio › Overview");
+
+    await expect(page.locator(".bar"), "no app bar on a phone").toBeVisible();
+    // The strip and its right-hand group both go. `.tabs-right` is where Refresh and its
+    // status message live at desktop, and the ticket deletes that group below 640 rather
+    // than reflowing it: the button becomes an icon in the bar and the message becomes a
+    // strip under it.
+    await expect(page.locator(".tabs"), "the desktop tab strip still renders").toBeHidden();
+    await expect(page.locator(".tabs-right"), "the right-hand tab group still renders").toBeHidden();
+
+    // The bar is the 48px the whole decision was made on. Variant A — both nav levels
+    // permanently visible — measured 147px, 181px with the home bar, and was rejected at
+    // 21% of an 844px screen. A bar that quietly grew past ~64px would have re-opened that
+    // trade without anyone noticing, so the budget is a gate rather than a comment.
+    const bar = await boxOf(page.locator(".bar"));
+    expect(bar.h, "the app bar has outgrown the vertical budget the drawer was chosen on")
+      .toBeLessThanOrEqual(64);
+  });
+
+  test("the drawer starts closed, opens on the hamburger, and closes on the scrim",
+    async ({ page, baseURL }) => {
+      await openView(page, baseURL, "Portfolio › Overview");
+
+      // Closed: off-canvas to the left, and out of the accessibility and focus order with
+      // it — a drawer that is merely translated is still tabbable, which is how a phone
+      // user lands focus on something they cannot see.
+      await expect(drawer(page), "the drawer is on screen before anything opened it").toBeHidden();
+      await expect(scrim(page)).toBeHidden();
+
+      await menuButton(page).click();
+      await expect(drawer(page)).toBeVisible();
+      await expect(scrim(page)).toBeVisible();
+      // Polled rather than measured once: the panel slides, so a single read lands
+      // wherever the 200ms transition happens to be. `toBeVisible` above is satisfied the
+      // instant `visibility` flips, which is at the *start* of the slide in.
+      await expect
+        .poll(async () => (await boxOf(drawer(page))).x, { message: "the drawer never arrived on screen" })
+        .toBeGreaterThanOrEqual(-1);
+      const panel = await boxOf(drawer(page));
+      expect(panel.w, "the drawer is wider than the screen it slides over")
+        .toBeLessThan(page.viewportSize().width);
+
+      // The scrim closes it. This is an acceptance criterion in its own right: it is the
+      // only dismissal a thumb finds without aiming.
+      //
+      // Tapped to the right of the drawer rather than at the scrim's own centre: the scrim
+      // spans the whole shell and the drawer sits on top of its left 246px, so the centre
+      // is under the panel. That is the geometry a person taps, not a workaround.
+      await scrim(page).click({ position: { x: page.viewportSize().width - 20, y: 200 } });
+      await expect(drawer(page)).toBeHidden();
+      await expect(scrim(page)).toBeHidden();
+    });
+
+  test("the drawer is the rail itself, holding every item it holds today",
+    async ({ page, baseURL }) => {
+      await openView(page, baseURL, "Portfolio › Overview");
+      await menuButton(page).click();
+
+      // "Verbatim" as a structural fact rather than a promise: there is one `.side` in the
+      // document and the phone tier restyles it, so the drawer cannot hold a different set
+      // of items from the rail — there is no second list to drift from the first.
+      await expect(page.locator(".side"), "a second navigation list exists to drift from the rail")
+        .toHaveCount(1);
+
+      const side = drawer(page);
+      await expect(side.locator(".brand")).toBeVisible();
+      await expect(side.getByTestId("nav-portfolio")).toBeVisible();
+      await expect(side.getByTestId("nav-networth")).toBeVisible();
+      await expect(side.getByTestId("nav-spending")).toBeVisible();
+      await expect(side.locator(".navitem.dim"), "the dimmed Settings entry").toBeVisible();
+      await expect(side.locator(".side-email"), "the signed-in email").toBeVisible();
+      await expect(side.locator(".logout-btn"), "Sign out").toBeVisible();
+
+      // And nothing was lifted into the bar instead. The bar holds three controls, none of
+      // them a section.
+      await expect(page.locator(".bar .navitem")).toHaveCount(0);
+
+      // Reachable means tappable. `--tap` is 44px and the drawer is a fully-responsive
+      // surface, so the floor applies to everything in it that is a control.
+      const targets = await page.$$eval(
+        ".side .navitem, .side .logout-btn",
+        (els) => els.map((el) => {
+          const r = el.getBoundingClientRect();
+          return { w: r.width, h: r.height, text: el.textContent.trim().slice(0, 20) };
+        })
+      );
+      expect(targets.length).toBeGreaterThan(0);
+      for (const t of targets) {
+        // Square, not tall: `--tap` was decided as a square floor, and `min(w, h)` is what
+        // stops one selector writing it as height-only.
+        expect.soft(Math.min(t.w, t.h), `"${t.text}" is ${Math.round(t.w)}x${Math.round(t.h)}`)
+          .toBeGreaterThanOrEqual(44);
+      }
+    });
+
+  test("choosing a section switches the pane and closes the drawer behind it",
+    async ({ page, baseURL }) => {
+      await openView(page, baseURL, "Portfolio › Overview");
+
+      await menuButton(page).click();
+      await drawer(page).getByTestId("nav-networth").click();
+
+      // Left open, the scrim would sit over every pane the rest of the suite measures
+      // through — and over the app bar, so the next tap does nothing.
+      await expect(drawer(page)).toBeHidden();
+      await expect(scrim(page)).toBeHidden();
+      await expect(page.getByTestId("networth-summary")).toBeVisible({ timeout: 20_000 });
+    });
+
+  test("nothing computes to position: fixed, with the drawer open", async ({ page, baseURL }) => {
+    await openView(page, baseURL, "Portfolio › Overview");
+    await menuButton(page).click();
+    await expect(drawer(page)).toBeVisible();
+
+    // `baseline.spec.js` asserts this for thirteen views at ten viewports, but only with
+    // the drawer shut — and the drawer and its scrim are the two elements in the whole app
+    // that a reflex would make `position: fixed`. Fixed is what strands chrome under the
+    // iOS keyboard and under a retracting toolbar; absolute inside a `100svh` shell is what
+    // makes the shell immune to both without a line of JS.
+    expect(await fixedPositionedElements(page)).toEqual([]);
+  });
+
+  test("the tab picker is a native select at 16px, listing every tab of the section",
+    async ({ page, baseURL }) => {
+      await openView(page, baseURL, "Portfolio › Overview");
+      const select = tabSelect(page);
+      await expect(select).toBeVisible();
+      expect(await select.evaluate((el) => el.tagName)).toBe("SELECT");
+
+      // 16px, and computed rather than declared: the inherited 14px is what makes iOS zoom
+      // the viewport to 16/14 = 114% on focus and leave it there. `font: inherit` on the
+      // app's base form rule is exactly the sort of thing that silently wins this back.
+      expect(
+        await select.evaluate((el) => getComputedStyle(el).fontSize),
+        "the picker inherited 14px — iOS will zoom the viewport to 114% on focus and stay there"
+      ).toBe("16px");
+
+      // Six items, none of them off-screen. This is the reason a native picker beat a
+      // horizontally scrolling strip: the strip hides options with no affordance that they
+      // exist, and six is the worst case.
+      const options = await select.evaluate((el) => [...el.options].map((o) => o.value));
+      expect(options).toEqual([
+        "Overview", "Holdings", "Performance", "Dividends", "Options", "Transactions",
+      ]);
+      await expect(select).toHaveValue("Overview");
+
+      // Net Worth has no tabs, so the picker is replaced by the section's name rather than
+      // rendering an empty control.
+      await menuButton(page).click();
+      await drawer(page).getByTestId("nav-networth").click();
+      await expect(tabSelect(page)).toHaveCount(0);
+      await expect(page.locator(".bar-title")).toHaveText("Net Worth");
+    });
+
+  test("refresh is icon-only, and its status displaces content rather than covering it",
+    async ({ page, baseURL }) => {
+      await loadApp(page, baseURL);
+      // Registered after `mockApi`'s catch-all, so it wins: Playwright matches routes in
+      // reverse registration order. There is no captured fixture for this path because it
+      // mutates rather than reads, and the suite never lets a mutation reach a server.
+      await page.route("**/api/refresh-prices", (route) =>
+        route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({ ok: 12, fail: 0 }),
+        })
+      );
+      await VIEWS.find((v) => v.name === "Portfolio › Overview").open(page);
+
+      const button = page.getByTestId("bar-refresh");
+      await expect(button).toBeVisible();
+      // Icon-only: the two-word label is what crushed the desktop control to 78x77 in a
+      // strip that had no room for it, and a phone bar has less. The glyph still has to be
+      // a 44px target, and it still has to say what it is to a screen reader.
+      expect((await button.textContent()).trim().length,
+        "the button still carries its text label").toBeLessThanOrEqual(2);
+      expect(await button.getAttribute("aria-label"),
+        "an icon-only control with no accessible name").toBeTruthy();
+      const btn = await boxOf(button);
+      expect(Math.min(btn.w, btn.h)).toBeGreaterThanOrEqual(44);
+
+      await expect(page.locator(".toast"), "the toast is on screen before any refresh ran")
+        .toHaveCount(0);
+      await button.click();
+      const toast = page.locator(".toast");
+      await expect(toast).toBeVisible();
+      await expect(toast).toContainText("12 updated");
+
+      // A flex child, not an overlay. Stated three ways because the reflex fix — absolutely
+      // positioning it under the bar — passes the first two and fails the third, which is
+      // the one a person notices: it would cover the first row of the pane.
+      expect(await toast.evaluate((el) => getComputedStyle(el).position)).toBe("static");
+      const bar = await boxOf(page.locator(".bar"));
+      const strip = await boxOf(toast);
+      const main = await boxOf(page.locator(".main"));
+      expect(strip.y, "the toast overlaps the app bar").toBeGreaterThanOrEqual(bar.bottom - 1);
+      expect(main.y, "the toast covers the top of the pane instead of pushing it down")
+        .toBeGreaterThanOrEqual(strip.bottom - 1);
+
+      // It goes where its control goes. Refresh is a Portfolio control, and at desktop the
+      // message lives inside the Portfolio branch, so leaving the section takes it with it.
+      // Without the same gate the strip would sit above Net Worth reporting on a button
+      // that is not on screen.
+      const shown = Date.now();
+      await menuButton(page).click();
+      await drawer(page).getByTestId("nav-networth").click();
+      await expect(page.getByTestId("bar-refresh")).toHaveCount(0);
+      await expect(toast, "the strip outlived the control it reports on").toHaveCount(0);
+      // ...and it went because the section changed, not because the clock beat us here.
+      // Without this the assertion above would pass on a build with no section gate at all.
+      expect(Date.now() - shown, "too slow to tell the section gate from the auto-dismiss")
+        .toBeLessThan(STATUS_MS);
+    });
+
+  test("the status strip is transient — it leaves on its own", async ({ page, baseURL }) => {
+    await loadApp(page, baseURL);
+    await page.route("**/api/refresh-prices", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ ok: 12, fail: 0 }),
+      })
+    );
+    await VIEWS.find((v) => v.name === "Portfolio › Overview").open(page);
+
+    await page.getByTestId("bar-refresh").click();
+    const toast = page.locator(".toast");
+    await expect(toast).toBeVisible();
+
+    // The whole shell was chosen on a vertical budget — 48px against a bottom bar's 147px —
+    // and a status line that never leaves spends that budget for the rest of the session.
+    // Generous timeout against a tight claim: what is asserted is that it goes at all.
+    await expect(toast, "the strip is permanent — it never gives the budget back")
+      .toHaveCount(0, { timeout: STATUS_MS * 3 });
+  });
+
+  test("the shell is a column that fills the screen, and the pane owns the scroll",
+    async ({ page, baseURL }) => {
+      // Holdings is the tallest thing in the app at this width, so there is genuinely
+      // something below the fold to fail to reach.
+      await openView(page, baseURL, "Portfolio › Holdings");
+
+      const height = page.viewportSize().height;
+      expect(await page.locator(".app").evaluate((el) => getComputedStyle(el).flexDirection))
+        .toBe("column");
+
+      const shell = await boxOf(page.locator(".app"));
+      expect(Math.round(shell.h), "the shell is not the height of the screen").toBe(height);
+      expect(Math.round(shell.bottom), "the shell hangs below the screen").toBe(height);
+
+      // The bottom of the content is reachable: the pane scrolls, and scrolling it to the
+      // end lands at the end. Under `height: 100vh` — which is `100lvh` by spec — the last
+      // strip of a shell that owns its own scroll is unreachable rather than merely clipped.
+      const scrolled = await page.locator(".main").evaluate((el) => {
+        el.scrollTop = el.scrollHeight;
+        return {
+          overflows: el.scrollHeight > el.clientHeight,
+          top: el.scrollTop,
+          max: el.scrollHeight - el.clientHeight,
+        };
+      });
+      expect(scrolled.overflows, "nothing to scroll — pick a taller view for this gate").toBe(true);
+      expect(Math.round(scrolled.top), "the pane will not scroll to its own end")
+        .toBe(Math.round(scrolled.max));
+    });
+});
+
+// ─── above the tier ─────────────────────────────────────────────────────────────────────
+
+test.describe("at 640px and above the navigation is untouched", () => {
+  test.skip(({ viewport }) => viewport.width < PHONE_TIER_BELOW, "the tablet tier and up");
+
+  test("the rail is a rail, the strip is a strip, and the shell's new parts do not render",
+    async ({ page, baseURL }) => {
+      await openView(page, baseURL, "Portfolio › Overview");
+
+      // The rail: in flow, 200px, at the left edge. Not a drawer that happens to be open.
+      const side = page.locator(".side");
+      await expect(side).toBeVisible();
+      const rail = await boxOf(side);
+      expect(Math.round(rail.w)).toBe(200);
+      expect(Math.round(rail.x)).toBe(0);
+      expect(await side.evaluate((el) => getComputedStyle(el).position)).toBe("static");
+
+      await expect(page.locator(".tabs")).toBeVisible();
+      await expect(page.locator(".tabs-right")).toBeVisible();
+      await expect(page.locator(".refresh-btn")).toBeVisible();
+
+      // The phone shell's parts are in the markup at every width — one component, no
+      // `matchMedia` — so what makes desktop unchanged is that they take no space.
+      for (const sel of [".bar", ".scrim"]) {
+        await expect(page.locator(sel), `${sel} renders above the phone tier`).toBeHidden();
+      }
+      await expect(page.locator(".app")).toHaveCSS("flex-direction", "row");
+    });
+});
+
+// ─── the declarations, at every viewport ────────────────────────────────────────────────
+
+test("the app bar's safe-area guard is unconditional, not inside the phone block",
+  async ({ page, baseURL }) => {
+    await loadApp(page, baseURL);
+    const rules = await declarationsFor(page, ".bar");
+    const unconditional = rules.filter((r) => r.media === null);
+    expect(unconditional, "`.bar` has no unconditional rule to carry the guard").toHaveLength(1);
+
+    // A rotated phone is 844px wide and exits the `max-width: 639.98px` block, so a guard
+    // written inside it is dead in the one orientation it exists for. That was a live
+    // contradiction in the shell's own prototype, caught by the gutter ticket; this is the
+    // gate that keeps it from coming back.
+    expect(unconditional[0].decls).toMatchObject({
+      "padding-left": "max(12px, env(safe-area-inset-left))",
+      "padding-right": "max(12px, env(safe-area-inset-right))",
+      "padding-top": "max(0px, env(safe-area-inset-top))",
+    });
+    // Guarding `.app` instead would inset the bar's *background* and leave an unpainted
+    // strip down the side of the notch. So the bar pads itself, and the inset ADDS to its
+    // height rather than eating into the 48px the whole decision was measured on.
+    expect(unconditional[0].decls["box-sizing"],
+      "border-box — the notch inset eats the bar's 48px instead of adding to it")
+      .toBe("content-box");
+
+    const phone = rules.filter((r) => r.media?.includes(PHONE_TIER_EDGE));
+    expect(phone, "`.bar` has more than a display flip in the phone block").toHaveLength(1);
+    expect(Object.keys(phone[0].decls), "the phone block should only turn the bar on")
+      .toEqual(["display"]);
+  });
+
+test("the content pane's landscape guard is unconditional too", async ({ page, baseURL }) => {
+  await loadApp(page, baseURL);
+  const unconditional = (await declarationsFor(page, ".main")).filter((r) => r.media === null);
+  expect(unconditional).toHaveLength(1);
+
+  // Same reasoning as the bar, one element down, and the same split the tablet tier uses
+  // throughout: the *value* follows width — 28px above the tier, 14px below it — and the
+  // *guard* is unconditional, because the notch does not care which tier you are in.
+  expect(unconditional[0].decls).toMatchObject({
+    "padding-left": "max(28px, env(safe-area-inset-left))",
+    "padding-right": "max(28px, env(safe-area-inset-right))",
+  });
+});
+
+test("the pane stops guarding the top inset now that the bar is above it",
+  async ({ page, baseURL }) => {
+    await loadApp(page, baseURL);
+    const phone = (await declarationsFor(page, ".main")).filter((r) =>
+      r.media?.includes(PHONE_TIER_EDGE)
+    );
+    expect(phone).toHaveLength(1);
+
+    // The trap this ticket inherited, written down. `env(safe-area-inset-top)` is
+    // viewport-relative rather than parent-relative, so it keeps returning the full inset
+    // to a pane that no longer touches the top of the screen. Left as it was, the notch
+    // would be paid for twice — once by the bar, once here — and the pane would start
+    // ~47px down on a notched phone.
+    expect(phone[0].decls["padding-top"],
+      "the pane still guards the top inset; with the app bar above it, that double-pads")
+      .toBe("14px");
+    // The other three sides are unchanged: bottom still guards, because under `100svh`
+    // the pane's bottom edge is still the screen's.
+    expect(phone[0].decls["padding-bottom"]).toBe("max(20px, env(safe-area-inset-bottom))");
+  });

--- a/web/tests/support/app.js
+++ b/web/tests/support/app.js
@@ -5,9 +5,17 @@
  * reached by clicking, not by navigating to a URL. That is a property of the app under
  * test, not a shortcut: the same clicks are what a person does, which is what makes the
  * gates measure a real render rather than a mounted component.
+ *
+ * BELOW 640px THE CLICKS ARE DIFFERENT ONES, because the navigation is. The rail is behind
+ * a hamburger and the tab strip is a native `<select>`, so `openView` branches on the
+ * viewport rather than on a flag: every caller keeps asking for "Spending › Recurring" and
+ * gets there the way a person on that viewport would. This is the whole reason the phone
+ * shell is the ticket that unblocks the rest — until it lands, no phone behaviour past the
+ * first screen can be reached at all.
  */
 import { expect } from "@playwright/test";
 import { fixtureFor } from "../fixtures/index.js";
+import { PHONE_TIER_BELOW } from "../viewports.js";
 
 /**
  * Serve every API call from committed fixtures and cut the page off from the network.
@@ -76,12 +84,40 @@ async function settle(page, anchor) {
   await expect(anchor(page).first()).toBeVisible({ timeout: 20_000 });
 }
 
+/** True when the viewport is inside the phone tier, where navigation is the drawer. */
+export const onPhone = (page) => page.viewportSize().width < PHONE_TIER_BELOW;
+
+/** The drawer's parts, named once so a rename breaks in one place rather than eleven. */
+export const menuButton = (page) => page.getByTestId("menu");
+export const drawer = (page) => page.locator(".side");
+export const scrim = (page) => page.getByTestId("scrim");
+export const tabSelect = (page) => page.getByTestId("tabsel");
+
 const section = (page, name) => page.locator(".navitem", { hasText: new RegExp(`^${name}$`) });
 const tab = (page, name) => page.locator(".tab", { hasText: new RegExp(`^${name}$`) });
 
+/**
+ * Switch section — through the drawer on a phone, straight off the rail above it.
+ *
+ * The drawer closes itself when a section is chosen, and this waits for that: leaving it
+ * open would leave the scrim over the pane every later gate measures through.
+ */
+async function openSection(page, name) {
+  if (!onPhone(page)) return section(page, name).click();
+  await menuButton(page).click();
+  await section(page, name).click();
+  await expect(scrim(page)).toBeHidden();
+}
+
+/** Switch tab — the native picker on a phone, the strip above it. */
+async function openTabControl(page, name) {
+  if (!onPhone(page)) return tab(page, name).click();
+  await tabSelect(page).selectOption(name);
+}
+
 async function openTab(page, sectionName, tabName, anchor) {
-  await section(page, sectionName).click();
-  await tab(page, tabName).click();
+  await openSection(page, sectionName);
+  await openTabControl(page, tabName);
   await settle(page, anchor);
 }
 
@@ -132,7 +168,7 @@ export const VIEWS = [
   {
     name: "Net Worth",
     open: async (page) => {
-      await section(page, "Net Worth").click();
+      await openSection(page, "Net Worth");
       await settle(page, (p) => p.getByTestId("networth-summary"));
     },
   },
@@ -157,6 +193,21 @@ export const VIEWS = [
     open: (page) => openTab(page, "Spending", "Transactions", (p) => p.locator(".card h3")),
   },
 ];
+
+/**
+ * Install the seam, load the app, and open one named view — the two lines every spec that
+ * measures a rendered view starts with, written once.
+ *
+ * Returns the seam, so a caller that wants to report "the view never settled because these
+ * paths had no fixture" still can; `baseline.spec.js` is the one that does.
+ */
+export async function openView(page, baseURL, viewName) {
+  const seam = await loadApp(page, baseURL);
+  const view = VIEWS.find((v) => v.name === viewName);
+  if (!view) throw new Error(`no view named "${viewName}" — check VIEWS`);
+  await view.open(page);
+  return seam;
+}
 
 /**
  * Load the app signed *out*, so the login screen renders instead of the shell.

--- a/web/tests/support/css.js
+++ b/web/tests/support/css.js
@@ -1,0 +1,57 @@
+/**
+ * Reading the *shipped* stylesheet, rather than the source or the computed cascade.
+ *
+ * Two specs need this and for the same reason: `baseline.spec.js`'s "WHAT THIS SUITE
+ * CANNOT CHECK, EVER" puts safe-area insets on the never list — Chromium reports every
+ * `env(safe-area-inset-*)` as 0 at every viewport, in both orientations — so a rule whose
+ * whole job is to survive a notch leaves nothing measurable behind. `getComputedStyle`
+ * hands back `14px` for a bare literal and for `max(14px, env(...))` alike, which is
+ * exactly the distinction those gates exist to make. Reading the CSSOM is what is left.
+ *
+ * Extracted here when the phone shell landed and `shell.spec.js` needed the same reader
+ * `foundations.spec.js` already had. One copy, because a second one drifts.
+ */
+
+/**
+ * Every rule in the shipped stylesheets whose selector is exactly `selector`, with the
+ * media condition it sits under and its *specified* declarations as `{ property: value }`.
+ *
+ * Read from the browser rather than from `styles.css`, so what is asserted is what ships —
+ * and the difference is not academic. The build expands `padding: 14px` into four longhands
+ * before this ever sees it, so the source's shorthand-then-longhand ordering (get it wrong
+ * and the shorthand silently resets all four sides) does not exist here to check. What
+ * catches that mistake is a resolved-padding assertion, where the bottom comes back 14px
+ * instead of 20px.
+ */
+export function declarationsFor(page, selector) {
+  return page.evaluate((sel) => {
+    const found = [];
+    const walk = (rules, media) => {
+      for (const rule of rules) {
+        // Matched *before* descending, not instead of: a `CSSStyleRule` carries its own
+        // (empty) `cssRules` list now that CSS nesting exists, so a style rule and a
+        // grouping rule are no longer distinguishable by that property being present.
+        if (rule.selectorText === sel) {
+          const decls = {};
+          for (const prop of rule.style) decls[prop] = rule.style.getPropertyValue(prop);
+          found.push({ media: media ?? null, decls });
+        }
+        if (rule.cssRules) walk(rule.cssRules, rule.conditionText ?? media);
+      }
+    };
+    for (const sheet of document.styleSheets) {
+      let rules;
+      try { rules = sheet.cssRules; } catch { continue; }   // a cross-origin sheet, if one ever appears
+      walk(rules, null);
+    }
+    return found;
+  }, selector);
+}
+
+/** The four resolved padding sides of one element, as CSS pixel strings. */
+export function paddingOf(page, selector) {
+  return page.evaluate((sel) => {
+    const s = getComputedStyle(document.querySelector(sel));
+    return { top: s.paddingTop, right: s.paddingRight, bottom: s.paddingBottom, left: s.paddingLeft };
+  }, selector);
+}

--- a/web/tests/unconditional.spec.js
+++ b/web/tests/unconditional.spec.js
@@ -1,5 +1,5 @@
 /**
- * The gates that hold at EVERY width, asserted at every width.
+ * The gates that hold at EVERY width, asserted at every width their subject exists at.
  *
  * `baseline.spec.js` is the "desktop is unchanged" ratchet and runs thirteen views past a
  * handful of universal gates. This file is its opposite number: a small set of specific
@@ -7,6 +7,13 @@
  * decision — no media query, no `matchMedia`, one code path. That is why they can be
  * asserted here rather than waiting for the phone tier: they are true today, at 360 and at
  * 1440 alike, or the slice is not finished.
+ *
+ * ONE GATE IS NOW SCOPED, AND THE DISTINCTION MATTERS. The phone shell replaced the
+ * labelled refresh control with an icon in the app bar, so below 640 there is no labelled
+ * button to measure — `.tabs-right` is `display: none`. The claim did not become
+ * conditional; its *subject* stopped rendering, which is a different thing from a rule
+ * being overridden in a media block, and it is why that one test skips rather than being
+ * softened. `shell.spec.js` carries the icon's own gates. Nothing else here is scoped.
  *
  * Every gate below moved OUT of `RESPONSIVE.md` when it moved in here. The checklist
  * shrinks as behaviour lands; it does not keep a copy.
@@ -19,17 +26,10 @@
  * `HSCROLL_GATE_APPLIES_BELOW`.
  */
 import { expect, test } from "@playwright/test";
-import { VIEWPORTS } from "./viewports.js";
-import { VIEWS, loadApp } from "./support/app.js";
+import { PHONE_TIER_BELOW, VIEWPORTS } from "./viewports.js";
+import { openView } from "./support/app.js";
 
 const viewportOf = (projectName) => VIEWPORTS.find((v) => v.name === projectName);
-const viewNamed = (name) => VIEWS.find((v) => v.name === name);
-
-/** Open one named view with the fixture seam installed. */
-async function open(page, baseURL, viewName) {
-  await loadApp(page, baseURL);
-  await viewNamed(viewName).open(page);
-}
 
 /** Every element matching `sel`, as `{ w, h }` border boxes, measured in the page. */
 function boxes(page, sel) {
@@ -42,8 +42,16 @@ function boxes(page, sel) {
 }
 
 test.describe("the refresh control keeps its natural size and its label on one line", () => {
+  // Scoped to 640 and up when the phone shell landed, because below it this control no
+  // longer exists to measure: the labelled button and the whole `.tabs-right` group it sits
+  // in are `display: none`, and Refresh is an icon in the app bar instead. The claim itself
+  // did not weaken — a labelled button that fits on one line is still unconditional
+  // *wherever the label renders*. `shell.spec.js` owns the icon's own gates below 640.
+  test.skip(({ viewport }) => viewport.width < PHONE_TIER_BELOW,
+    "below 640 the labelled control is replaced by the app bar's icon");
+
   test("Portfolio › Overview", async ({ page, baseURL }) => {
-    await open(page, baseURL, "Portfolio › Overview");
+    await openView(page, baseURL, "Portfolio › Overview");
     const btn = page.locator(".refresh-btn");
 
     // One line, stated two ways, because either alone is weak. `white-space: nowrap` says
@@ -73,7 +81,7 @@ test.describe("card grids collapse rather than crush, and never produce a third 
   ]) {
     test(viewName, async ({ page, baseURL }, testInfo) => {
       const vp = viewportOf(testInfo.project.name);
-      await open(page, baseURL, viewName);
+      await openView(page, baseURL, viewName);
 
       const grids = await page.$$eval(".grid2", (els) =>
         els.map((el) => ({
@@ -101,9 +109,13 @@ test.describe("card grids collapse rather than crush, and never produce a third 
 test.describe("the tab strip wraps rather than crushing its neighbour", () => {
   test("Portfolio", async ({ page, baseURL }, testInfo) => {
     const vp = viewportOf(testInfo.project.name);
-    await open(page, baseURL, "Portfolio › Overview");
+    await openView(page, baseURL, "Portfolio › Overview");
     const tabs = page.locator(".tabs").first();
 
+    // Still asserted below 640, where the strip is `display: none`, because the wrap rule
+    // itself is still unconditional — the phone tier hides the strip, it does not restyle
+    // it — and a computed value survives `display: none`. If someone later moves
+    // `flex-wrap` into a media block, this notices at four viewports.
     expect(await tabs.evaluate((el) => getComputedStyle(el).flexWrap)).toBe("wrap");
 
     // The no-op half of the claim, and the reason this file needed a tenth viewport: at
@@ -123,7 +135,7 @@ test.describe("every editor control is at least 24px square", () => {
   // these views are optimised for. Comfort beyond 24px is deliberately below the floor
   // here — that is the 44px target the fully-responsive views get, not this one.
   test("Net Worth", async ({ page, baseURL }) => {
-    await open(page, baseURL, "Net Worth");
+    await openView(page, baseURL, "Net Worth");
     const controls = await boxes(page, ".main button, .main input, .main select");
     expect(controls.length).toBeGreaterThan(0);
     for (const c of controls) {
@@ -133,7 +145,7 @@ test.describe("every editor control is at least 24px square", () => {
   });
 
   test("Spending › Classify", async ({ page, baseURL }) => {
-    await open(page, baseURL, "Spending › Classify");
+    await openView(page, baseURL, "Spending › Classify");
     // `.link-btn` included: seven of Classify's controls are one, at ~21px tall before this
     // slice. The 44px comfort target for the *fully responsive* views — Recurring's three
     // `.link-btn`s among them — is phone-only and lands with the phone tier, not here.
@@ -150,7 +162,7 @@ test("the rule text area matches the app's dark styling", async ({ page, baseURL
   // The `textarea` exists only inside `RuleModal`, so this is the one gate in the file that
   // has to open something. It rendered UA-default — a white box on a dark modal — because
   // `styles.css`'s form rule named `input, select` and not `textarea`.
-  await open(page, baseURL, "Spending › Classify");
+  await openView(page, baseURL, "Spending › Classify");
   await page.getByRole("button", { name: "+ Propose a rule" }).click();
   const box = page.locator("textarea");
   await expect(box).toBeVisible();
@@ -172,7 +184,7 @@ test("the rule text area matches the app's dark styling", async ({ page, baseURL
 test.describe("list rows are a full-width track with the fill behind the text", () => {
   for (const viewName of ["Portfolio › Overview", "Spending › Overview", "Spending › By Category"]) {
     test(viewName, async ({ page, baseURL }) => {
-      await open(page, baseURL, viewName);
+      await openView(page, baseURL, viewName);
 
       const rows = await page.$$eval(".barrow", (els) =>
         els.map((el) => {
@@ -214,7 +226,7 @@ test.describe("the options tables lead with a merged identity cell", () => {
     ["Portfolio › SecurityDetail", "Contract"],
   ]) {
     test(viewName, async ({ page, baseURL }) => {
-      await open(page, baseURL, viewName);
+      await openView(page, baseURL, viewName);
 
       // The options table is the one with a `Contract` header. Find it by that, not by
       // index — `SecurityDetail` has three tables and `Options` has three.


### PR DESCRIPTION
Closes #27.

Navigation that works on a phone — the ticket that unblocks the rest. Until it lands, no phone behaviour past the first screen can be reached at all, which is why the suite's own view drivers change with it: below 640 every existing gate now reaches its view through the hamburger, the drawer and the picker.

## The shell

**The drawer is `.side` itself**, restyled below 640 rather than rebuilt beside it. There is exactly one navigation list in the document, so "the drawer holds every item the sidebar holds" is a structural fact rather than two lists somebody has to keep in step. Brand, sections, the dimmed Settings entry and the signed-in footer all arrive unchanged; the footer sinks with `margin-top: auto`, because `.side` is a flex column here and nowhere else.

**Nothing is `position: fixed`.** The drawer and its scrim are `absolute` inside a shell that is already `100svh`, which is what makes the whole thing immune to the iOS keyboard and to a retracting toolbar without a line of JS. `visibility` rides alongside the transform: a panel that is only translated off-canvas is still in the focus order.

**Tabs become a native `<select>`.** Six is the worst case, and a scroll strip pushes options off the edge with nothing to say they are there. `font-size: 16px` is restated *after* `font: inherit` deliberately — the app's own form rule sets `font: inherit`, which is exactly what would silently win the inherited 14px back, and at 14px iOS zooms the viewport to 16/14 = 114% on focus and does not zoom out again. Net Worth owns no tabs, so the slot carries the section's name.

**Refresh shrinks to an icon and keeps its section** — it moves, it is not promoted. Its status becomes a strip *between* the bar and the pane: a flex child rather than an overlay, so it pushes content down instead of covering the first row. It is transient by the same argument that chose the drawer — a shell picked on a vertical budget cannot then spend part of it on a status line that never leaves.

## The notch

The safe-area guards on the app bar and `.main` are **unconditional**, and that is the point: a rotated phone is 844px wide and *exits* the phone block, and landscape is the only orientation where the notch is at the side. The bar pads itself rather than `.app`, which would inset the bar's background and leave an unpainted strip down the side of the notch, and it is `content-box` so the top inset adds to its 48px instead of eating it. `.main`'s phone `padding-top` drops its guard in the same move — the bar clears the notch now, and `env()` is viewport-relative, so leaving it would pay twice. That trap is marked discharged in `RESPONSIVE.md`; three new ones replace it.

## Verification

`shell.spec.js` covers the shell; "all thirteen views are reachable at 390×844" is asserted thirteen times over in `baseline.spec.js` rather than copied here. The two criteria about a notch are asserted as **declarations**, through the CSSOM reader `foundations.spec.js` already had and that moves to `tests/support/css.js` to be shared rather than duplicated — Chromium reports every `env(safe-area-inset-*)` as 0 at every viewport in both orientations.

Gates that could go stale are written to fail rather than pass vacuously: the bar's height is capped at 64px (48 against a bottom bar's 147 is the entire basis of the design), the drawer is asserted to *be* `.side`, nothing is `position: fixed` **with the drawer open**, and the status strip's disappearance on leaving Portfolio is timed against `STATUS_MS` so it cannot pass because the auto-dismiss got there first.

The horizontal-overflow ratchet falls by 200 on every gated phone row — the sidebar leaving the flow — or to zero where 200 was more than the whole overflow. The three viewports at or above 640px are untouched to the pixel.

`make test-web`: 429 passed, 62 skipped.

## Deliberately not here

- The `(max-height: 500px)` height guard that brings this shell to 844×390 is #33's acceptance criterion. What this ticket owes is that the bar's guards are already in place wherever it renders, and both halves of that are asserted.
- Table overflow at 390 is unchanged — that is #28.
- **Accepted ambiguity, not a bug:** with the drawer shut nothing names the current section, and both Portfolio and Spending own a tab called "Overview".