### PR TITLE
Pattern A: pinned identity column and scroll ownership

### DIFF
--- a/RESPONSIVE.md
+++ b/RESPONSIVE.md
@@ -50,7 +50,12 @@ Applied to all 12 tab views, SecurityDetail, and sign-in. Must pass.
 
 1. **`.main` never scrolls horizontally.** Sideways scroll is confined to a container that is visibly a
    table. *(Not "no horizontal page scroll" — `.main { overflow: auto }` absorbs everything before it
-   reaches the page, so that criterion can never fail.)*
+   reaches the page, so that criterion can never fail.)* **Five of the thirteen views now hold it
+   outright at every gated viewport** — Holdings, Performance, Dividends and Recurring, because the
+   pinned column took their scroll off the pane, plus Classify, which was already there. The ratchet in
+   `hscroll-baseline.js` records what is left and why: the two ledgers and SecurityDetail wait for
+   card-per-row, Net Worth for the editor floor, and four views share one residual that is not a table
+   at all — `.grid2`'s 420px track floor against a 362px pane.
 2. No overlapping or clipped content.
 3. Every control reachable and tappable — **44px square** in fully-responsive views. *(The 24px
    editor floor has landed and is asserted by `unconditional.spec.js`; it is not checked here any
@@ -97,17 +102,17 @@ criteria **instead of** the universal list — reading comfort, row density and 
 | view | check |
 |---|---|
 | Portfolio › Overview | tiles reflow to 2 columns; **donuts gone below 640**. *(`.grid2` collapsing to one column and the S2 inline rows have landed — both asserted.)* |
-| Portfolio › Holdings | pattern **A**: Security pinned, h-scroll inside the wrapper, sticky `th` stays put as the wrapper scrolls; `tr:active` feedback and a persistent `›` in the pinned cell; footnote collapsed into `<details>`; row tap opens SecurityDetail |
-| Portfolio › Performance | pattern **A**, grouping key pinned (its `th` is `{by}` — lowercase, changes with the `<select>`). Row count is bounded by the grouping dimension (max 8), so the whole table is on screen and `max-height: 60svh` never bites |
-| Portfolio › Dividends | crosstab pattern **A** (grows in columns, so h-scroll never expires); payment ledger pattern **B** cards; `LabelList` dropped below 640 |
-| Portfolio › Options | contract ledger **A** — pinned Underlying; it already has an `overflow-x: auto` wrapper at `:70`, so this keeps behaviour rather than replacing it. By-ticker and by-type unchanged (273/261px, they genuinely fit); monthly P/L halved to 6 bars with a reserved band so negative labels clear the ticks. *(The merged `Contract` cell has landed — asserted; the pin has not.)* |
+| Portfolio › Holdings | ~~pattern **A**: Security pinned, h-scroll inside the wrapper, sticky `th` stays put as the wrapper scrolls; `tr:active` feedback and a persistent `›` in the pinned cell; footnote collapsed into `<details>`~~ **landed** — all of it asserted by `pinned.spec.js`, at seven viewports rather than at 390 alone. What is left here is eyes-only: row tap opens SecurityDetail, and whether the pin reads as an identity |
+| Portfolio › Performance | ~~pattern **A**, grouping key pinned (its `th` is `{by}` — lowercase, changes with the `<select>`)~~ **landed** — the `{by}` header is asserted by name, which is what says the *grouping key* got pinned rather than a label. Row count is bounded by the grouping dimension (max 8), so the whole table is on screen and `max-height: 60svh` never bites — asserted as the short half of the cap's one-rule claim |
+| Portfolio › Dividends | ~~crosstab pattern **A** (grows in columns, so h-scroll never expires)~~ **landed**; payment ledger pattern **B** cards; `LabelList` dropped below 640 |
+| Portfolio › Options | ~~contract ledger **A** — pinned Underlying; it already has an `overflow-x: auto` wrapper at `:70`, so this keeps behaviour rather than replacing it~~ **landed** — the wrapper's own 480px cap moved to `.selfscroll` so the phone tier's `60svh` can win over it, which an inline `max-height` could not. By-ticker and by-type unchanged (273/261px, they genuinely fit); monthly P/L halved to 6 bars with a reserved band so negative labels clear the ticks. *(The merged `Contract` cell landed earlier — asserted.)* |
 | Portfolio › Transactions | pattern **B** cards |
-| Portfolio › SecurityDetail | txn history **B**; dividend history **B**; options history **A**, pinning the merged two-line `Contract` cell. Three tables, two patterns, deliberately. `← Holdings` is a ≥44px target and is the **only** way back — there is no router. *(The merged cell itself has landed at every width — asserted; only the pin is left.)* |
+| Portfolio › SecurityDetail | txn history **B**; dividend history **B**; ~~options history **A**, pinning the merged two-line `Contract` cell~~ **landed**. Three tables, two patterns, deliberately. `← Holdings` is a ≥44px target and is the **only** way back — there is no router. *(This view is the one place the pane still scrolls sideways after the pin: the 914px txn history is what sets the width, and it waits for **B**.)* |
 | Net Worth | editor floor; line chart has a **DOM key, not `<Legend>`**; Breakdown and History wrapped in `overflow-x: auto`; ~~`100svh`~~ *(the shell's, landed and asserted)* |
 | Spending › Overview | donut gone below 640, list is the chart; Top Line Items pattern **B** (471px — A's pin would be the 232px Line item, 70% of the viewport). Both halves of the `.grid2` end up as ranked lists |
 | Spending › By Category | donut gone below 640; Categories pattern **A** with the name column pinned — it keeps its own `▸`/`▾` and does **not** get the persistent `›`; drilled transactions render as **B** cards **below the table**, not as a nested row, headed by subcategory + count + aggregate |
 | Spending › Classify | editor floor; `.fillpane` neutralised so the page scrolls as one; **⇅ Reorder hidden on phone**; `RuleModal` uses `svh`. *(The `textarea`'s styling has landed — asserted.)* |
-| Spending › Recurring | monitor **A** *(open call)* and candidates **A**; three `.link-btn`s at 44px square; **two nested scroll regions** — the feel check |
+| Spending › Recurring | ~~monitor **A** *(open call)* and candidates **A**~~ **landed** — both pinned; the open call is untouched by that, since it asks whether this view wants a different information design rather than whether the reflow works. **Only the candidates table is asserted**: the owner tracks nothing, so `/api/spending/recurring` is `[]` in the committed fixtures and the monitor never mounts. `pinned.spec.js` annotates that gap on every run rather than closing it with an invented row — so the monitor's pin is an eyes-only check here. Three `.link-btn`s at 44px square; **two nested scroll regions** — the feel check |
 | Spending › Transactions | pattern **B** cards |
 | Sign-in | ~~`100vh` → `100svh` at `auth.jsx:50` and `:125`~~ **landed** — asserted, along with the box filling the screen, optical centring and the absence of any phone rule. GSI button **carved out** of the 44px floor; no `env()` padding anywhere. What is left here is eyes-only: whether the carved-out button looks right beside a 44px world |
 
@@ -156,8 +161,28 @@ Things the build session must be told, not left to discover.
   **519px** with the live DB's longest subcategory name. `auto-fit` still behaves; the column just spills
   inside itself between 1024 and ~1256.
 - **`640` is a literal in three places**: `styles.css`'s `max-width: 639.98px`, `tests/viewports.js`'s
-  `PHONE_TIER_BELOW` / `PHONE_TIER_MEDIA`, and — once the charts land — the `matchMedia` hook. No
-  single source of truth without a build step. Every site cross-references the others in a comment.
+  `PHONE_TIER_BELOW` / `PHONE_TIER_EDGE`, and `Holdings.jsx`'s `startsCollapsed` — the app's first
+  `matchMedia` read, which arrived with the pinned column rather than with the charts as the map
+  expected. The charts will be the **fourth**. No single source of truth without a build step. Every
+  site cross-references the others in a comment.
+- **`1024` is now a literal in two places** for the same reason: `styles.css`'s `max-width: 1023.98px`
+  and `tests/viewports.js`'s `PIN_TIER_BELOW` / `PIN_TIER_EDGE`. It is the same number as
+  `HSCROLL_GATE_APPLIES_BELOW` and deliberately not the same constant — the gate is exempt above 1024
+  *because* the pattern stops there, so a ticket that takes the pin to desktop moves one and not both.
+- **`border-collapse: separate` does not paint a border declared on a `<tr>` at all.** It is the
+  trap behind the trap: switching a table to `separate` to keep the sticky borders silently deletes any
+  row-level rule in it. `Dividends`' 2px total rule was one, and is `.totalrow` on the cells now.
+- **A pinned first cell must not be a `colSpan` banner.** `Holdings`' group rows are excluded from the
+  pin by `:not(.grouprow)` — pinning a seven-column banner parks a subtotal over the numbers the
+  sideways scroll exists to reach. The label slides away instead; its background is what keeps the row
+  identifiable once it has. Any new grouped pattern-A table needs the same class.
+- **An inline `max-height` beats the phone tier's `60svh`.** `Options`' trades wrapper shipped its cap
+  inline; it is `.selfscroll` now precisely so the cascade can reach it. Nothing else may put a height
+  on a `.pinned` wrapper inline.
+- **A row with `opacity` below 1 makes its own pinned cell translucent**, so the columns scrolling under
+  it ghost through at ~30%. Live on `Holdings`' closed positions (behind a checkbox) and `Recurring`'s
+  inactive rows. Accepted rather than fixed: the alternative is changing how those rows dim at every
+  width, which is a desktop change nobody asked for.
 - In `.main`, the padding **longhands must follow the shorthand** — the shorthand resets all four sides.
 - ~~**`.main`'s phone `padding-top` guards `env(safe-area-inset-top)` and must stop once the app bar
   lands.**~~ **Discharged** by the shell: the pane's top is a bare `14px` now and the app bar carries
@@ -179,7 +204,9 @@ Things the build session must be told, not left to discover.
   rule that hides the strip is `.main > .tabs`; a bare `.tabs` deletes that heading and the year picker
   with it, and the view still renders, so nothing fails loudly.
 - Sticky + pinned cells require `border-collapse: separate; border-spacing: 0`; under `collapse` they
-  lose their borders.
+  lose their borders. *(Landed, and `pinned.spec.js` asserts both the border model and the resulting
+  1px rules on the header and the pinned column — the model alone would pass while the borders were
+  gone for some other reason.)*
 - `display: none` starves `ResponsiveContainer` to 0×0 — drop chart *chrome* via `matchMedia`, never the
   container.
 

--- a/RESPONSIVE.md
+++ b/RESPONSIVE.md
@@ -160,6 +160,12 @@ Things the build session must be told, not left to discover.
 - `.grid2`'s `minmax(420px, 1fr)` is **~100px optimistic against real data** — `Overview:33`'s card needs
   **519px** with the live DB's longest subcategory name. `auto-fit` still behaves; the column just spills
   inside itself between 1024 and ~1256.
+- **The 420px track floor is also the last unowned entry in the horizontal ratchet, and no ticket has
+  it.** Below 640 the floor exceeds the 362px pane outright, so `Portfolio › Overview`, `Options`,
+  `By Category` and `Spending › Overview` all carry the *same* residual — 74 / 44 / 4 / 8 / 48 by
+  viewport, one cause, no table involved. The pinned column cannot reach it and neither can card-per-row
+  or the editors' floor. The usual remedy is `minmax(min(420px, 100%), 1fr)`. **Written down here
+  because a residual with no owner is precisely how the four unassigned tables happened.**
 - **`640` is a literal in three places**: `styles.css`'s `max-width: 639.98px`, `tests/viewports.js`'s
   `PHONE_TIER_BELOW` / `PHONE_TIER_EDGE`, and `Holdings.jsx`'s `startsCollapsed` — the app's first
   `matchMedia` read, which arrived with the pinned column rather than with the charts as the map
@@ -176,13 +182,17 @@ Things the build session must be told, not left to discover.
   pin by `:not(.grouprow)` — pinning a seven-column banner parks a subtotal over the numbers the
   sideways scroll exists to reach. The label slides away instead; its background is what keeps the row
   identifiable once it has. Any new grouped pattern-A table needs the same class.
-- **An inline `max-height` beats the phone tier's `60svh`.** `Options`' trades wrapper shipped its cap
+- **An inline `max-height` beats the pattern's `60svh`.** `Options`' trades wrapper shipped its cap
   inline; it is `.selfscroll` now precisely so the cascade can reach it. Nothing else may put a height
   on a `.pinned` wrapper inline.
-- **A row with `opacity` below 1 makes its own pinned cell translucent**, so the columns scrolling under
-  it ghost through at ~30%. Live on `Holdings`' closed positions (behind a checkbox) and `Recurring`'s
-  inactive rows. Accepted rather than fixed: the alternative is changing how those rows dim at every
-  width, which is a desktop change nobody asked for.
+- **`overflow-x: auto` forces `overflow-y` from `visible` to `auto`.** So a `.pinned` wrapper is the
+  sticky scrollport for its own header *whether or not anyone gave it a height* — and a scrollport that
+  sizes to content never scrolls, so the header rides the page away instead of sticking. Measured at
+  −500px of drift on a 500px page scroll. **This is why `60svh` sits with the pattern at 1024 rather
+  than in the phone block**, where it was first written: scoped to the phone it would leave the header
+  broken from 640 to 1024, and in landscape too, since a rotated phone is 844px wide and exits that
+  block. The map already had this mechanism recorded once — `Dividends.jsx:30`'s "dead sticky header on
+  desktop today" is the same sentence about a table short enough for it not to matter.
 - In `.main`, the padding **longhands must follow the shorthand** — the shorthand resets all four sides.
 - ~~**`.main`'s phone `padding-top` guards `env(safe-area-inset-top)` and must stop once the app bar
   lands.**~~ **Discharged** by the shell: the pane's top is a bare `14px` now and the app bar carries

--- a/web/TESTING.md
+++ b/web/TESTING.md
@@ -49,6 +49,16 @@ none of it renders. It shares
 `foundations.spec.js`'s CSSOM reader (`tests/support/css.js`) for the two criteria that are
 about a notch and therefore have no geometric form in Chromium.
 
+`tests/pinned.spec.js` — pattern A: seven tables across six views that pin an identity column and
+scroll the rest sideways below **1024px**, not 640. It is the one spec whose tier is the pin tier,
+because the pin is worth more as the window narrows: the same gates run at seven viewports and the
+other three assert the inverse — that the desktop table is untouched. It also carries the two gates
+that have no geometry. **The column count of every pinned table is asserted**, because "no table
+drops a column" is the criterion a build could satisfy every *geometric* gate while breaking. And
+`overscroll-behavior` is asserted to be declared **nowhere**: the reflex on a capped scroll box is
+`contain`, chaining is the decision, and a synthetic scroll does not chain, so there is nothing to
+measure.
+
 `tests/inventory.spec.js` — the checks that read files rather than pixels: the table count, the
 single donut implementation, that no `100vh` survives under `web/src`, the viewport meta's
 `viewport-fit=cover`, the viewport list against `RESPONSIVE.md`, and the fixtures' own

--- a/web/playwright.config.js
+++ b/web/playwright.config.js
@@ -39,7 +39,7 @@ export default defineConfig({
     { name: "inventory", testMatch: /inventory\.spec\.js/ },
     ...VIEWPORTS.map((v) => ({
       name: v.name,
-      testMatch: /(baseline|unconditional|foundations|shell)\.spec\.js/,
+      testMatch: /(baseline|unconditional|foundations|shell|pinned)\.spec\.js/,
       use: {
         ...devices["Desktop Chrome"],
         viewport: { width: v.width, height: v.height },

--- a/web/src/modules/portfolio/Dividends.jsx
+++ b/web/src/modules/portfolio/Dividends.jsx
@@ -29,10 +29,10 @@ export default function Dividends() {
         <h3>Annual Dividend Income&nbsp;<span className="pill">SGD · latest FX</span></h3>
         {/* The crosstab grows in COLUMNS — one per year — so horizontal scroll is the only
             treatment that does not expire, and comparing a bucket across years is the whole
-            of what it is for. It already carried `overflow-x: auto` at every width, which is
-            kept: `.pinned` adds the pin, the sticky header and the borders that survive it
-            below 1024px, and changes nothing above. */}
-        <div className="pinned" style={{ overflowX: "auto" }}>
+            of what it is for. It already carried `overflow-x: auto` at every width, which
+            `.hscroll` keeps: `.pinned` adds the pin, the header and the borders that survive
+            it below 1024px, and changes nothing above. */}
+        <div className="pinned hscroll">
           <table>
             <thead><tr>
               <th className="l">Bucket</th>

--- a/web/src/modules/portfolio/Dividends.jsx
+++ b/web/src/modules/portfolio/Dividends.jsx
@@ -27,7 +27,12 @@ export default function Dividends() {
     <>
       <div className="card">
         <h3>Annual Dividend Income&nbsp;<span className="pill">SGD · latest FX</span></h3>
-        <div style={{ overflowX: "auto" }}>
+        {/* The crosstab grows in COLUMNS — one per year — so horizontal scroll is the only
+            treatment that does not expire, and comparing a bucket across years is the whole
+            of what it is for. It already carried `overflow-x: auto` at every width, which is
+            kept: `.pinned` adds the pin, the sticky header and the borders that survive it
+            below 1024px, and changes nothing above. */}
+        <div className="pinned" style={{ overflowX: "auto" }}>
           <table>
             <thead><tr>
               <th className="l">Bucket</th>
@@ -43,7 +48,9 @@ export default function Dividends() {
                   })}
                 </tr>
               ))}
-              <tr style={{ borderTop: "2px solid var(--line, #ccc)", fontWeight: 600 }}>
+              {/* The rule is on the cells, not the row: `border-collapse: separate` — which
+                  the pinned pattern switches this table to — does not paint a row border. */}
+              <tr className="totalrow">
                 <td className="l">Total</td>
                 {years.map((y) => <td key={y} className="pos">{sgd(ann.totals[y] || 0)}</td>)}
               </tr>

--- a/web/src/modules/portfolio/Holdings.jsx
+++ b/web/src/modules/portfolio/Holdings.jsx
@@ -12,6 +12,22 @@ const GROUPS = {                                   // group key -> label
 };
 
 const NCOLS = 12;
+
+/**
+ * The phone tier, as JavaScript says it — and the third place `640` is written as a literal.
+ *
+ * `styles.css` says `max-width: 639.98px` and `tests/viewports.js` says `< 640`; JS cannot
+ * read a CSS custom property and this repo takes no build step to make one, so the three
+ * sites cross-reference in comments rather than share a constant. `RESPONSIVE.md`'s Traps
+ * names all of them.
+ *
+ * Read ONCE, at mount, deliberately: it seeds the footnote's initial state and nothing more.
+ * A live `matchMedia` listener here would fight the user's own toggle on every rotation, and
+ * a footnote that reopens itself when you turn the phone is worse than one that is stale.
+ */
+const startsCollapsed = () =>
+  typeof window !== "undefined" && window.matchMedia("(max-width: 639.98px)").matches;
+
 const groupKey = (r, by) =>
   by === "account" ? ((r.accounts || []).join(", ") || "—") : (r[by] || "—");
 const plOf = (r) => (r.status === "closed" ? r.pl_sgd : r.unrealised_pl_sgd);
@@ -49,7 +65,7 @@ function DataRow({ r, onClick, max }) {
   const pl = plOf(r);
   const { net, partial } = netOf(r);
   return (
-    <tr style={{ cursor: "pointer", opacity: closed ? 0.7 : 1 }} onClick={onClick}>
+    <tr className="rowlink" style={{ cursor: "pointer", opacity: closed ? 0.7 : 1 }} onClick={onClick}>
       <td className="l">{r.name} <span className="pill">{r.ticker}</span>
         {closed && <span className="pill" style={{ marginLeft: 4, color: "var(--mut)" }}>closed</span>}
         <div className="mut" style={{ fontSize: 11 }}>{(r.accounts || []).join(", ")}</div></td>
@@ -80,6 +96,7 @@ export default function Holdings() {
   const [by, setBy] = useState("asset_type");
   const [showClosed, setShowClosed] = useState(false);
   const [collapsed, setCollapsed] = useState({});
+  const [noteOpen, setNoteOpen] = useState(() => !startsCollapsed());
 
   useEffect(() => {
     setRows(null);
@@ -138,48 +155,60 @@ export default function Holdings() {
         </label>
         <span className="mut" style={{ fontSize: 12, marginLeft: "auto" }}>click a row for full history</span>
       </div>
-      <table>
-        <thead><tr>
-          <th className="l">Security</th><th className="l">Bucket</th><th className="l">Mkt</th>
-          <th>Units</th><th>Avg Cost</th><th>Price</th>
-          <th>Cost (SGD)</th><th>MV (SGD)</th><th>P/L</th>
-          <th title="converted at latest FX; hover a row for the native amount">Dividends (SGD)</th>
-          <th>Options P/L</th>
-          <th title="total P/L incl dividends + option premiums">Net</th><th>XIRR</th>
-        </tr></thead>
-        <tbody>
-          {flat
-            ? rows.map((r, i) => <DataRow key={i} r={r} max={maxNet} onClick={() => open(r)} />)
-            : groups.map((g) => {
-              const hidden = collapsed[g.key];
-              return (
-                <React.Fragment key={g.key}>
-                  <tr onClick={() => toggle(g.key)} style={{ cursor: "pointer", background: "var(--panel2)" }}>
-                    <td className="l" colSpan={7} style={{ fontWeight: 600 }}>
-                      {hidden ? "▸" : "▾"} {g.label}
-                      <span className="mut" style={{ fontWeight: 400 }}> · {g.rows.length}</span>
-                    </td>
-                    <td>{sgd(g.mv)}</td>
-                    <td className={cls(g.pl)}>{sgd(g.pl)}</td>
-                    <td className="pos">{g.inc ? sgd(g.inc) : ""}</td>
-                    <td className={cls(g.opt)}>{g.opt ? sgd(g.opt) : ""}</td>
-                    <td className={cls(g.net)} style={{ fontWeight: 700 }}>{sgd(g.net)}</td>
-                    <td></td>
-                  </tr>
-                  {!hidden && g.rows.map((r, i) => <DataRow key={i} r={r} max={maxNet} onClick={() => open(r)} />)}
-                </React.Fragment>
-              );
-            })}
-        </tbody>
-      </table>
-      <p className="mut" style={{ fontSize: 12 }}>
-        Open positions show market value & unrealised P/L; closed positions (units ≈ 0) show realised
-        P/L. Avg cost / cost basis / XIRR shown where transaction cost is known. CDP cost comes from
-        cdp-stocks; positions transferred CDP→FSM keep their CDP purchase cost (pooled per funding bucket).
-        XIRR is the money-weighted return incl. realised trades & dividends.
-        <b>Net</b> = total P/L (realised + unrealised + dividends) + option premiums — the bar shows its
-        size vs the biggest mover; <b>~</b> marks cost-unknown names where Net counts only dividends + premiums.
-      </p>
+      {/* The widest table in the app — 1302px of content, 13 columns — read through the
+          pinned-column pattern: Security stays put, the numbers scroll under it. The wrapper
+          is what owns the sideways scroll below 1024px, so `.main` no longer does. */}
+      <div className="pinned">
+        <table>
+          <thead><tr>
+            <th className="l">Security</th><th className="l">Bucket</th><th className="l">Mkt</th>
+            <th>Units</th><th>Avg Cost</th><th>Price</th>
+            <th>Cost (SGD)</th><th>MV (SGD)</th><th>P/L</th>
+            <th title="converted at latest FX; hover a row for the native amount">Dividends (SGD)</th>
+            <th>Options P/L</th>
+            <th title="total P/L incl dividends + option premiums">Net</th><th>XIRR</th>
+          </tr></thead>
+          <tbody>
+            {flat
+              ? rows.map((r, i) => <DataRow key={i} r={r} max={maxNet} onClick={() => open(r)} />)
+              : groups.map((g) => {
+                const hidden = collapsed[g.key];
+                return (
+                  <React.Fragment key={g.key}>
+                    <tr className="grouprow" onClick={() => toggle(g.key)} style={{ cursor: "pointer", background: "var(--panel2)" }}>
+                      <td className="l" colSpan={7} style={{ fontWeight: 600 }}>
+                        {hidden ? "▸" : "▾"} {g.label}
+                        <span className="mut" style={{ fontWeight: 400 }}> · {g.rows.length}</span>
+                      </td>
+                      <td>{sgd(g.mv)}</td>
+                      <td className={cls(g.pl)}>{sgd(g.pl)}</td>
+                      <td className="pos">{g.inc ? sgd(g.inc) : ""}</td>
+                      <td className={cls(g.opt)}>{g.opt ? sgd(g.opt) : ""}</td>
+                      <td className={cls(g.net)} style={{ fontWeight: 700 }}>{sgd(g.net)}</td>
+                      <td></td>
+                    </tr>
+                    {!hidden && g.rows.map((r, i) => <DataRow key={i} r={r} max={maxNet} onClick={() => open(r)} />)}
+                  </React.Fragment>
+                );
+              })}
+          </tbody>
+        </table>
+      </div>
+      {/* Five lines of prose above a table that wants every row it can get: collapsed on a
+          phone, where it is worth two rows in portrait and two in landscape, and open with
+          its summary hidden everywhere else, which is the paragraph this used to be.
+          `open` is read once at mount rather than tracked, so a user's own toggle stands. */}
+      <details className="tablenote" open={noteOpen} onToggle={(e) => setNoteOpen(e.currentTarget.open)}>
+        <summary>About these figures</summary>
+        <p className="mut" style={{ fontSize: 12 }}>
+          Open positions show market value & unrealised P/L; closed positions (units ≈ 0) show realised
+          P/L. Avg cost / cost basis / XIRR shown where transaction cost is known. CDP cost comes from
+          cdp-stocks; positions transferred CDP→FSM keep their CDP purchase cost (pooled per funding bucket).
+          XIRR is the money-weighted return incl. realised trades & dividends.
+          <b>Net</b> = total P/L (realised + unrealised + dividends) + option premiums — the bar shows its
+          size vs the biggest mover; <b>~</b> marks cost-unknown names where Net counts only dividends + premiums.
+        </p>
+      </details>
     </div>
   );
 }

--- a/web/src/modules/portfolio/Options.jsx
+++ b/web/src/modules/portfolio/Options.jsx
@@ -67,11 +67,12 @@ export default function Options() {
 
       <div className="card">
         <h3>Trades&nbsp;<span className="pill">most recent {trades ? trades.length : 0}</span></h3>
-        {/* Eleven columns, 862px, and cross-security comparison is plainly its job — the
+        {/* Eight columns since the merged contract cell — eleven and 862px when the pattern
+            was chosen for it — and cross-security comparison is plainly its job, so the
             contract ledger takes the pinned pattern rather than card-per-row, on the
             measurement that a nine-field card is four rows per screen against twelve here.
             `.selfscroll` is the 480px cap and both-axis scroll this wrapper already shipped,
-            moved off the inline styles so the phone tier's cap can win over it. */}
+            moved off the inline styles so the pattern's own cap can win over it. */}
         {!trades ? <div className="loading">Loading…</div> : (
           <div className="pinned selfscroll">
             <table>

--- a/web/src/modules/portfolio/Options.jsx
+++ b/web/src/modules/portfolio/Options.jsx
@@ -67,8 +67,13 @@ export default function Options() {
 
       <div className="card">
         <h3>Trades&nbsp;<span className="pill">most recent {trades ? trades.length : 0}</span></h3>
+        {/* Eleven columns, 862px, and cross-security comparison is plainly its job — the
+            contract ledger takes the pinned pattern rather than card-per-row, on the
+            measurement that a nine-field card is four rows per screen against twelve here.
+            `.selfscroll` is the 480px cap and both-axis scroll this wrapper already shipped,
+            moved off the inline styles so the phone tier's cap can win over it. */}
         {!trades ? <div className="loading">Loading…</div> : (
-          <div style={{ overflowX: "auto", maxHeight: 480, overflowY: "auto" }}>
+          <div className="pinned selfscroll">
             <table>
               <thead><tr>
                 <th className="l">Underlying</th><th className="l">Contract</th><th className="l">Closed</th>

--- a/web/src/modules/portfolio/Performance.jsx
+++ b/web/src/modules/portfolio/Performance.jsx
@@ -14,29 +14,38 @@ export default function Performance() {
           <option value="account">by Account</option>
         </select>
       </h3>
+      {/* The cheapest pinned table in the app, and the second widest: 921px, of which two
+          columns fit a phone. Every one of its eight numeric columns is an aggregate you
+          rank, which is the whole of what this view is for. The grouping key is the pin —
+          note its header is `{by}`, lowercase, and changes with the select. Row count is
+          bounded by the grouping dimension (four markets, three buckets, eight accounts and
+          never more), so the tier's `60svh` cap is a permanent no-op here rather than a
+          conditional one, and the whole table is on screen at once. */}
       {!d ? <div className="loading">Loading…</div> : (
-        <table>
-          <thead><tr>
-            <th className="l">{by}</th><th>Capital</th><th>Current Value</th>
-            <th>Unrealised P/L</th><th>Realised P/L</th><th>Dividends</th>
-            <th>Options</th><th>Net P/L</th><th>Return</th>
-          </tr></thead>
-          <tbody>
-            {Object.entries(d).sort((a, b) => b[1].net_pl_sgd - a[1].net_pl_sgd).map(([k, v]) => (
-              <tr key={k}>
-                <td className="l" style={{ fontWeight: 600 }}>{k}</td>
-                <td className="mut">{v.capital_sgd ? sgd(v.capital_sgd) : "—"}</td>
-                <td>{sgd(v.mv_sgd)}</td>
-                <td className={cls(v.unrealised_pl_sgd)}>{v.capital_sgd ? sgd(v.unrealised_pl_sgd) : "—"}</td>
-                <td className={cls(v.realised_pl_sgd)}>{v.realised_pl_sgd ? sgd(v.realised_pl_sgd) : "—"}</td>
-                <td className="pos">{sgd(v.income_sgd)}</td>
-                <td className={cls(v.options_pl_sgd)}>{v.options_pl_sgd ? sgd(v.options_pl_sgd) : "—"}</td>
-                <td className={cls(v.net_pl_sgd)} style={{ fontWeight: 600 }}>{sgd(v.net_pl_sgd)}</td>
-                <td className={cls(v.net_pl_sgd)}>{v.return_pct != null ? pct(v.return_pct) : "—"}</td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
+        <div className="pinned">
+          <table>
+            <thead><tr>
+              <th className="l">{by}</th><th>Capital</th><th>Current Value</th>
+              <th>Unrealised P/L</th><th>Realised P/L</th><th>Dividends</th>
+              <th>Options</th><th>Net P/L</th><th>Return</th>
+            </tr></thead>
+            <tbody>
+              {Object.entries(d).sort((a, b) => b[1].net_pl_sgd - a[1].net_pl_sgd).map(([k, v]) => (
+                <tr key={k}>
+                  <td className="l" style={{ fontWeight: 600 }}>{k}</td>
+                  <td className="mut">{v.capital_sgd ? sgd(v.capital_sgd) : "—"}</td>
+                  <td>{sgd(v.mv_sgd)}</td>
+                  <td className={cls(v.unrealised_pl_sgd)}>{v.capital_sgd ? sgd(v.unrealised_pl_sgd) : "—"}</td>
+                  <td className={cls(v.realised_pl_sgd)}>{v.realised_pl_sgd ? sgd(v.realised_pl_sgd) : "—"}</td>
+                  <td className="pos">{sgd(v.income_sgd)}</td>
+                  <td className={cls(v.options_pl_sgd)}>{v.options_pl_sgd ? sgd(v.options_pl_sgd) : "—"}</td>
+                  <td className={cls(v.net_pl_sgd)} style={{ fontWeight: 600 }}>{sgd(v.net_pl_sgd)}</td>
+                  <td className={cls(v.net_pl_sgd)}>{v.return_pct != null ? pct(v.return_pct) : "—"}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
       )}
       <p className="mut" style={{ fontSize: 12 }}>
         <b>Capital</b> = cost basis of current holdings (Capital + Unrealised = Current Value).

--- a/web/src/modules/portfolio/SecurityDetail.jsx
+++ b/web/src/modules/portfolio/SecurityDetail.jsx
@@ -100,25 +100,31 @@ export default function SecurityDetail({ ticker, bucket, onBack }) {
         <div className="card" style={{ marginTop: 18 }}>
           <h3>Option trades ({opts.length}) · {s.ticker} wheel
             <span className="pill" style={{ marginLeft: 8 }}>realised {sgd(optPlSgd)}</span></h3>
-          <table>
-            <thead><tr>
-              <th className="l">Contract</th><th className="l">Closed</th>
-              <th>Premium</th><th>Buyback</th><th className="l">Outcome</th><th>P/L</th>
-            </tr></thead>
-            <tbody>
-              {opts.map((t, i) => (
-                <tr key={i}>
-                  <ContractCell trade={t} />
-                  <td className="l mut">{t.close_date || "—"}</td>
-                  <td>{t.premium_open == null ? "—" : fmt(t.premium_open, 2)}</td>
-                  <td className="mut">{t.premium_close ? fmt(t.premium_close, 2) : "—"}</td>
-                  <td className="l mut">{t.outcome}</td>
-                  <td className={cls(t.realized_native)}>
-                    {money(t.realized_native, t.currency, 0)}</td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
+          {/* The one pinned table on this page — three tables, two patterns, deliberately.
+              What you do with one security's wheel log is scan P/L and Outcome *down* the
+              column, and the ledger is uncapped (73 trades on the longest). The pin is the
+              merged `Contract` cell rather than a first column of Put / Put / Call. */}
+          <div className="pinned">
+            <table>
+              <thead><tr>
+                <th className="l">Contract</th><th className="l">Closed</th>
+                <th>Premium</th><th>Buyback</th><th className="l">Outcome</th><th>P/L</th>
+              </tr></thead>
+              <tbody>
+                {opts.map((t, i) => (
+                  <tr key={i}>
+                    <ContractCell trade={t} />
+                    <td className="l mut">{t.close_date || "—"}</td>
+                    <td>{t.premium_open == null ? "—" : fmt(t.premium_open, 2)}</td>
+                    <td className="mut">{t.premium_close ? fmt(t.premium_close, 2) : "—"}</td>
+                    <td className="l mut">{t.outcome}</td>
+                    <td className={cls(t.realized_native)}>
+                      {money(t.realized_native, t.currency, 0)}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
         </div>
       )}
     </div>

--- a/web/src/modules/spending/Recurring.jsx
+++ b/web/src/modules/spending/Recurring.jsx
@@ -91,60 +91,64 @@ export default function Recurring() {
       <div className="card">
         <h3>Tracked recurring spends</h3>
         {items.length === 0 ? <div className="mut">None yet. Add one above, or pull from Detected below.</div> : (
-          <table>
-            <thead><tr>
-              <th className="l">Name</th><th className="l">Merchant</th><th className="l">Cadence</th>
-              <th>Expected</th><th>Last amt</th><th>Drift</th>
-              <th className="l">Last seen</th><th>Typ. day</th><th className="l">Next due</th>
-              <th className="l">Status</th><th></th>
-            </tr></thead>
-            <tbody>
-              {items.map((r) => (
-                <tr key={r.id} style={r.active ? null : { opacity: 0.5 }}>
-                  <td className="l" style={{ fontWeight: 600 }}>{r.name}</td>
-                  <td className="l mut">{r.merchant_match || "—"}</td>
-                  <td className="l">{r.cadence}</td>
-                  <td>{r.expected_amount == null ? "—" : sgd(r.expected_amount)}</td>
-                  <td className="mut">{r.last_amount == null ? "—" : sgd(r.last_amount)}</td>
-                  <td className={r.amount_drift > 0 ? "neg" : r.amount_drift < 0 ? "pos" : "mut"}>
-                    {r.amount_drift == null ? "—" : (r.amount_drift > 0 ? "+" : "") + sgd(r.amount_drift)}</td>
-                  <td className="l mut">{r.last_seen || "—"}</td>
-                  <td className="mut">{r.typical_day || "—"}</td>
-                  <td className="l">{r.next_due || "—"}{r.shift && <span className="mut" title={"shifted to " + r.shift + " business day (weekend)"}>&nbsp;{shiftArrow(r.next_due)}</span>}</td>
-                  <td className="l"><Badge status={r.status} /></td>
-                  <td><button className="link-btn" onClick={() => remove(r.id)} title="Delete">✕</button></td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
+          <div className="pinned">
+            <table>
+              <thead><tr>
+                <th className="l">Name</th><th className="l">Merchant</th><th className="l">Cadence</th>
+                <th>Expected</th><th>Last amt</th><th>Drift</th>
+                <th className="l">Last seen</th><th>Typ. day</th><th className="l">Next due</th>
+                <th className="l">Status</th><th></th>
+              </tr></thead>
+              <tbody>
+                {items.map((r) => (
+                  <tr key={r.id} style={r.active ? null : { opacity: 0.5 }}>
+                    <td className="l" style={{ fontWeight: 600 }}>{r.name}</td>
+                    <td className="l mut">{r.merchant_match || "—"}</td>
+                    <td className="l">{r.cadence}</td>
+                    <td>{r.expected_amount == null ? "—" : sgd(r.expected_amount)}</td>
+                    <td className="mut">{r.last_amount == null ? "—" : sgd(r.last_amount)}</td>
+                    <td className={r.amount_drift > 0 ? "neg" : r.amount_drift < 0 ? "pos" : "mut"}>
+                      {r.amount_drift == null ? "—" : (r.amount_drift > 0 ? "+" : "") + sgd(r.amount_drift)}</td>
+                    <td className="l mut">{r.last_seen || "—"}</td>
+                    <td className="mut">{r.typical_day || "—"}</td>
+                    <td className="l">{r.next_due || "—"}{r.shift && <span className="mut" title={"shifted to " + r.shift + " business day (weekend)"}>&nbsp;{shiftArrow(r.next_due)}</span>}</td>
+                    <td className="l"><Badge status={r.status} /></td>
+                    <td><button className="link-btn" onClick={() => remove(r.id)} title="Delete">✕</button></td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
         )}
       </div>
 
       <div className="card">
         <h3>Detected&nbsp;<span className="pill">from ledger · not tracked</span></h3>
         {cands.length === 0 ? <div className="mut">No unregistered recurring patterns found.</div> : (
-          <table>
-            <thead><tr>
-              <th className="l">Merchant</th><th className="l">Cadence</th><th>Seen</th>
-              <th>Avg amt</th><th>Typ. day</th><th className="l">Last seen</th><th></th>
-            </tr></thead>
-            <tbody>
-              {cands.map((c, i) => (
-                <tr key={i}>
-                  <td className="l">{c.merchant}</td>
-                  <td className="l">{c.cadence}</td>
-                  <td>{c.occurrences}</td>
-                  <td>{sgd(c.avg_amount)}</td>
-                  <td className="mut">{c.typical_day}</td>
-                  <td className="l mut">{c.last_seen}</td>
-                  <td style={{ whiteSpace: "nowrap" }}>
-                    <button className="link-btn" onClick={() => addCandidate(c)}>+ Track</button>
-                    &nbsp;<button className="link-btn mut" onClick={() => dismiss(c.merchant)} title="Not recurring — dismiss">✕</button>
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
+          <div className="pinned">
+            <table>
+              <thead><tr>
+                <th className="l">Merchant</th><th className="l">Cadence</th><th>Seen</th>
+                <th>Avg amt</th><th>Typ. day</th><th className="l">Last seen</th><th></th>
+              </tr></thead>
+              <tbody>
+                {cands.map((c, i) => (
+                  <tr key={i}>
+                    <td className="l">{c.merchant}</td>
+                    <td className="l">{c.cadence}</td>
+                    <td>{c.occurrences}</td>
+                    <td>{sgd(c.avg_amount)}</td>
+                    <td className="mut">{c.typical_day}</td>
+                    <td className="l mut">{c.last_seen}</td>
+                    <td style={{ whiteSpace: "nowrap" }}>
+                      <button className="link-btn" onClick={() => addCandidate(c)}>+ Track</button>
+                      &nbsp;<button className="link-btn mut" onClick={() => dismiss(c.merchant)} title="Not recurring — dismiss">✕</button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
         )}
       </div>
     </div>

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -133,6 +133,83 @@ th, td { padding: 7px 10px; text-align: right; border-bottom: 1px solid #20262e;
 th { color: var(--mut); font-size: 11px; text-transform: uppercase; position: sticky; top: 0; background: var(--panel); }
 td.l, th.l { text-align: left; }
 tr:hover td { background: #1a212a; }
+/* Hover is dead on touch, so a tappable row says so a second way: `:active` for the tap
+   itself, and the persistent `›` in the pinned block below for the state between taps.
+   Written at every width rather than inside a tier — a mouse-down flash in the colour the
+   row already takes on hover costs desktop nothing, and the alternative was a second rule
+   in a tablet tier whose whole claim is that it holds exactly one. */
+tr.rowlink:active > td { background: #1a212a; }
+/* Dividends' total rule, moved off the `<tr>` and onto its cells. `border-collapse:
+   separate` — which the pinned block below switches that table to — does not paint a border
+   declared on a row at all. Identical under both modes, so it is unconditional. */
+.totalrow > * { border-top: 2px solid var(--line); font-weight: 600; }
+
+/* ─── pattern A: the pinned identity column ──────────────────────────────────────────────
+   For the tables that exist so you can compare a number DOWN the column. You read the real
+   table through a 390px window rather than a translation of it: the identity column is
+   pinned, the rest scrolls horizontally, and alignment, tabular numerals and the sticky
+   header survive untouched — which is most of why this beat card-per-row on the widest
+   table, 15 rows on screen against 3. No table drops a column; the pattern scrolls to them.
+
+   BELOW 1024, not below 640. The pin is worth *more* as the window narrows: at 640, behind
+   the 200px rail, the desktop table shows two identity columns and not one number, and
+   because `.main` owns the scroll there, reaching a number takes the identity away with it —
+   strictly worse than the phone. Above 1024 none of this applies and the desktop table is
+   what it always was; pattern A at desktop widths is a separate, open question.
+
+   THE TRAP. Under `border-collapse: collapse` the borders belong to the *table*'s border
+   grid, and a cell that has left the flow leaves them behind — a sticky header and a pinned
+   column both lose their rules. `separate` with zero spacing renders identically here,
+   because the only border in play is a per-cell `border-bottom`.
+
+   The z-indexes are layered rather than merely nonzero, and the order is forced. A pinned
+   body cell comes *earlier* in the DOM than the cells that scroll under it, so without a
+   z-index they paint over it; the header must clear the pinned column; and the header's own
+   first cell is stuck on both axes at once, so it must clear the header. 2 / 3 / 4. Static
+   body cells need no number — positioned descendants already paint above them.
+
+   `overscroll-behavior` IS DELIBERATELY UNSET, and this comment is the reason it stays that
+   way. The reflex on a capped scroll box is `contain`; here it is actively wrong. Default
+   chaining is what you want — flick the table, hit its end, the page keeps going. `contain`
+   traps the gesture inside a 60svh box with nothing to say why. `-webkit-overflow-scrolling:
+   touch` is absent for a duller reason: it has been the default since iOS 13. */
+@media (max-width: 1023.98px) {
+  .pinned { overflow-x: auto; }
+  .pinned table { border-collapse: separate; border-spacing: 0; }
+  .pinned th { z-index: 3; }
+  .pinned thead > tr > :first-child { position: sticky; left: 0; z-index: 4; }
+  /* `.grouprow` is excluded because its first cell is a `colSpan` banner as wide as seven
+     columns — pinning that would park seven columns' worth of subtotal over the numbers the
+     scroll exists to reach. The group label slides away instead; its background is what
+     keeps the row identifiable once it has. */
+  .pinned tbody > tr:not(.grouprow) > :first-child {
+    position: sticky; left: 0; z-index: 2; background: var(--panel); }
+  .pinned tbody > tr:not(.grouprow):hover > :first-child { background: #1a212a; }
+  .pinned tbody > tr.rowlink:active > :first-child { background: #1a212a; }
+  /* The chevron: persistent, at the right edge of the *pinned* cell, so "this row opens
+     something" is visible without hovering and cannot be scrolled away. Absolutely
+     positioned against the sticky cell with the padding reserving its lane, so it never
+     collides with a long name. Rows that merely expand in place keep their own ▸/▾ and do
+     not get this — the chevron means the row navigates away. */
+  .pinned tbody > tr.rowlink > :first-child { padding-right: 24px; }
+  .pinned tbody > tr.rowlink > :first-child::after {
+    content: "›"; position: absolute; right: 8px; top: 50%; transform: translateY(-50%);
+    color: var(--mut); font-size: 15px; font-weight: 600; }
+}
+/* The trades ledger capped its own height and scrolled both ways before this pattern
+   existed — which is what makes A the *smaller* change there rather than a replacement.
+   Kept as a class rather than the inline styles it replaces so the phone tier's `60svh` can
+   win over it: an inline `max-height` beats any stylesheet. */
+.selfscroll { overflow: auto; max-height: 480px; }
+/* Holdings' footnote as a disclosure — five lines of prose above a table that wants every
+   row it can get. The summary is hidden by default and turned on in the phone block, which
+   is the inverse of how it reads: `open` is set once at mount from the same 640 the
+   stylesheet uses, so above the tier the element renders open with no summary and looks
+   exactly like the paragraph it replaced. It stays OUTSIDE the scroll wrapper — a block
+   child of an `overflow-x: auto` container sizes to the container rather than to the table,
+   so it would sit at the far left and slide out of view as you scrolled right to read
+   columns. */
+.tablenote > summary { display: none; }
 .pos { color: var(--pos); } .neg { color: var(--neg); } .mut { color: var(--mut); }
 .pill { font-size: 11px; padding: 1px 7px; border-radius: 9px; background: var(--panel2); color: var(--mut); }
 /* the merged options identity cell — see modules/portfolio/contract.jsx */
@@ -202,9 +279,11 @@ input, select, textarea { background: var(--panel2); border: 1px solid var(--lin
    `639.98px` rather than `639px` so no fractional viewport width lands in a 1px dead zone
    against the tablet tier's `min-width: 640px`.
 
-   640 is a literal in three places: here, `tests/viewports.js`, and — once the charts land —
-   the `matchMedia` hook. JS cannot read a custom property and this repo takes no build step
-   to make one, so the sides cross-reference in comments instead of sharing a constant. */
+   640 is a literal in three places: here, `tests/viewports.js`, and `Holdings.jsx`'s
+   `startsCollapsed` — the app's first `matchMedia` read, which landed with the pinned column
+   rather than with the charts as expected. JS cannot read a custom property and this repo
+   takes no build step to make one, so the sides cross-reference in comments instead of
+   sharing a constant. The charts will be the fourth site, not the third. */
 @media (max-width: 639.98px) {
   /* The content gutter, and the app's first safe-area handling.
 
@@ -292,4 +371,36 @@ input, select, textarea { background: var(--panel2); border: 1px solid var(--lin
   /* Square, like every other call site of `--tap` — a floor one selector writes differently
      stops being a floor. Free here: the label is already ~76px wide. */
   .logout-btn { min-height: var(--tap); min-width: var(--tap); }
+
+  /* ── pattern A's height, and the sticky header it buys ──
+     A wrapper that sizes to its content is a scroll container that never scrolls, and a
+     sticky header inside one is dead — it sticks to a top that never moves. A cap restores
+     it, and on a 13-column table scrolled sideways the header is the half of the pattern
+     that tells you *which number* you are looking at; the pin only tells you which row.
+
+     ONE SELF-LIMITING RULE RATHER THAN AN EXEMPTION LIST. `max-height` is a no-op whenever
+     the table is shorter, so Performance — bounded at eight rows by its grouping dimension
+     and never more — never sees it, while Recurring engages only once its list is long.
+     Rejected unconditional: turning a long list into a 60vh box on a 1280px desktop is a
+     visible change to a view nobody complained about.
+
+     `svh`, like the shell, so the box cannot resize mid-flick when a toolbar retracts. A
+     height rather than a row count on purpose: it almost always clips the last row through
+     the middle, and half a row is the most reliable "more below" cue there is — which is
+     also why there is no gradient and no scrollbar affordance here.
+
+     The scroll-ownership work expected `Holdings` to escape this rule, on the reading that
+     its table is a direct flex child of `.main` — where `overflow-x` flips `min-height:
+     auto` to 0, the wrapper shrinks to the pane, and the header sticks for free. In the
+     shipped markup every view's root is a `.card`, so no such table exists and the rule is
+     uniform. That is the outcome the rule was shaped to make safe: one declaration, no list
+     of exceptions to keep current. */
+  .pinned { max-height: 60svh; }
+
+  /* The disclosure the footnote becomes here. Measured at the 44px pitch it takes Holdings
+     from 11 rows to 13 in portrait and from 2 to 4 in landscape — the largest single row
+     win available on that screen. Left a list-item so the platform's own marker survives;
+     `min-height` rather than flex centring for the same reason. */
+  .tablenote > summary { display: list-item; min-height: var(--tap); padding: 11px 0;
+    color: var(--mut); font-size: 12px; font-weight: 600; cursor: pointer; }
 }

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1,6 +1,10 @@
 :root {
   --bg: #0f1419; --panel: #161b22; --panel2: #1c232c; --line: #2b333d;
   --txt: #d7dde4; --mut: #8b97a5; --pos: #2ea043; --neg: #f85149; --acc: #388bfd;
+  /* The row-feedback colour. A literal until the pinned column gave it a third and fourth
+     call site: an opaque pinned cell has to restate whatever the row it sits in is doing,
+     so hover and the tap flash both need it in two places rather than one. */
+  --hover: #1a212a;
   /* The one number that earns a token in a block that otherwise holds only colours: the
      phone tap floor. It recurs across unrelated selectors as the phone tier lands, which
      is the whole test — every other phone value is written as a literal in the media
@@ -132,17 +136,32 @@ table { width: 100%; border-collapse: collapse; font-variant-numeric: tabular-nu
 th, td { padding: 7px 10px; text-align: right; border-bottom: 1px solid #20262e; white-space: nowrap; }
 th { color: var(--mut); font-size: 11px; text-transform: uppercase; position: sticky; top: 0; background: var(--panel); }
 td.l, th.l { text-align: left; }
-tr:hover td { background: #1a212a; }
+tr:hover td { background: var(--hover); }
 /* Hover is dead on touch, so a tappable row says so a second way: `:active` for the tap
    itself, and the persistent `›` in the pinned block below for the state between taps.
    Written at every width rather than inside a tier — a mouse-down flash in the colour the
    row already takes on hover costs desktop nothing, and the alternative was a second rule
    in a tablet tier whose whole claim is that it holds exactly one. */
-tr.rowlink:active > td { background: #1a212a; }
+tr.rowlink:active > td { background: var(--hover); }
 /* Dividends' total rule, moved off the `<tr>` and onto its cells. `border-collapse:
    separate` — which the pinned block below switches that table to — does not paint a border
    declared on a row at all. Identical under both modes, so it is unconditional. */
 .totalrow > * { border-top: 2px solid var(--line); font-weight: 600; }
+
+/* The two wrappers that predate this pattern, keeping the behaviour they shipped with so the
+   pin is additive rather than a replacement — and so both still hold above 1024, where
+   `.pinned` does nothing. Dividends' crosstab is `.hscroll`; the trades ledger is both.
+
+   Classes rather than the inline styles they replace, and declared ABOVE the pattern rather
+   than below it, for one reason each. Inline first: `.selfscroll`'s 480px would otherwise
+   beat the pattern's `60svh` outright, because an inline value beats any stylesheet. Then
+   order: `.selfscroll` and `.pinned` have the same specificity and a media query adds none,
+   so whichever is written last wins — and the one that has to win is the tier's. This is a
+   source-order dependency, which is a bad thing to rely on and a worse thing to leave
+   unguarded, so `pinned.spec.js` measures every wrapper against the cap rather than trusting
+   it. That gate caught this exact rule in the wrong place. */
+.hscroll { overflow-x: auto; }
+.selfscroll { overflow: auto; max-height: 480px; }
 
 /* ─── pattern A: the pinned identity column ──────────────────────────────────────────────
    For the tables that exist so you can compare a number DOWN the column. You read the real
@@ -175,6 +194,33 @@ tr.rowlink:active > td { background: #1a212a; }
    touch` is absent for a duller reason: it has been the default since iOS 13. */
 @media (max-width: 1023.98px) {
   .pinned { overflow-x: auto; }
+  /* THE HEIGHT IS PART OF THE PATTERN, not part of the phone tier, and getting that wrong is
+     silent. `overflow-x: auto` forces `overflow-y` from `visible` to `auto`, so this wrapper
+     becomes the sticky scrollport for the `th` above whether anyone asked for it or not — and
+     a scrollport that sizes to its content never scrolls, so the header rides the *page*
+     away instead of sticking. Measured: −500px of drift on a 500px page scroll. Without a
+     height here the pattern would take a working sticky header (stuck to `.main`, which does
+     scroll) and break it everywhere between 640 and 1024.
+
+     ONE SELF-LIMITING RULE RATHER THAN AN EXEMPTION LIST. `max-height` is a no-op whenever
+     the table is shorter, so Performance — bounded at eight rows by its grouping dimension
+     and never more — never sees it, while Recurring engages only once its list is long.
+
+     Scoped to the pattern's own tier rather than to the phone, which is where 020 wrote it
+     when pattern A was still a phone-only idea and 018 had not yet widened it to 1024. 018
+     said as much in its hand-off: scoping horizontal scroll to the table "changes what
+     `.main` owns — adjacent to, not the same as, the vertical question in 020". This is that
+     question, answered. It also fixes landscape, which the phone-only version could not
+     reach at all: a rotated phone is 844px wide and exits the phone block, so the inner box
+     020 decision 5 deliberately kept in landscape was not actually there. What stays out is
+     desktop, which is what 020 was protecting — a long list turning into a 60vh box on a
+     1280px monitor is a visible change to a view nobody complained about.
+
+     `svh`, like the shell, so the box cannot resize mid-flick when a toolbar retracts. A
+     height rather than a row count on purpose: it almost always clips the last row through
+     the middle, and half a row is the most reliable "more below" cue there is — which is
+     also why there is no gradient and no scrollbar affordance here. */
+  .pinned { max-height: 60svh; }
   .pinned table { border-collapse: separate; border-spacing: 0; }
   .pinned th { z-index: 3; }
   .pinned thead > tr > :first-child { position: sticky; left: 0; z-index: 4; }
@@ -184,8 +230,10 @@ tr.rowlink:active > td { background: #1a212a; }
      keeps the row identifiable once it has. */
   .pinned tbody > tr:not(.grouprow) > :first-child {
     position: sticky; left: 0; z-index: 2; background: var(--panel); }
-  .pinned tbody > tr:not(.grouprow):hover > :first-child { background: #1a212a; }
-  .pinned tbody > tr.rowlink:active > :first-child { background: #1a212a; }
+  /* The pinned cell is opaque, so it needs the row's two feedback states restated on it or
+     it stays flat while the rest of the row lights up. */
+  .pinned tbody > tr:not(.grouprow):hover > :first-child,
+  .pinned tbody > tr.rowlink:active > :first-child { background: var(--hover); }
   /* The chevron: persistent, at the right edge of the *pinned* cell, so "this row opens
      something" is visible without hovering and cannot be scrolled away. Absolutely
      positioned against the sticky cell with the padding reserving its lane, so it never
@@ -196,11 +244,6 @@ tr.rowlink:active > td { background: #1a212a; }
     content: "›"; position: absolute; right: 8px; top: 50%; transform: translateY(-50%);
     color: var(--mut); font-size: 15px; font-weight: 600; }
 }
-/* The trades ledger capped its own height and scrolled both ways before this pattern
-   existed — which is what makes A the *smaller* change there rather than a replacement.
-   Kept as a class rather than the inline styles it replaces so the phone tier's `60svh` can
-   win over it: an inline `max-height` beats any stylesheet. */
-.selfscroll { overflow: auto; max-height: 480px; }
 /* Holdings' footnote as a disclosure — five lines of prose above a table that wants every
    row it can get. The summary is hidden by default and turned on in the phone block, which
    is the inverse of how it reads: `open` is set once at mount from the same 640 the
@@ -372,30 +415,13 @@ input, select, textarea { background: var(--panel2); border: 1px solid var(--lin
      stops being a floor. Free here: the label is already ~76px wide. */
   .logout-btn { min-height: var(--tap); min-width: var(--tap); }
 
-  /* ── pattern A's height, and the sticky header it buys ──
-     A wrapper that sizes to its content is a scroll container that never scrolls, and a
-     sticky header inside one is dead — it sticks to a top that never moves. A cap restores
-     it, and on a 13-column table scrolled sideways the header is the half of the pattern
-     that tells you *which number* you are looking at; the pin only tells you which row.
-
-     ONE SELF-LIMITING RULE RATHER THAN AN EXEMPTION LIST. `max-height` is a no-op whenever
-     the table is shorter, so Performance — bounded at eight rows by its grouping dimension
-     and never more — never sees it, while Recurring engages only once its list is long.
-     Rejected unconditional: turning a long list into a 60vh box on a 1280px desktop is a
-     visible change to a view nobody complained about.
-
-     `svh`, like the shell, so the box cannot resize mid-flick when a toolbar retracts. A
-     height rather than a row count on purpose: it almost always clips the last row through
-     the middle, and half a row is the most reliable "more below" cue there is — which is
-     also why there is no gradient and no scrollbar affordance here.
-
-     The scroll-ownership work expected `Holdings` to escape this rule, on the reading that
-     its table is a direct flex child of `.main` — where `overflow-x` flips `min-height:
-     auto` to 0, the wrapper shrinks to the pane, and the header sticks for free. In the
-     shipped markup every view's root is a `.card`, so no such table exists and the rule is
-     uniform. That is the outcome the rule was shaped to make safe: one declaration, no list
-     of exceptions to keep current. */
-  .pinned { max-height: 60svh; }
+  /* PATTERN A'S HEIGHT IS NOT HERE, and its absence is the decision. `60svh` reads like a
+     phone rule and 020 wrote it as one, but the height is what makes the sticky header work
+     at all — and a phone-only version would leave the header broken from 640 to 1024 and,
+     because a rotated phone is 844px wide, in landscape too. It travels with the pattern
+     instead; see the `.pinned` block above. This is the second time a rule written for the
+     phone turned out to belong to the width the pattern claims rather than to the tier —
+     `.main`'s landscape gutter was the first. */
 
   /* The disclosure the footnote becomes here. Measured at the 44px pitch it takes Holdings
      from 11 rows to 13 in portrait and from 2 to 4 in landscape — the largest single row

--- a/web/tests/hscroll-baseline.js
+++ b/web/tests/hscroll-baseline.js
@@ -23,7 +23,7 @@
  * Above 1024px there is no gate and therefore no entries here — `HSCROLL_GATE_APPLIES_BELOW`
  * in `viewports.js` says why those three viewports are exempt.
  *
- * LOWERED THREE TIMES SO FAR.
+ * LOWERED FOUR TIMES SO FAR.
  *
  * 1. The unconditional fixes. `.grid2`'s `auto-fit` did most of it: two 419px tracks side by
  *    side became one, so `Portfolio › Overview` went 619 → 288 at 360px, `Spending › By
@@ -50,12 +50,30 @@
  *    and `Classify` (34) at 360, `Classify` (4) at 390, and `Spending › Overview` (35) at
  *    639. The three viewports at or above 640px are untouched to the pixel, which is the
  *    tier boundary doing its job for the second time.
+ *
+ * 4. The pinned identity column. The first drop that is not uniform and not a constant: it
+ *    is **the whole overflow or none of it**, per view, because a table either got the
+ *    pattern or did not. Six of the seven rows that carried the largest numbers go to
+ *    **zero at every gated viewport** — `Holdings` from 1031, `Performance` from 507,
+ *    `Recurring` from 430 — and they go to zero at 640, 834 and 844 as well, because the
+ *    pattern is written below 1024 rather than below 640. That is the first time a tier
+ *    boundary has *not* shown up in this file, and it is deliberate: the pin is worth more
+ *    as the window narrows, so the tablet has it too.
+ *
+ *    `SecurityDetail` is the seventh and does not move. Its options table was pinned; its
+ *    914px transaction history was not, and that is the one that sets the width. The
+ *    remaining non-zero rows name what is left rather than what failed: both `Transactions`
+ *    ledgers and `SecurityDetail` wait for card-per-row, `Net Worth` for the editor floor,
+ *    and the identical 74 / 44 / 4 / 8 / 48 across `Portfolio › Overview`, `Options`,
+ *    `By Category` and `Spending › Overview` is one shared cause — `.grid2`'s `minmax(420px,
+ *    1fr)` track floor, which does not fit a 362px pane. None of the four holds a table
+ *    this pattern was assigned to.
  */
 export const HSCROLL_BASELINE = {
   "small-phone": {
     "Portfolio › Overview": 74,
-    "Portfolio › Holdings": 1031,
-    "Portfolio › Performance": 507,
+    "Portfolio › Holdings": 0,
+    "Portfolio › Performance": 0,
     "Portfolio › Dividends": 0,
     "Portfolio › Options": 74,
     "Portfolio › Transactions": 891,
@@ -64,13 +82,13 @@ export const HSCROLL_BASELINE = {
     "Spending › Overview": 114,
     "Spending › By Category": 74,
     "Spending › Classify": 0,
-    "Spending › Recurring": 430,
+    "Spending › Recurring": 0,
     "Spending › Transactions": 867,
   },
   "design-width": {
     "Portfolio › Overview": 44,
-    "Portfolio › Holdings": 1001,
-    "Portfolio › Performance": 477,
+    "Portfolio › Holdings": 0,
+    "Portfolio › Performance": 0,
     "Portfolio › Dividends": 0,
     "Portfolio › Options": 44,
     "Portfolio › Transactions": 861,
@@ -79,13 +97,13 @@ export const HSCROLL_BASELINE = {
     "Spending › Overview": 84,
     "Spending › By Category": 44,
     "Spending › Classify": 0,
-    "Spending › Recurring": 400,
+    "Spending › Recurring": 0,
     "Spending › Transactions": 837,
   },
   "large-phone": {
     "Portfolio › Overview": 4,
-    "Portfolio › Holdings": 961,
-    "Portfolio › Performance": 437,
+    "Portfolio › Holdings": 0,
+    "Portfolio › Performance": 0,
     "Portfolio › Dividends": 0,
     "Portfolio › Options": 4,
     "Portfolio › Transactions": 821,
@@ -94,13 +112,13 @@ export const HSCROLL_BASELINE = {
     "Spending › Overview": 44,
     "Spending › By Category": 4,
     "Spending › Classify": 0,
-    "Spending › Recurring": 360,
+    "Spending › Recurring": 0,
     "Spending › Transactions": 797,
   },
   "phone-tier-last-pixel": {
     "Portfolio › Overview": 0,
-    "Portfolio › Holdings": 752,
-    "Portfolio › Performance": 228,
+    "Portfolio › Holdings": 0,
+    "Portfolio › Performance": 0,
     "Portfolio › Dividends": 0,
     "Portfolio › Options": 0,
     "Portfolio › Transactions": 612,
@@ -109,13 +127,13 @@ export const HSCROLL_BASELINE = {
     "Spending › Overview": 0,
     "Spending › By Category": 0,
     "Spending › Classify": 0,
-    "Spending › Recurring": 151,
+    "Spending › Recurring": 0,
     "Spending › Transactions": 588,
   },
   "tablet-tier-first-pixel": {
     "Portfolio › Overview": 8,
-    "Portfolio › Holdings": 965,
-    "Portfolio › Performance": 441,
+    "Portfolio › Holdings": 0,
+    "Portfolio › Performance": 0,
     "Portfolio › Dividends": 0,
     "Portfolio › Options": 8,
     "Portfolio › Transactions": 825,
@@ -124,13 +142,13 @@ export const HSCROLL_BASELINE = {
     "Spending › Overview": 48,
     "Spending › By Category": 8,
     "Spending › Classify": 0,
-    "Spending › Recurring": 364,
+    "Spending › Recurring": 0,
     "Spending › Transactions": 801,
   },
   "rotated-phone": {
     "Portfolio › Overview": 0,
-    "Portfolio › Holdings": 761,
-    "Portfolio › Performance": 237,
+    "Portfolio › Holdings": 0,
+    "Portfolio › Performance": 0,
     "Portfolio › Dividends": 0,
     "Portfolio › Options": 0,
     "Portfolio › Transactions": 621,
@@ -139,13 +157,13 @@ export const HSCROLL_BASELINE = {
     "Spending › Overview": 0,
     "Spending › By Category": 0,
     "Spending › Classify": 0,
-    "Spending › Recurring": 160,
+    "Spending › Recurring": 0,
     "Spending › Transactions": 597,
   },
   "ipad-portrait": {
     "Portfolio › Overview": 0,
-    "Portfolio › Holdings": 771,
-    "Portfolio › Performance": 247,
+    "Portfolio › Holdings": 0,
+    "Portfolio › Performance": 0,
     "Portfolio › Dividends": 0,
     "Portfolio › Options": 0,
     "Portfolio › Transactions": 631,
@@ -154,7 +172,7 @@ export const HSCROLL_BASELINE = {
     "Spending › Overview": 0,
     "Spending › By Category": 0,
     "Spending › Classify": 0,
-    "Spending › Recurring": 170,
+    "Spending › Recurring": 0,
     "Spending › Transactions": 607,
   },
 };

--- a/web/tests/pinned.spec.js
+++ b/web/tests/pinned.spec.js
@@ -238,10 +238,10 @@ for (const { view, tables, unrendered } of PINNED) {
 }
 
 test.describe("the height that makes the sticky header work", () => {
-  test("caps every pattern-A wrapper at 60svh on a phone, and leaves short tables alone",
+  test("caps every pattern-A wrapper at 60svh below the tier, and leaves short tables alone",
     async ({ page, baseURL }, testInfo) => {
       const vp = viewportOf(testInfo.project.name);
-      test.skip(vp.width >= PHONE_TIER_BELOW, "the cap is phone-only, by decision");
+      test.skip(vp.width >= PIN_TIER_BELOW, "above the tier the table keeps its full height");
 
       const cap = vp.height * 0.6;
 
@@ -275,23 +275,45 @@ test.describe("the height that makes the sticky header work", () => {
       });
     });
 
-  test("writes the cap in the phone block and nowhere else", async ({ page, baseURL }) => {
+  test("writes the cap against the pattern's tier, not the phone's", async ({ page, baseURL }) => {
     await openView(page, baseURL, "Portfolio › Holdings");
     const rules = await declarationsFor(page, ".pinned");
-    const capped = rules.filter((r) => r.decls["max-height"] !== undefined);
-    expect(capped, "`.pinned` declares a height in more than one place").toHaveLength(1);
-    // Rejected unconditional: turning a long list into a 60vh box on a 1280px desktop is a
-    // visible change to a view nobody complained about.
-    expect(capped[0].media, "the cap escaped the phone block").toContain("639.98px");
-    // `svh`, like the shell — a box sized in `vh` resizes mid-flick when a toolbar retracts,
-    // and this one is being flicked by definition.
-    expect(capped[0].decls["max-height"]).toBe("60svh");
 
     const pattern = rules.filter((r) => r.decls["overflow-x"] !== undefined);
     expect(pattern, "the pattern itself is declared in more than one place").toHaveLength(1);
     expect(pattern[0].media, "the pattern is not written against the pin tier")
       .toContain(PIN_TIER_EDGE);
+
+    const capped = rules.filter((r) => r.decls["max-height"] !== undefined);
+    expect(capped, "`.pinned` declares a height in more than one place").toHaveLength(1);
+    // THE TIER IS THE ASSERTION. `overflow-x: auto` forces `overflow-y` to `auto`, so the
+    // wrapper becomes the sticky scrollport wherever the pattern applies — and a scrollport
+    // that sizes to content never scrolls, so the header rides the page away instead. Behind
+    // `PHONE_TIER_EDGE` this rule leaves the header broken from 640 to 1024 and in landscape,
+    // where a rotated phone is 844px wide. The two edges are one character apart to read and
+    // a whole tier apart in effect, which is exactly why this is a gate.
+    expect(capped[0].media, "the cap is scoped to a narrower tier than the pattern it serves")
+      .toContain(PIN_TIER_EDGE);
+    // `svh`, like the shell — a box sized in `vh` resizes mid-flick when a toolbar retracts,
+    // and this one is being flicked by definition.
+    expect(capped[0].decls["max-height"]).toBe("60svh");
   });
+
+  test("the long table really is a scroll box wherever the pattern applies",
+    async ({ page, baseURL }, testInfo) => {
+      const vp = viewportOf(testInfo.project.name);
+      test.skip(vp.width >= PIN_TIER_BELOW, "above the tier the pane owns the scroll again");
+      // The gate the per-view header check cannot hold on its own: that one skips a wrapper
+      // that does not scroll, on the reasonable grounds that a short table has nothing to
+      // demonstrate — which is also exactly what a dead sticky header looks like from here.
+      // Holdings is long at every width in the fixtures, so for that one table "it does not
+      // scroll" is never a legitimate answer.
+      await openView(page, baseURL, "Portfolio › Holdings");
+      const scrolls = await page.locator(".pinned").first()
+        .evaluate((el) => el.scrollHeight > el.clientHeight);
+      expect(scrolls, "the wrapper sizes to content, so its sticky header sticks to nothing")
+        .toBe(true);
+    });
 });
 
 test("no rule anywhere declares `overscroll-behavior`", async ({ page, baseURL }) => {
@@ -366,10 +388,12 @@ test.describe("a tappable row says so without a hover", () => {
       const rules = await declarationsFor(page, "tr.rowlink:active > td");
       expect(rules, "no `:active` feedback — hover does not exist on touch").toHaveLength(1);
       expect(rules[0].media, "the tap feedback was scoped to a tier").toBeNull();
-      // `background-color`, not `background`: the CSSOM expands the shorthand into its nine
-      // longhands, so the property as authored is not a key here at all.
-      expect(rules[0].decls["background-color"], "the row flashes nothing on tap")
-        .toBe("rgb(26, 33, 42)");
+      // Read from `text` rather than `decls`, and `support/css.js` explains why at length: a
+      // shorthand carrying a `var()` arrives as nine longhands with EMPTY values and no
+      // shorthand key, so `background: var(--hover)` is invisible under both names. The
+      // token itself is the assertion — the pinned cell has to restate this colour, and a
+      // literal here is how the two halves of one feedback state drift apart.
+      expect(rules[0].text, "the row flashes nothing on tap").toContain("var(--hover)");
     });
 });
 

--- a/web/tests/pinned.spec.js
+++ b/web/tests/pinned.spec.js
@@ -1,0 +1,426 @@
+/**
+ * Pattern A: the pinned identity column, and the scroll ownership that comes with it.
+ *
+ * Seven tables across six views exist so you can compare a number DOWN the column. Below
+ * 1024px they are read through a window: the identity column is pinned, the rest scrolls
+ * horizontally inside a wrapper, and the header stays put while the rows go by. This file
+ * is the gate on all three halves plus the traps that make them fragile.
+ *
+ * WHY THE TIER IS 1024 AND NOT 640. The pin is worth *more* as the window narrows. At 640,
+ * behind the 200px rail, the desktop table shows two identity columns and not one number,
+ * and because `.main` owns the scroll there, reaching a number takes the identity away with
+ * it — strictly worse than the phone. So every gate here runs at seven of the ten viewports,
+ * and the other three assert the inverse: that nothing changed above the tier.
+ *
+ * WHAT IS ASSERTED AS A DECLARATION RATHER THAN AS GEOMETRY, and why — the same reasoning
+ * `foundations.spec.js` opens with. `overscroll-behavior` being *unset* has no geometry: the
+ * observable difference between `auto` and `contain` is whether a flick that reaches the end
+ * of the table carries on to the page, and a synthetic scroll does not chain. So it is
+ * asserted twice over as a fact about the stylesheet — no rule declares it, and it computes
+ * to `auto` on every wrapper — because it is the one property here whose *absence* is the
+ * decision, and the reflex is to reach for `contain`.
+ *
+ * WHAT THIS CANNOT CHECK. Whether two nested scroll regions on Recurring feel confusing —
+ * that is an open call on a real device, not an assertion. And nothing here says the pinned
+ * column is a useful *identity*; a pin that reads Put / Put / Call passes every gate below
+ * and is worthless. That is what the merged contract cell exists for, and it is a reading
+ * job rather than a measurement.
+ */
+import { expect, test } from "@playwright/test";
+import { PHONE_TIER_BELOW, PIN_TIER_BELOW, PIN_TIER_EDGE, VIEWPORTS } from "./viewports.js";
+import { openView } from "./support/app.js";
+import { declarationsFor } from "./support/css.js";
+
+const viewportOf = (projectName) => VIEWPORTS.find((v) => v.name === projectName);
+
+/**
+ * Every table assigned the pattern, with the two things a pin can silently get wrong.
+ *
+ * `pin` is the first header's text, which is the assertion that the *right* column got
+ * pinned — Performance's is `{by}`, lowercase and changing with its `<select>`, so this
+ * doubles as the check that the pinned header is the grouping key rather than a label.
+ *
+ * `cols` is the header count, and it is here because of the criterion no other gate covers:
+ * **no table drops a column.** The pattern scrolls to them. A build that "fixed" the phone by
+ * hiding four columns behind a media query would pass every geometric gate in this file.
+ * Dividends is `null` because its column count is one per year and grows with time — which
+ * is exactly why that table got horizontal scroll rather than anything that expires.
+ *
+ * `unrendered` is the seam showing through, and it is written down rather than left as a
+ * shorter list. Recurring's tracked monitor is behind a non-empty tracked list and the owner
+ * tracks nothing, so the committed fixture is `[]` and that table does not render at all —
+ * the same shape of blind spot that let four tables through an entire planning effort. The
+ * fixtures are derived from the live database and are not hand-edited, so the honest move is
+ * to name the gap: it is reported as an annotation on every run rather than closed by
+ * inventing a row.
+ */
+const PINNED = [
+  { view: "Portfolio › Holdings", tables: [{ pin: "Security", cols: 13 }] },
+  { view: "Portfolio › Performance", tables: [{ pin: "market", cols: 9 }] },
+  { view: "Portfolio › Dividends", tables: [{ pin: "Bucket", cols: null }] },
+  { view: "Portfolio › Options", tables: [{ pin: "Underlying", cols: 8 }] },
+  { view: "Portfolio › SecurityDetail", tables: [{ pin: "Contract", cols: 6 }] },
+  {
+    view: "Spending › Recurring",
+    tables: [{ pin: "Merchant", cols: 7 }],
+    unrendered: [
+      "Recurring.jsx's tracked monitor (11 cols, pin `Name`) — `/api/spending/recurring` " +
+      "is `[]` in the committed fixtures, so the table is never mounted",
+    ],
+  },
+];
+
+/** The measurements one wrapper can be asked for, taken in a single round trip. */
+const wrapperFacts = (page, index) =>
+  page.locator(".pinned").nth(index).evaluate((wrap) => {
+    const style = getComputedStyle(wrap);
+    const table = wrap.querySelector("table");
+    const tableStyle = getComputedStyle(table);
+    const headers = [...table.querySelectorAll("thead th")];
+    const corner = headers[0];
+    // `:not(.grouprow)` in the stylesheet, and here for the same reason: Holdings' group
+    // banner is a `colSpan` cell as wide as seven columns and is deliberately not pinned.
+    const body = table.querySelector("tbody tr:not(.grouprow) > *");
+    const banner = table.querySelector("tbody tr.grouprow > *");
+    return {
+      overflowX: style.overflowX,
+      overscroll: style.overscrollBehavior,
+      height: wrap.getBoundingClientRect().height,
+      scrollsX: wrap.scrollWidth > wrap.clientWidth,
+      scrollsY: wrap.scrollHeight > wrap.clientHeight,
+      borderCollapse: tableStyle.borderCollapse,
+      borderSpacing: tableStyle.borderSpacing,
+      headerCount: headers.length,
+      pinText: corner.textContent.trim(),
+      corner: {
+        position: getComputedStyle(corner).position,
+        left: getComputedStyle(corner).left,
+        top: getComputedStyle(corner).top,
+        borderBottomWidth: getComputedStyle(corner).borderBottomWidth,
+      },
+      body: body && {
+        position: getComputedStyle(body).position,
+        left: getComputedStyle(body).left,
+        borderBottomWidth: getComputedStyle(body).borderBottomWidth,
+      },
+      bannerPosition: banner && getComputedStyle(banner).position,
+    };
+  });
+
+for (const { view, tables, unrendered } of PINNED) {
+  test.describe(view, () => {
+    test("pins its identity column and scrolls the rest, with the header and its borders intact",
+      async ({ page, baseURL }, testInfo) => {
+        const vp = viewportOf(testInfo.project.name);
+        await openView(page, baseURL, view);
+
+        for (const gap of unrendered ?? []) {
+          testInfo.annotations.push({ type: "not-covered-by-fixtures", description: gap });
+        }
+
+        // Soft throughout: one page load, every gate reported. A pin that is missing and a
+        // header that lost its border are two findings, and hearing about them one run at a
+        // time is what makes a suite this size expensive to work against.
+        expect.soft(await page.locator(".pinned").count(), "pattern-A wrappers in this view")
+          .toBe(tables.length);
+
+        for (const [i, spec] of tables.entries()) {
+          const f = await wrapperFacts(page, i);
+
+          expect.soft(f.pinText, `the pinned header of table ${i + 1}`).toBe(spec.pin);
+          if (spec.cols !== null) {
+            expect.soft(f.headerCount, "a column was dropped — the pattern scrolls to them")
+              .toBe(spec.cols);
+          } else {
+            // One column per year, so the count is the fixture's rather than a constant.
+            expect.soft(f.headerCount, "the crosstab lost its year columns")
+              .toBeGreaterThanOrEqual(3);
+          }
+
+          if (vp.width >= PIN_TIER_BELOW) {
+            // The other half of the claim: above the tier this is the table it always was.
+            expect.soft(f.borderCollapse, "the desktop table changed its border model")
+              .toBe("collapse");
+            expect.soft(f.body?.position, "the pin reached desktop").toBe("static");
+            continue;
+          }
+
+          expect.soft(f.overflowX, `wrapper ${i + 1} does not own the sideways scroll`)
+            .toBe("auto");
+          // THE TRAP. Under `collapse` the borders belong to the table's border grid and a
+          // cell that has left the flow leaves them behind, so the pin and the sticky header
+          // both render rule-less. The border widths below are the half that would actually
+          // be visible; the border model is the half that explains it.
+          expect.soft(f.borderCollapse, "sticky cells lose their borders under `collapse`")
+            .toBe("separate");
+          expect.soft(f.borderSpacing, "`separate` without zero spacing is a visible change")
+            .toBe("0px");
+          expect.soft(f.corner.borderBottomWidth, "the sticky header lost its rule").toBe("1px");
+          expect.soft(f.body.borderBottomWidth, "the pinned column lost its rules").toBe("1px");
+
+          expect.soft(f.corner.position, "the header corner is not stuck").toBe("sticky");
+          expect.soft(f.corner.left, "the header corner is not pinned left").toBe("0px");
+          expect.soft(f.corner.top, "the header corner is not stuck to the top").toBe("0px");
+          expect.soft(f.body.position, "the identity column is not pinned").toBe("sticky");
+          expect.soft(f.body.left).toBe("0px");
+          if (f.bannerPosition !== null) {
+            // Holdings only, and deliberate: pinning a seven-column `colSpan` banner would
+            // park a subtotal over the numbers the sideways scroll exists to reach.
+            expect.soft(f.bannerPosition, "the group banner got pinned").toBe("static");
+          }
+
+          // The decision that has no geometry — see the header.
+          expect.soft(f.overscroll, "`overscroll-behavior` was set; default chaining is the decision")
+            .toBe("auto");
+        }
+      });
+
+    test("the identity stays put while the numbers scroll under it", async ({ page, baseURL }, testInfo) => {
+      const vp = viewportOf(testInfo.project.name);
+      test.skip(vp.width >= PIN_TIER_BELOW, "above the tier there is no pin to hold still");
+      await openView(page, baseURL, view);
+
+      for (let i = 0; i < tables.length; i++) {
+        // A table narrow enough to fit has nothing to demonstrate: the pin is still there,
+        // it simply never leaves. Reported rather than silently skipped, because "it fits"
+        // and "the wrapper stopped scrolling" look identical from here.
+        const moved = await page.locator(".pinned").nth(i).evaluate((wrap) => {
+          const row = wrap.querySelector("tbody tr:not(.grouprow)");
+          const pin = row.children[0];
+          const far = row.children[row.children.length - 1];
+          if (wrap.scrollWidth <= wrap.clientWidth) return null;
+          const before = { pin: pin.getBoundingClientRect().x, far: far.getBoundingClientRect().x };
+          wrap.scrollLeft = wrap.scrollWidth - wrap.clientWidth;
+          const after = { pin: pin.getBoundingClientRect().x, far: far.getBoundingClientRect().x };
+          return { pinDrift: Math.abs(after.pin - before.pin), farDrift: before.far - after.far };
+        });
+        if (moved === null) {
+          testInfo.annotations.push({
+            type: "fits-outright",
+            description: `${vp.name} · ${view} · table ${i + 1} needs no scroll`,
+          });
+          continue;
+        }
+        expect.soft(moved.pinDrift, `table ${i + 1}: the identity column scrolled away`)
+          .toBeLessThanOrEqual(1);
+        expect.soft(moved.farDrift, `table ${i + 1}: nothing scrolled`).toBeGreaterThan(0);
+      }
+    });
+
+    test("the header stays put while the rows go by", async ({ page, baseURL }, testInfo) => {
+      const vp = viewportOf(testInfo.project.name);
+      test.skip(vp.width >= PIN_TIER_BELOW, "above the tier the wrapper is not a scroll box");
+      await openView(page, baseURL, view);
+
+      for (let i = 0; i < tables.length; i++) {
+        const stuck = await page.locator(".pinned").nth(i).evaluate((wrap) => {
+          const th = wrap.querySelector("thead th");
+          if (wrap.scrollHeight <= wrap.clientHeight) return null;
+          const before = th.getBoundingClientRect().y;
+          wrap.scrollTop = wrap.scrollHeight - wrap.clientHeight;
+          return { drift: Math.abs(th.getBoundingClientRect().y - before) };
+        });
+        if (stuck === null) {
+          // Performance is the permanent case: its row count is bounded by the grouping
+          // dimension at eight, so it never scrolls and the tier's cap is a permanent no-op
+          // on it. That is why the cap is a `max-height` and not an exemption list.
+          testInfo.annotations.push({
+            type: "no-vertical-scroll",
+            description: `${vp.name} · ${view} · table ${i + 1} fits its box`,
+          });
+          continue;
+        }
+        expect.soft(stuck.drift, `table ${i + 1}: the sticky header scrolled away with the rows`)
+          .toBeLessThanOrEqual(1);
+      }
+    });
+  });
+}
+
+test.describe("the height that makes the sticky header work", () => {
+  test("caps every pattern-A wrapper at 60svh on a phone, and leaves short tables alone",
+    async ({ page, baseURL }, testInfo) => {
+      const vp = viewportOf(testInfo.project.name);
+      test.skip(vp.width >= PHONE_TIER_BELOW, "the cap is phone-only, by decision");
+
+      const cap = vp.height * 0.6;
+
+      // Every wrapper first, because the criterion is about all of them and the pair below
+      // only proves the two ends of it.
+      for (const { view, tables } of PINNED) {
+        await openView(page, baseURL, view);
+        const heights = await page.locator(".pinned")
+          .evaluateAll((els) => els.map((el) => el.getBoundingClientRect().height));
+        expect(heights, `${view}: pattern-A wrappers`).toHaveLength(tables.length);
+        for (const [i, h] of heights.entries()) {
+          expect.soft(h, `${view} table ${i + 1} is taller than the cap`).toBeLessThanOrEqual(cap + 1);
+        }
+      }
+
+      // Holdings is the long one and Performance the short one, and the pair IS the claim:
+      // one self-limiting rule rather than an exemption list. A `max-height` does nothing to
+      // a table that fits, so the same declaration reaches both and neither is named.
+      await openView(page, baseURL, "Portfolio › Holdings");
+      const long = await page.locator(".pinned").first().evaluate((el) => el.getBoundingClientRect().height);
+      expect(long, "the long table is not capped — its sticky header is dead").toBeLessThanOrEqual(cap + 1);
+      expect(long, "the cap collapsed the table").toBeGreaterThan(cap - 2);
+
+      await openView(page, baseURL, "Portfolio › Performance");
+      const short = await page.locator(".pinned").first().evaluate((el) => el.getBoundingClientRect().height);
+      expect(short, "the short table is being held at the cap rather than fitting")
+        .toBeLessThan(cap - 1);
+      testInfo.annotations.push({
+        type: "pinned-heights",
+        description: `${vp.name} · cap ${Math.round(cap)}px · Holdings ${Math.round(long)}px · Performance ${Math.round(short)}px`,
+      });
+    });
+
+  test("writes the cap in the phone block and nowhere else", async ({ page, baseURL }) => {
+    await openView(page, baseURL, "Portfolio › Holdings");
+    const rules = await declarationsFor(page, ".pinned");
+    const capped = rules.filter((r) => r.decls["max-height"] !== undefined);
+    expect(capped, "`.pinned` declares a height in more than one place").toHaveLength(1);
+    // Rejected unconditional: turning a long list into a 60vh box on a 1280px desktop is a
+    // visible change to a view nobody complained about.
+    expect(capped[0].media, "the cap escaped the phone block").toContain("639.98px");
+    // `svh`, like the shell — a box sized in `vh` resizes mid-flick when a toolbar retracts,
+    // and this one is being flicked by definition.
+    expect(capped[0].decls["max-height"]).toBe("60svh");
+
+    const pattern = rules.filter((r) => r.decls["overflow-x"] !== undefined);
+    expect(pattern, "the pattern itself is declared in more than one place").toHaveLength(1);
+    expect(pattern[0].media, "the pattern is not written against the pin tier")
+      .toContain(PIN_TIER_EDGE);
+  });
+});
+
+test("no rule anywhere declares `overscroll-behavior`", async ({ page, baseURL }) => {
+  // The reflex on a nested scroll box is `contain`, and here it is actively wrong: default
+  // chaining is what you want — flick the table, hit its end, the page keeps going. `contain`
+  // traps the gesture inside a 60svh box with nothing to say why. This is a source gate
+  // rather than a behavioural one because a synthetic scroll does not chain, so the
+  // difference between `auto` and `contain` cannot be observed from here at all.
+  await openView(page, baseURL, "Portfolio › Holdings");
+  const offenders = await page.evaluate(() => {
+    const found = [];
+    const walk = (rules) => {
+      for (const rule of rules) {
+        if (rule.style) {
+          for (const prop of rule.style) {
+            if (prop.startsWith("overscroll-behavior")) found.push(`${rule.selectorText} { ${prop} }`);
+          }
+        }
+        if (rule.cssRules) walk(rule.cssRules);
+      }
+    };
+    for (const sheet of document.styleSheets) {
+      try { walk(sheet.cssRules); } catch { /* a cross-origin sheet, if one ever appears */ }
+    }
+    return found;
+  });
+  expect(offenders, "chaining is the decision — see the comment above `.pinned`").toEqual([]);
+});
+
+test.describe("a tappable row says so without a hover", () => {
+  test("carries a persistent chevron in the pinned cell, below the tier only",
+    async ({ page, baseURL }, testInfo) => {
+      const vp = viewportOf(testInfo.project.name);
+      await openView(page, baseURL, "Portfolio › Holdings");
+
+      const cell = page.locator(".pinned tbody tr.rowlink > *").first();
+      const seen = await cell.evaluate((el) => ({
+        chevron: getComputedStyle(el, "::after").content,
+        lane: getComputedStyle(el).paddingRight,
+      }));
+
+      if (vp.width >= PIN_TIER_BELOW) {
+        // Above the tier there is no pinned cell to carry it, and hover is alive. A chevron
+        // written unconditionally would also widen the identity column at desktop, which is
+        // the layout change "desktop is unchanged" actually forbids.
+        expect(seen.chevron, "the chevron reached desktop").toBe("none");
+        return;
+      }
+      expect(seen.chevron, "no chevron — tappability is invisible without a hover")
+        .toContain("›");
+      // Absolutely positioned against the sticky cell, with the padding reserving its lane,
+      // so a long security name cannot collide with it.
+      expect(parseFloat(seen.lane), "the chevron has no lane to sit in").toBeGreaterThanOrEqual(24);
+      testInfo.annotations.push({ type: "chevron", description: `${vp.name} · lane ${seen.lane}` });
+    });
+
+  test("takes its feedback from `:active` rather than `:hover`, at every width",
+    async ({ page, baseURL }) => {
+      await openView(page, baseURL, "Portfolio › Holdings");
+      // The rule is read rather than exercised, and not for want of trying: with a mouse,
+      // `:hover` is true whenever `:active` is, and they resolve to the same colour here on
+      // purpose — so a mouse-down that turns the row that colour proves nothing about which
+      // of the two did it. Reading the sheet is what distinguishes them.
+      //
+      // Unconditional on purpose: a mouse-down flash in the colour the row already takes on
+      // hover costs desktop nothing, where a second rule inside the tablet tier would cost
+      // that tier the claim that it holds exactly one.
+      //
+      // It ships merged with `tr:hover td` — same declaration block, so the build folds the
+      // two into one rule. `declarationsFor` matches a member of the selector list for that
+      // reason; see its comment.
+      const rules = await declarationsFor(page, "tr.rowlink:active > td");
+      expect(rules, "no `:active` feedback — hover does not exist on touch").toHaveLength(1);
+      expect(rules[0].media, "the tap feedback was scoped to a tier").toBeNull();
+      // `background-color`, not `background`: the CSSOM expands the shorthand into its nine
+      // longhands, so the property as authored is not a key here at all.
+      expect(rules[0].decls["background-color"], "the row flashes nothing on tap")
+        .toBe("rgb(26, 33, 42)");
+    });
+});
+
+test.describe("Holdings' footnote", () => {
+  test("is a disclosure on a phone and the paragraph it always was above the tier",
+    async ({ page, baseURL }, testInfo) => {
+      const vp = viewportOf(testInfo.project.name);
+      await openView(page, baseURL, "Portfolio › Holdings");
+
+      const note = page.locator("details.tablenote");
+      await expect(note, "the footnote is not a disclosure element").toHaveCount(1);
+      const summary = note.locator("summary");
+
+      if (vp.width < PHONE_TIER_BELOW) {
+        // Measured at the 44px pitch, collapsing it takes the table from 11 rows to 13 in
+        // portrait and from 2 to 4 in landscape — the largest single row win on that screen.
+        await expect(summary, "no way to open the footnote on the one screen it is shut on")
+          .toBeVisible();
+        expect(await note.evaluate((el) => el.open), "the footnote is open, spending the rows it saves")
+          .toBe(false);
+        const box = await summary.boundingBox();
+        expect(box.height, "the disclosure is below the tap floor").toBeGreaterThanOrEqual(44);
+      } else {
+        // Open with its summary hidden: what renders is the paragraph, unchanged.
+        await expect(summary, "a summary appeared above the tier").toBeHidden();
+        expect(await note.evaluate((el) => el.open), "the desktop footnote is collapsed").toBe(true);
+      }
+      testInfo.annotations.push({ type: "footnote", description: `${vp.name}` });
+    });
+});
+
+test("numbers stay right-aligned and tabular in every pinned table", async ({ page, baseURL }) => {
+  // Most of why the pattern won: you are reading the real table through a window rather than
+  // a translation of it, so the two properties that make a column of money comparable at a
+  // glance are untouched. They are asserted at every viewport including desktop, because the
+  // claim is that the pattern costs them nothing anywhere.
+  for (const { view, tables } of PINNED) {
+    await openView(page, baseURL, view);
+    for (let i = 0; i < tables.length; i++) {
+      const numeric = await page.locator(".pinned").nth(i).evaluate((wrap) => {
+        // The first body cell with no `.l` — the app marks left-aligned columns and leaves
+        // the numeric ones to the sheet's default.
+        const cell = [...wrap.querySelectorAll("tbody tr:not(.grouprow) > *")]
+          .find((td) => !td.classList.contains("l"));
+        if (!cell) return null;
+        const s = getComputedStyle(cell);
+        return { align: s.textAlign, numerals: s.fontVariantNumeric };
+      });
+      expect(numeric, `${view} table ${i + 1} has no numeric column`).not.toBeNull();
+      expect.soft(numeric.align, `${view} table ${i + 1}`).toBe("right");
+      expect.soft(numeric.numerals, `${view} table ${i + 1}`).toContain("tabular-nums");
+    }
+  }
+});

--- a/web/tests/shell.spec.js
+++ b/web/tests/shell.spec.js
@@ -301,9 +301,16 @@ test.describe("below 640px the navigation is a drawer and a picker", () => {
 
   test("the shell is a column that fills the screen, and the pane owns the scroll",
     async ({ page, baseURL }) => {
-      // Holdings is the tallest thing in the app at this width, so there is genuinely
-      // something below the fold to fail to reach.
-      await openView(page, baseURL, "Portfolio › Holdings");
+      // A view whose pane genuinely has something below the fold to fail to reach.
+      //
+      // IT USED TO BE HOLDINGS, and it stopped being able to be, which is the pinned-column
+      // pattern landing rather than a flaw here. That table's wrapper is capped at 60svh on
+      // a phone, so the card fits the pane, `.main` has nothing to scroll, and the ONE
+      // scrollable region on that screen is the table itself. Asserting the pane scrolls
+      // there would now be asserting the pattern had not landed. The spending ledger is the
+      // durable choice: it is a long list in a card at every width, and card-per-row will
+      // keep it one when it arrives.
+      await openView(page, baseURL, "Spending › Transactions");
 
       const height = page.viewportSize().height;
       expect(await page.locator(".app").evaluate((el) => getComputedStyle(el).flexDirection))

--- a/web/tests/support/css.js
+++ b/web/tests/support/css.js
@@ -13,8 +13,8 @@
  */
 
 /**
- * Every rule in the shipped stylesheets whose selector is exactly `selector`, with the
- * media condition it sits under and its *specified* declarations as `{ property: value }`.
+ * Every rule in the shipped stylesheets that applies to `selector`, with the media condition
+ * it sits under and its *specified* declarations as `{ property: value }`.
  *
  * Read from the browser rather than from `styles.css`, so what is asserted is what ships —
  * and the difference is not academic. The build expands `padding: 14px` into four longhands
@@ -22,16 +22,34 @@
  * and the shorthand silently resets all four sides) does not exist here to check. What
  * catches that mistake is a resolved-padding assertion, where the bottom comes back 14px
  * instead of 20px.
+ *
+ * MATCHED AGAINST THE RULE'S SELECTOR *LIST*, not against the whole of `selectorText`, and
+ * that is the build showing through again: two rules that share a declaration block are
+ * merged into one, so `tr.rowlink:active > td { background: … }` ships as
+ * `tr:hover td, tr.rowlink:active > td { … }`. An exact comparison finds nothing and fails
+ * as "no such rule" rather than as "written alongside another one" — which is the wrong
+ * thing to go looking for. Matching a member of the list is also simply what the caller
+ * means: the rule *does* apply to the selector it asked about.
+ *
+ * The declarations are the whole block, shared members included. Every caller today asks
+ * about a property only one of them sets; a rule merged out of two that set the *same*
+ * property could not have been distinguished in the source either.
  */
 export function declarationsFor(page, selector) {
   return page.evaluate((sel) => {
+    // Whitespace around combinators is the only thing normalised — the build strips it, and
+    // nothing else about a selector is safe to rewrite here. Splitting on commas is safe for
+    // the selectors this suite asks about; a `:not(a, b)` would need a real parser.
+    const norm = (s) => s.replace(/\s*([>+~])\s*/g, "$1").replace(/\s+/g, " ").trim();
+    const want = norm(sel);
+    const applies = (text) => text.split(",").some((one) => norm(one) === want);
     const found = [];
     const walk = (rules, media) => {
       for (const rule of rules) {
         // Matched *before* descending, not instead of: a `CSSStyleRule` carries its own
         // (empty) `cssRules` list now that CSS nesting exists, so a style rule and a
         // grouping rule are no longer distinguishable by that property being present.
-        if (rule.selectorText === sel) {
+        if (rule.selectorText !== undefined && applies(rule.selectorText)) {
           const decls = {};
           for (const prop of rule.style) decls[prop] = rule.style.getPropertyValue(prop);
           found.push({ media: media ?? null, decls });

--- a/web/tests/support/css.js
+++ b/web/tests/support/css.js
@@ -13,8 +13,13 @@
  */
 
 /**
- * Every rule in the shipped stylesheets that applies to `selector`, with the media condition
- * it sits under and its *specified* declarations as `{ property: value }`.
+ * Every rule in the shipped stylesheets whose selector *list* contains `selector`, with the
+ * media condition it sits under and its *specified* declarations as `{ property: value }`.
+ *
+ * Textual containment, not selector matching: `.pinned` finds the rule written `.pinned` and
+ * not the rule written `.pinned table`, which also applies to `.pinned`'s subtree. Callers
+ * ask "how was this written", so that is the right reading — but it is a narrower one than
+ * the word "applies" would suggest.
  *
  * Read from the browser rather than from `styles.css`, so what is asserted is what ships —
  * and the difference is not academic. The build expands `padding: 14px` into four longhands
@@ -34,6 +39,14 @@
  * The declarations are the whole block, shared members included. Every caller today asks
  * about a property only one of them sets; a rule merged out of two that set the *same*
  * property could not have been distinguished in the source either.
+ *
+ * `text` IS THE BLOCK AS AUTHORED, and it is here because `decls` has a blind spot with a
+ * shape nobody would guess. A shorthand normally expands into its longhands — `background:
+ * #1a212a` arrives as nine of them, `background-color` among them with a real value. But a
+ * shorthand carrying a `var()` cannot be split at parse time, because the custom property is
+ * not resolved until computed-value time, so the same nine longhands arrive with **empty**
+ * values and the shorthand key does not exist either. `background: var(--hover)` is
+ * therefore invisible in `decls` under both names. `cssText` is the only place it survives.
  */
 export function declarationsFor(page, selector) {
   return page.evaluate((sel) => {
@@ -52,7 +65,7 @@ export function declarationsFor(page, selector) {
         if (rule.selectorText !== undefined && applies(rule.selectorText)) {
           const decls = {};
           for (const prop of rule.style) decls[prop] = rule.style.getPropertyValue(prop);
-          found.push({ media: media ?? null, decls });
+          found.push({ media: media ?? null, decls, text: rule.style.cssText });
         }
         if (rule.cssRules) walk(rule.cssRules, rule.conditionText ?? media);
       }

--- a/web/tests/viewports.js
+++ b/web/tests/viewports.js
@@ -44,6 +44,22 @@ export const HSCROLL_GATE_APPLIES_BELOW = 1024;
 export const PHONE_TIER_BELOW = 640;
 export const PHONE_TIER_EDGE = "639.98px";
 
+/**
+ * The width below which the pinned-column pattern applies — the phone tier and the tablet
+ * tier together, because the pin is worth *more* as the window narrows, not less.
+ *
+ * The same number as `HSCROLL_GATE_APPLIES_BELOW` above, and not by coincidence: the gate is
+ * exempt at and above 1024 precisely *because* the pattern stops there. They are written
+ * twice because they are two claims — "the pin applies here" and "the pane must not scroll
+ * sideways here" — and a later ticket that takes the pattern to desktop widths moves one of
+ * them without moving the other.
+ *
+ * `.98` for the same reason as the phone edge: no fractional viewport width lands in a dead
+ * zone. `PIN_TIER_EDGE` survives minification into the range syntax as its number alone.
+ */
+export const PIN_TIER_BELOW = 1024;
+export const PIN_TIER_EDGE = "1023.98px";
+
 export const VIEWPORTS = [
   { name: "small-phone",             width: 360,  height: 740,  why: "small phone — the tightest realistic width" },
   { name: "design-width",            width: 390,  height: 844,  why: "the design width; every measurement in the spec was taken here" },


### PR DESCRIPTION
Closes #28.

Seven tables across six views exist so you can compare a number **down the column**. They now read as the real table through a 390px window rather than a translation of it: the identity column is pinned, the rest scrolls horizontally inside its own wrapper, and alignment, tabular numerals and the sticky header survive untouched. No table drops a column — the pattern scrolls to them.

Pinned: `Holdings` (Security), `Performance` (the `{by}` grouping key), `Dividends`' crosstab (Bucket), `Options`' trade ledger (Underlying), `SecurityDetail`'s options history (the merged Contract cell), `Recurring`'s monitor (Name) and candidates (Merchant).

**Below 1024, not below 640.** The pin is worth *more* as the window narrows: at 640, behind the 200px rail, the desktop table shows two identity columns and not one number, and because `.main` owns the scroll there, reaching a number takes the identity away with it. #33 then only has to reach the tables this ticket did not own.

## The traps, and what they cost

**The border model.** Under `border-collapse: collapse` the borders belong to the table's border grid, and a cell that has left the flow leaves them behind — a sticky header and a pinned column both render rule-less. `separate` with zero spacing is identical here. Its casualty is the border declared on a `<tr>`, which `separate` does not paint at all: Dividends' 2px total rule is `.totalrow` on the cells now.

**Scroll ownership, ratified.** `overflow-x: auto` forces `overflow-y` from `visible` to `auto`, so the wrapper becomes the sticky scrollport whether or not anyone gave it a height — and a scrollport that sizes to content never scrolls, so the header rides the *page* away instead. `60svh` is what makes the header work, so it travels with the pattern rather than sitting in the phone block where 020 wrote it. One self-limiting rule rather than an exemption list: `max-height` is a no-op on a table that fits, so Performance (bounded at eight rows by its grouping dimension) never sees it.

**`overscroll-behavior` is deliberately unset**, and asserted to be declared nowhere. The reflex on a capped scroll box is `contain`; here it is actively wrong — flick the table, hit its end, the page keeps going.

Hover is dead on touch, so a tappable row says so twice: `:active` at every width, and a persistent `›` in the pinned cell below the tier. Holdings' group banner is excluded from the pin — it is a seven-column `colSpan` cell, and pinning it would park a subtotal over the numbers the scroll exists to reach. Holdings' footnote becomes a `<details>` on phone, worth two rows in portrait and two in landscape.

## Acceptance criteria

Seven of eight met. **AC 4** — "the main pane does not scroll horizontally below 1024px on any view" — is met for every view this ticket owns: Holdings 1031→0, Performance 507→0, Recurring 430→0, at every gated viewport including 640, 834 and 844. The residuals belong elsewhere: both ledgers and SecurityDetail to #29, Net Worth to #32, and a fourth cause that **belongs to no ticket** — `.grid2`'s `minmax(420px, 1fr)` track floor against a 362px pane, which is the whole of the identical 74 / 44 / 4 / 8 / 48 across four views. Recorded in `RESPONSIVE.md` rather than left to be rediscovered.

## Verification

`make test-web` — **647 passed, 0 failed**. New `tests/pinned.spec.js` runs at seven viewports and the other three assert the inverse. It gates the column count of every pinned table, because "no table drops a column" is the criterion a build could break while passing every geometric gate.

**Desktop is unchanged, measured rather than argued**: `main` was built in a worktree and `.main`'s horizontal overflow compared at 1100, 1280 and 1440 across all thirteen views — identical to the pixel.

## Review found a real regression

Both review axes independently caught `60svh` sitting in the phone block, which left the header broken from 640 to 1024 and in landscape (a rotated phone is 844px wide and exits that block). Measured at −500px of drift on a 500px page scroll — worse than before, since the header used to stick to `.main`. Two of the new gates were complicit and are fixed with it. The fix then exposed a cascade bug underneath — `.selfscroll`'s 480px beat the tier's cap on source order — which the new every-wrapper gate caught.

## One gap, named rather than closed

Recurring's tracked monitor never mounts: the owner tracks nothing, so `/api/spending/recurring` is `[]` in the committed fixtures. Its pin is unasserted, annotated on every run, and back on the manual checklist. Inventing a fixture row would be the plausible-data error the fixtures exist to prevent.