### PR TITLE
Pattern B: card per row for ledger tables

### DIFF
--- a/RESPONSIVE.md
+++ b/RESPONSIVE.md
@@ -106,7 +106,7 @@ criteria **instead of** the universal list — reading comfort, row density and 
 | Portfolio › Overview | tiles reflow to 2 columns; **donuts gone below 640**. *(`.grid2` collapsing to one column and the S2 inline rows have landed — both asserted.)* |
 | Portfolio › Holdings | ~~pattern **A**: Security pinned, h-scroll inside the wrapper, sticky `th` stays put as the wrapper scrolls; `tr:active` feedback and a persistent `›` in the pinned cell; footnote collapsed into `<details>`~~ **landed** — all of it asserted by `pinned.spec.js`, at seven viewports rather than at 390 alone. What is left here is eyes-only: row tap opens SecurityDetail, and whether the pin reads as an identity |
 | Portfolio › Performance | ~~pattern **A**, grouping key pinned (its `th` is `{by}` — lowercase, changes with the `<select>`)~~ **landed** — the `{by}` header is asserted by name, which is what says the *grouping key* got pinned rather than a label. Row count is bounded by the grouping dimension (max 8), so the whole table is on screen and `max-height: 60svh` never bites — asserted as the short half of the cap's one-rule claim |
-| Portfolio › Dividends | ~~crosstab pattern **A** (grows in columns, so h-scroll never expires)~~ **landed**; ~~payment ledger pattern **B** cards~~ **landed** — asserted by `cards.spec.js`, including that the 520px scroll box the table sits in does *not* come with the cards: a capped box inside a page that already scrolls is a second scroll region. `LabelList` dropped below 640 |
+| Portfolio › Dividends | ~~crosstab pattern **A** (grows in columns, so h-scroll never expires)~~ **landed**; ~~payment ledger pattern **B** cards~~ **landed** — asserted by `cards.spec.js`, including that the 520px scroll box the table sits in does *not* come with the cards: a capped box inside a page that already scrolls is a second scroll region. Its `payments` pill now counts what is **rendered** rather than what the server holds, because under cards that pill is where the missing header's count went and the flagged-only filter moves it. The two `title=` explanations on `Declared /u` / `Implied /u` go with the `<thead>` — no loss on touch, where a tooltip never existed, and the kv keys carry the labels. `LabelList` dropped below 640 |
 | Portfolio › Options | ~~contract ledger **A** — pinned Underlying; it already has an `overflow-x: auto` wrapper at `:70`, so this keeps behaviour rather than replacing it~~ **landed** — the wrapper's own 480px cap moved to `.selfscroll` so the phone tier's `60svh` can win over it, which an inline `max-height` could not. By-ticker and by-type unchanged (273/261px, they genuinely fit); monthly P/L halved to 6 bars with a reserved band so negative labels clear the ticks. *(The merged `Contract` cell landed earlier — asserted.)* |
 | Portfolio › Transactions | ~~pattern **B** cards~~ **landed** — eight fields, but still one amount, so the trade is the row and the cash it moved is the hero; Qty and Price take the key/value block. Asserted at every viewport, including that the table is what renders at 640 and above |
 | Portfolio › SecurityDetail | ~~txn history **B**~~ **landed**; ~~dividend history **B**~~ **landed but never rendered** — PLTR is the row the suite drills into because it has 73 option trades, and it has no dividends at all, so `cards.spec.js` annotates that gap on every run rather than closing it with an invented row; ~~options history **A**, pinning the merged two-line `Contract` cell~~ **landed**. Three tables, two patterns, deliberately. `← Holdings` is a ≥44px target and is the **only** way back — there is no router. *(The pane no longer scrolls sideways here below 640: the 914px txn history is cards now. At 640 and above it still does, and that is the tablet tier's.)* |
@@ -137,7 +137,7 @@ Failing these **changes a decision**, rather than reporting a bug.
   design entirely, not a reflow.
 - Recurring's two nested scroll regions — geometry is fine; whether it *feels* confusing is not
   measurable from here.
-- `SecurityDetail.jsx:48` txn history stays **B**, but it measures the same ~4 cards per screen that
+- `SecurityDetail.jsx:49` txn history stays **B**, but it measures the same ~4 cards per screen that
   overturned B for the options table beside it (8 cols, 914px, up to 71 rows, four numbers per row). If it
   reads as cramped, it wants **A** and SecurityDetail becomes B, A, A. **Now buildable rather than
   hypothetical** — the cards are on screen, so this is a look rather than a thought experiment.
@@ -153,7 +153,7 @@ screen against A's 12 — the same reasoning that rejected B for Holdings at 3.)
 
 Things the build session must be told, not left to discover.
 
-- `Transactions.jsx:35` carries an inline `fontSize: 13` — **CSS cannot reach it**; the rule silently
+- `spending/Transactions.jsx:40` carries an inline `fontSize: 13` — **CSS cannot reach it**; the rule silently
   no-ops until that style moves to a class.
 - `Classify.jsx:126` carries an inline `maxHeight: 232` — same problem, accepted as-is.
 - `ByCategory.jsx:133` carries an inline `paddingLeft: 26` — same family. It is what makes that table's
@@ -164,7 +164,7 @@ Things the build session must be told, not left to discover.
   which row you are on.
 - **A nested `<table>` inherits its parent's width**, so it sets the parent's min-content. This is why the
   By Category drilldown leaves the table on phone rather than becoming cards in place.
-- `.grid2`'s `minmax(420px, 1fr)` is **~100px optimistic against real data** — `Overview:33`'s card needs
+- `.grid2`'s `minmax(420px, 1fr)` is **~100px optimistic against real data** — `spending/Overview.jsx:36`'s card needs
   **519px** with the live DB's longest subcategory name. `auto-fit` still behaves; the column just spills
   inside itself between 1024 and ~1256.
 - **The 420px track floor is also the last unowned entry in the horizontal ratchet, and no ticket has

--- a/RESPONSIVE.md
+++ b/RESPONSIVE.md
@@ -52,10 +52,12 @@ Applied to all 12 tab views, SecurityDetail, and sign-in. Must pass.
    table. *(Not "no horizontal page scroll" — `.main { overflow: auto }` absorbs everything before it
    reaches the page, so that criterion can never fail.)* **Five of the thirteen views now hold it
    outright at every gated viewport** — Holdings, Performance, Dividends and Recurring, because the
-   pinned column took their scroll off the pane, plus Classify, which was already there. The ratchet in
-   `hscroll-baseline.js` records what is left and why: the two ledgers and SecurityDetail wait for
-   card-per-row, Net Worth for the editor floor, and four views share one residual that is not a table
-   at all — `.grid2`'s 420px track floor against a 362px pane.
+   pinned column took their scroll off the pane, plus Classify, which was already there. **Card-per-row
+   adds three more *below 640* — both Transactions ledgers and SecurityDetail — but not at 640 and above,
+   because that pattern is phone-only by decision.** The ratchet in `hscroll-baseline.js` records what is
+   left and why: those three at 640/834/844 wait for the tablet tier's pin, Net Worth for the editor
+   floor, and **four views now share one residual to the pixel** — `.grid2`'s 420px track floor against a
+   362px pane, which `Spending › Overview` joined exactly when its Top Line Items table became cards.
 2. No overlapping or clipped content.
 3. Every control reachable and tappable — **44px square** in fully-responsive views. *(The 24px
    editor floor has landed and is asserted by `unconditional.spec.js`; it is not checked here any
@@ -104,16 +106,16 @@ criteria **instead of** the universal list — reading comfort, row density and 
 | Portfolio › Overview | tiles reflow to 2 columns; **donuts gone below 640**. *(`.grid2` collapsing to one column and the S2 inline rows have landed — both asserted.)* |
 | Portfolio › Holdings | ~~pattern **A**: Security pinned, h-scroll inside the wrapper, sticky `th` stays put as the wrapper scrolls; `tr:active` feedback and a persistent `›` in the pinned cell; footnote collapsed into `<details>`~~ **landed** — all of it asserted by `pinned.spec.js`, at seven viewports rather than at 390 alone. What is left here is eyes-only: row tap opens SecurityDetail, and whether the pin reads as an identity |
 | Portfolio › Performance | ~~pattern **A**, grouping key pinned (its `th` is `{by}` — lowercase, changes with the `<select>`)~~ **landed** — the `{by}` header is asserted by name, which is what says the *grouping key* got pinned rather than a label. Row count is bounded by the grouping dimension (max 8), so the whole table is on screen and `max-height: 60svh` never bites — asserted as the short half of the cap's one-rule claim |
-| Portfolio › Dividends | ~~crosstab pattern **A** (grows in columns, so h-scroll never expires)~~ **landed**; payment ledger pattern **B** cards; `LabelList` dropped below 640 |
+| Portfolio › Dividends | ~~crosstab pattern **A** (grows in columns, so h-scroll never expires)~~ **landed**; ~~payment ledger pattern **B** cards~~ **landed** — asserted by `cards.spec.js`, including that the 520px scroll box the table sits in does *not* come with the cards: a capped box inside a page that already scrolls is a second scroll region. `LabelList` dropped below 640 |
 | Portfolio › Options | ~~contract ledger **A** — pinned Underlying; it already has an `overflow-x: auto` wrapper at `:70`, so this keeps behaviour rather than replacing it~~ **landed** — the wrapper's own 480px cap moved to `.selfscroll` so the phone tier's `60svh` can win over it, which an inline `max-height` could not. By-ticker and by-type unchanged (273/261px, they genuinely fit); monthly P/L halved to 6 bars with a reserved band so negative labels clear the ticks. *(The merged `Contract` cell landed earlier — asserted.)* |
-| Portfolio › Transactions | pattern **B** cards |
-| Portfolio › SecurityDetail | txn history **B**; dividend history **B**; ~~options history **A**, pinning the merged two-line `Contract` cell~~ **landed**. Three tables, two patterns, deliberately. `← Holdings` is a ≥44px target and is the **only** way back — there is no router. *(This view is the one place the pane still scrolls sideways after the pin: the 914px txn history is what sets the width, and it waits for **B**.)* |
+| Portfolio › Transactions | ~~pattern **B** cards~~ **landed** — eight fields, but still one amount, so the trade is the row and the cash it moved is the hero; Qty and Price take the key/value block. Asserted at every viewport, including that the table is what renders at 640 and above |
+| Portfolio › SecurityDetail | ~~txn history **B**~~ **landed**; ~~dividend history **B**~~ **landed but never rendered** — PLTR is the row the suite drills into because it has 73 option trades, and it has no dividends at all, so `cards.spec.js` annotates that gap on every run rather than closing it with an invented row; ~~options history **A**, pinning the merged two-line `Contract` cell~~ **landed**. Three tables, two patterns, deliberately. `← Holdings` is a ≥44px target and is the **only** way back — there is no router. *(The pane no longer scrolls sideways here below 640: the 914px txn history is cards now. At 640 and above it still does, and that is the tablet tier's.)* |
 | Net Worth | editor floor; line chart has a **DOM key, not `<Legend>`**; Breakdown and History wrapped in `overflow-x: auto`; ~~`100svh`~~ *(the shell's, landed and asserted)* |
-| Spending › Overview | donut gone below 640, list is the chart; Top Line Items pattern **B** (471px — A's pin would be the 232px Line item, 70% of the viewport). Both halves of the `.grid2` end up as ranked lists |
-| Spending › By Category | donut gone below 640; Categories pattern **A** with the name column pinned — it keeps its own `▸`/`▾` and does **not** get the persistent `›`; drilled transactions render as **B** cards **below the table**, not as a nested row, headed by subcategory + count + aggregate |
+| Spending › Overview | donut gone below 640, list is the chart; ~~Top Line Items pattern **B** (471px — A's pin would be the 232px Line item, 70% of the viewport)~~ **landed**, and it is the row that proves the map's claim about the leftover overflow: this view fell 114 → 74 / 84 → 44 / 44 → 4 and landed **exactly** on the three other `.grid2` views. Both halves of the `.grid2` end up as ranked lists |
+| Spending › By Category | donut gone below 640; Categories pattern **A** with the name column pinned — it keeps its own `▸`/`▾` and does **not** get the persistent `›`; drilled transactions render as **B** cards **below the table**, not as a nested row, headed by subcategory + count + aggregate. **The only grouped B table in the spec, and therefore the only group header** — `cards.jsx` ships none, because the six tables card-per-row landed on are all flat and an unused component is a header no test can reach. The drill's own slice adds it alongside the lift |
 | Spending › Classify | editor floor; `.fillpane` neutralised so the page scrolls as one; **⇅ Reorder hidden on phone**; `RuleModal` uses `svh`. *(The `textarea`'s styling has landed — asserted.)* |
 | Spending › Recurring | ~~monitor **A** *(open call)* and candidates **A**~~ **landed** — both pinned; the open call is untouched by that, since it asks whether this view wants a different information design rather than whether the reflow works. **Only the candidates table is asserted**: the owner tracks nothing, so `/api/spending/recurring` is `[]` in the committed fixtures and the monitor never mounts. `pinned.spec.js` annotates that gap on every run rather than closing it with an invented row — so the monitor's pin is an eyes-only check here. Three `.link-btn`s at 44px square; **two nested scroll regions** — the feel check |
-| Spending › Transactions | pattern **B** cards |
+| Spending › Transactions | ~~pattern **B** cards~~ **landed** — the six-field shape the whole pattern was measured on: merchant, one amount, and four muted fields on a second line, with no key/value block at all. Its excluded rows keep their dimming, but **no fixture holds one** — every captured transaction is counted spend and `include_excluded=true` was never captured, so both renderings are equally unexercised and `cards.spec.js` asserts the two agree on 0.55 rather than observing either |
 | Sign-in | ~~`100vh` → `100svh` at `auth.jsx:50` and `:125`~~ **landed** — asserted, along with the box filling the screen, optical centring and the absence of any phone rule. GSI button **carved out** of the 44px floor; no `env()` padding anywhere. What is left here is eyes-only: whether the carved-out button looks right beside a 44px world |
 
 ## Observations
@@ -137,7 +139,12 @@ Failing these **changes a decision**, rather than reporting a bug.
   measurable from here.
 - `SecurityDetail.jsx:48` txn history stays **B**, but it measures the same ~4 cards per screen that
   overturned B for the options table beside it (8 cols, 914px, up to 71 rows, four numbers per row). If it
-  reads as cramped, it wants **A** and SecurityDetail becomes B, A, A.
+  reads as cramped, it wants **A** and SecurityDetail becomes B, A, A. **Now buildable rather than
+  hypothetical** — the cards are on screen, so this is a look rather than a thought experiment.
+- **Whether a phone list of 1001 cards is usable.** `spending/Transactions` fetches `limit=1000` and the
+  card is ~2× an A row's height, so the pattern's own list is the app's longest render. The map routed the
+  row-cap question to observation during verification and it is still open; nothing about it is decidable
+  at a desk, and the table it replaced was equally uncapped.
 
 *(`Options.jsx:71` left this list: resolved to **A**, on the measurement that a 9-field card is 4 rows per
 screen against A's 12 — the same reasoning that rejected B for Holdings at 3.)*
@@ -166,11 +173,28 @@ Things the build session must be told, not left to discover.
   viewport, one cause, no table involved. The pinned column cannot reach it and neither can card-per-row
   or the editors' floor. The usual remedy is `minmax(min(420px, 100%), 1fr)`. **Written down here
   because a residual with no owner is precisely how the four unassigned tables happened.**
-- **`640` is a literal in three places**: `styles.css`'s `max-width: 639.98px`, `tests/viewports.js`'s
-  `PHONE_TIER_BELOW` / `PHONE_TIER_EDGE`, and `Holdings.jsx`'s `startsCollapsed` — the app's first
+- **`640` is a literal in four places**: `styles.css`'s `max-width: 639.98px`, `tests/viewports.js`'s
+  `PHONE_TIER_BELOW` / `PHONE_TIER_EDGE`, `Holdings.jsx`'s `startsCollapsed` — the app's first
   `matchMedia` read, which arrived with the pinned column rather than with the charts as the map
-  expected. The charts will be the **fourth**. No single source of truth without a build step. Every
-  site cross-references the others in a comment.
+  expected — and `cards.jsx`'s `usePhone`, which arrived with card-per-row. The charts will be the
+  **fifth**. No single source of truth without a build step. Every site cross-references the others in
+  a comment.
+- **The two `matchMedia` readers differ on purpose, and the difference is not an inconsistency.**
+  `Holdings.jsx` reads the query **once, at mount**, because it only seeds a disclosure's initial state
+  and the user then owns it — a footnote that reopens itself on rotate is worse than a stale one.
+  `cards.jsx`'s `usePhone` **subscribes**, because it *is* the layout: a rotated phone is 844px wide,
+  has left the tier, and must get its table back without a reload. `cards.spec.js` drives that rotation
+  rather than trusting it.
+- **Pattern B's tier is written in JavaScript and nowhere else.** Pattern A restyles markup that renders
+  at every width, so its 1024 has to be a media query — and `pinned.spec.js` gates *which* tier, because
+  `639.98` and `1023.98` are one character apart to read. B is different markup, so none of `.cards`,
+  `.rowcard` or the `.rc-*` rules is inside a media block at all: above 640 the hook does not render
+  them. Wrapping them "for safety" would be 640 written twice. Asserted.
+- **A comment mentioning `<table` breaks the table-inventory count.** The gate is a plain
+  `grep -ro "<table" web/src`, so prose is indistinguishable from markup to it — a CSS comment
+  explaining what the cards replace pushed the count to 23 and failed `inventory.spec.js`. Say "the
+  real table" in prose. Deliberate: the grep is the same one a human runs, and teaching it to parse
+  is how it stops being cheap enough to run.
 - **`1024` is now a literal in two places** for the same reason: `styles.css`'s `max-width: 1023.98px`
   and `tests/viewports.js`'s `PIN_TIER_BELOW` / `PIN_TIER_EDGE`. It is the same number as
   `HSCROLL_GATE_APPLIES_BELOW` and deliberately not the same constant — the gate is exempt above 1024

--- a/web/TESTING.md
+++ b/web/TESTING.md
@@ -59,6 +59,15 @@ drops a column" is the criterion a build could satisfy every *geometric* gate wh
 `contain`, chaining is the decision, and a synthetic scroll does not chain, so there is nothing to
 measure.
 
+`tests/cards.spec.js` — pattern B: six tables across five views that stop being tables below **640px**
+and become one card per row. The mirror image of `pinned.spec.js` in every way that matters: its tier
+is the phone rather than the pin, its markup is *different* rather than restyled, and so the thing it
+has to gate is that the tier lives in `usePhone()` and **nowhere in the stylesheet** — a media query
+around those rules would be 640 written twice. It drives a rotation at one project, which is the only
+gate that can tell a live `matchMedia` from a read at mount, and it names two things the fixtures
+cannot reach: no captured spending row is excluded, and the security the suite drills into has no
+dividends.
+
 `tests/inventory.spec.js` — the checks that read files rather than pixels: the table count, the
 single donut implementation, that no `100vh` survives under `web/src`, the viewport meta's
 `viewport-fit=cover`, the viewport list against `RESPONSIVE.md`, and the fixtures' own

--- a/web/playwright.config.js
+++ b/web/playwright.config.js
@@ -39,7 +39,7 @@ export default defineConfig({
     { name: "inventory", testMatch: /inventory\.spec\.js/ },
     ...VIEWPORTS.map((v) => ({
       name: v.name,
-      testMatch: /(baseline|unconditional|foundations|shell|pinned)\.spec\.js/,
+      testMatch: /(baseline|unconditional|foundations|shell|pinned|cards)\.spec\.js/,
       use: {
         ...devices["Desktop Chrome"],
         viewport: { width: v.width, height: v.height },

--- a/web/src/cards.jsx
+++ b/web/src/cards.jsx
@@ -26,6 +26,10 @@ import React, { useEffect, useState } from "react";
  * NOTHING IS CLIPPED. No ellipsis, no `white-space: nowrap` — long names wrap instead. The
  * prototype truncated, and truncation is the one failure this pattern cannot afford: a card
  * you have to widen to read is a table with extra steps.
+ *
+ * A MISSING VALUE IS AN EM DASH HERE WHERE THE TABLE LEAVES THE CELL BLANK, and that is the
+ * one place a card deliberately says something its row did not. An empty cell in a column of
+ * numbers reads as "nothing here"; an empty hero reads as broken.
  */
 
 /**
@@ -93,7 +97,7 @@ export function RowCard({ name, hero, heroClass, meta, fields, dim }) {
     <div className={"rowcard" + (dim ? " dim" : "")}>
       <div className="rc-head">
         <span className="rc-nm">{name}</span>
-        <span className={"rc-hero " + (heroClass || "")}>{hero}</span>
+        <span className={"rc-hero" + (heroClass ? " " + heroClass : "")}>{hero}</span>
       </div>
       {meta && meta.length > 0 && (
         <div className="rc-sub">
@@ -105,7 +109,7 @@ export function RowCard({ name, hero, heroClass, meta, fields, dim }) {
           {fields.map((f, i) => (
             <div key={i}>
               <span className="k">{f.k}</span>
-              <span className={"v " + (f.cls || "")}>{f.v}</span>
+              <span className={"v" + (f.cls ? " " + f.cls : "")}>{f.v}</span>
             </div>
           ))}
         </div>

--- a/web/src/cards.jsx
+++ b/web/src/cards.jsx
@@ -1,0 +1,115 @@
+import React, { useEffect, useState } from "react";
+
+/**
+ * Pattern B — card per row, for the tables that exist so you can read ONE ROW AT A TIME.
+ *
+ * The other pattern is the pinned identity column (`.pinned` in `styles.css`), for tables you
+ * read by comparing a number *down* a column. The test that assigns a table to one or the
+ * other is not the word "ledger" and not the column count: it is **how many numbers a row
+ * carries**. A cash-transaction row carries one amount, so it fits a two-line card with
+ * nothing hidden and no interaction at all — where the pin would make you swipe to reach the
+ * amount. An options contract row carries five, plus two dates and an outcome; a nine-field
+ * card measures 121px, which is 4 rows on a 390x844 screen against 12 for the pin, and 4 is
+ * the side of the trade that was already rejected for the widest table at 3. Those tables
+ * take the pin.
+ *
+ * THERE IS NO HEADER HERE, and that is the pattern rather than an omission. A card names its
+ * own fields, so a header would restate every label once per screen; the header's other job —
+ * saying how many rows there are and what they add up to — passes to the count in the card
+ * title above the list, and, in a grouped table, to a group header row between the cards.
+ *
+ * WHAT SURVIVES AND WHAT DOES NOT. The hero amount stays right-aligned and tabular, because
+ * it is the one number the row is about. The remaining fields align *within* a card and not
+ * across cards. That is a real loss and it is acceptable precisely here: this pattern is only
+ * ever assigned to tables where comparing across rows is not the job.
+ *
+ * NOTHING IS CLIPPED. No ellipsis, no `white-space: nowrap` — long names wrap instead. The
+ * prototype truncated, and truncation is the one failure this pattern cannot afford: a card
+ * you have to widen to read is a table with extra steps.
+ */
+
+/**
+ * The phone tier, as JavaScript says it — and the FOURTH place `640` is written as a literal.
+ *
+ * `styles.css` says `max-width: 639.98px`, `tests/viewports.js` says `< 640`, and
+ * `Holdings.jsx` reads the same query for its footnote. JS cannot read a CSS custom property
+ * and this repo takes no build step to make one, so the four sites cross-reference in
+ * comments rather than share a constant. `RESPONSIVE.md`'s Traps names all of them.
+ */
+const PHONE = "(max-width: 639.98px)";
+
+/**
+ * Live, unlike `Holdings.jsx`'s one-shot read of the same query — and the difference is the
+ * point rather than an inconsistency. That one seeds a piece of state the *user* then owns,
+ * so re-reading it on rotate would fight them. This one IS the layout: at 844px wide a
+ * rotated phone has left the tier and must get its table back, and a card list that survived
+ * the rotation would be a phone design shipped to a landscape screen.
+ *
+ * The initialiser runs before the effect so the first paint is already right; the effect
+ * re-reads as well as subscribing, because a viewport can change between the two.
+ */
+export function usePhone() {
+  const [phone, setPhone] = useState(
+    () => typeof window !== "undefined" && window.matchMedia(PHONE).matches);
+  useEffect(() => {
+    const mq = window.matchMedia(PHONE);
+    const sync = () => setPhone(mq.matches);
+    sync();
+    mq.addEventListener("change", sync);
+    return () => mq.removeEventListener("change", sync);
+  }, []);
+  return phone;
+}
+
+/** The column of cards. One flex column so the gap is declared once rather than per card. */
+export function Cards({ children }) {
+  return <div className="cards">{children}</div>;
+}
+
+/**
+ * THE GROUP HEADER IS NOT HERE, and its absence is the ticket boundary rather than a gap.
+ * None of the six tables this pattern lands on is grouped — the one grouped B table in the
+ * whole spec is the spending drill's third level, which leaves its parent table entirely and
+ * is headed by subcategory, count and aggregate. That structure belongs to the drill's own
+ * ticket, which is blocked on this module existing; it adds the header alongside the lift.
+ * Shipping an unused component here would be a header no test could reach.
+ */
+
+/**
+ * One row, as a card.
+ *
+ * `name` + `hero` are line one: what the row is, and the one number it is about. `meta` is
+ * line two — the row's textual fields, muted, flowing inline and wrapping. `fields` is the
+ * optional key/value block underneath, for the *other* numbers, two to a line; a six-field
+ * ledger row has none and stops at two lines, which is the measurement the pattern was
+ * chosen on.
+ *
+ * `dim` carries over the treatment the table row had: an excluded spending transaction is
+ * dimmed in the table and stays dimmed here, because the reason it is dim (it does not count
+ * towards spend) is the same fact in both renderings.
+ */
+export function RowCard({ name, hero, heroClass, meta, fields, dim }) {
+  return (
+    <div className={"rowcard" + (dim ? " dim" : "")}>
+      <div className="rc-head">
+        <span className="rc-nm">{name}</span>
+        <span className={"rc-hero " + (heroClass || "")}>{hero}</span>
+      </div>
+      {meta && meta.length > 0 && (
+        <div className="rc-sub">
+          {meta.map((m, i) => <span key={i}>{m}</span>)}
+        </div>
+      )}
+      {fields && fields.length > 0 && (
+        <div className="rc-kv">
+          {fields.map((f, i) => (
+            <div key={i}>
+              <span className="k">{f.k}</span>
+              <span className={"v " + (f.cls || "")}>{f.v}</span>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/modules/portfolio/Dividends.jsx
+++ b/web/src/modules/portfolio/Dividends.jsx
@@ -86,7 +86,12 @@ export default function Dividends() {
       <div className="card">
         <h3>Dividend Detail — qty held &amp; declared rate&nbsp;
           <span className="pill">SGD · latest FX</span>
-          {det && <span className="pill" style={{ marginLeft: 6 }}>{det.total} payments</span>}
+          {/* The count of what is RENDERED, not what the server holds — `det.total` ignores
+              the flagged-only filter, and under the card pattern this pill is where the
+              missing header's count went, so a title that disagrees with the cards below it
+              is the one thing it must not do. The `shownSgd` pill beside it was already
+              filter-aware; these two now say the same thing about the same list. */}
+          {det && <span className="pill" style={{ marginLeft: 6 }}>{rows.length} payments</span>}
           {det && <span className="pill" style={{ marginLeft: 6 }}>{sgd(shownSgd)}</span>}
           {det && det.flagged > 0 &&
             <span className="pill" style={{ marginLeft: 6, color: "var(--neg)" }}>{det.flagged} need manual input</span>}
@@ -104,7 +109,11 @@ export default function Dividends() {
             {rows.map((r) => (
               <RowCard key={r.id}
                 name={<>{r.name} {r.ticker && <span className="pill">{r.ticker}</span>}</>}
-                hero={money(r.gross_sgd, "SGD", 2)} heroClass="pos"
+                // No colour class on the hero: the table's Gross SGD cell is unclassed, and a
+                // hero that is green here and plain at 641px would be the pattern restating a
+                // decision it only inherited. SecurityDetail's dividend hero IS `pos`, because
+                // that table's cell is.
+                hero={money(r.gross_sgd, "SGD", 2)}
                 meta={[
                   r.pay_date || "—",
                   r.account,

--- a/web/src/modules/portfolio/Dividends.jsx
+++ b/web/src/modules/portfolio/Dividends.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from "react";
 import { BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer, LabelList } from "recharts";
 import { get, fmt, sgd, money } from "../../api.js";
+import { Cards, RowCard, usePhone } from "../../cards.jsx";
 
 const BUCKET_LABEL = { cash: "Cash", srs: "SRS", cpf: "CPF" };
 
@@ -8,6 +9,7 @@ export default function Dividends() {
   const [ann, setAnn] = useState(null);
   const [det, setDet] = useState(null);
   const [onlyFlagged, setOnlyFlagged] = useState(false);
+  const phone = usePhone();
   useEffect(() => {
     get("/api/dividends-annual").then(setAnn).catch(() => setAnn({ years: [], buckets: [], matrix: {}, totals: {} }));
     get("/api/dividend-details").then(setDet).catch(() => setDet({ rows: [], flagged: 0, total: 0, total_sgd: 0 }));
@@ -93,6 +95,33 @@ export default function Dividends() {
             &nbsp;flagged only
           </label>
         </h3>
+        {phone ? (
+          /* Pattern B. Three numbers besides the hero — qty held and the two per-unit rates —
+             so this ledger takes the key/value block. The 520px scroll box above does NOT
+             come with it: a capped box inside a page that already scrolls is a second scroll
+             region, and the pattern's whole claim is one list you read straight down. */
+          <Cards>
+            {rows.map((r) => (
+              <RowCard key={r.id}
+                name={<>{r.name} {r.ticker && <span className="pill">{r.ticker}</span>}</>}
+                hero={money(r.gross_sgd, "SGD", 2)} heroClass="pos"
+                meta={[
+                  r.pay_date || "—",
+                  r.account,
+                  ...(r.currency !== "SGD" ? [money(r.gross, r.currency, 2)] : []),
+                  r.flags.length
+                    ? <span className="pill" style={{ color: "var(--neg)" }}>{r.flags.join("; ")}</span>
+                    : <>✓ {r.rate_source}</>,
+                ]}
+                fields={[
+                  { k: "Qty held", v: `${r.qty == null ? "—" : fmt(r.qty, 0)}${r.qty_source === "ledger" ? " (led)" : ""}` },
+                  { k: "Declared /u", v: money(r.declared_rate, r.currency, 4),
+                    cls: r.declared_rate == null ? "mut" : "pos" },
+                  { k: "Implied /u", v: money(r.implied_rate, r.currency, 4), cls: "mut" },
+                ]} />
+            ))}
+          </Cards>
+        ) : (
         <div style={{ maxHeight: 520, overflow: "auto" }}>
           <table>
             <thead><tr>
@@ -128,6 +157,7 @@ export default function Dividends() {
             </tbody>
           </table>
         </div>
+        )}
       </div>
     </>
   );

--- a/web/src/modules/portfolio/SecurityDetail.jsx
+++ b/web/src/modules/portfolio/SecurityDetail.jsx
@@ -1,9 +1,11 @@
 import React, { useEffect, useState } from "react";
 import { get, fmt, sgd, money, pct, cls } from "../../api.js";
+import { Cards, RowCard, usePhone } from "../../cards.jsx";
 import { ContractCell } from "./contract.jsx";
 
 export default function SecurityDetail({ ticker, bucket, onBack }) {
   const [d, setD] = useState(null);
+  const phone = usePhone();
   useEffect(() => {
     setD(null);
     get(`/api/holding?ticker=${encodeURIComponent(ticker)}&bucket=${bucket}`)
@@ -45,6 +47,29 @@ export default function SecurityDetail({ ticker, bucket, onBack }) {
 
       <div className="card" style={{ marginBottom: 18 }}>
         <h3>Transaction history ({d.transactions.length}) · running balance</h3>
+        {phone ? (
+          /* Pattern B — and the open call the map left on it: this row carries four numbers,
+             which measures the same ~4 cards per screen that overturned B for the options
+             table beside it. It stays B on the reading job rather than the count: what you do
+             with one security's own ledger is read a trade, not compare a column. If it reads
+             as cramped on a real phone the view becomes B, A, A, which is why the assignment
+             is recorded in `RESPONSIVE.md` as an open call rather than a gate.
+             Every row is the same security, so the identity is when and what — the date with
+             the action beside it — and the cash the trade moved is the hero. */
+          <Cards>
+            {d.transactions.map((t, i) => (
+              <RowCard key={i}
+                name={<>{t.trade_date || "—"} <span className="pill">{t.action}</span></>}
+                hero={t.gross_amount == null ? "—" : money(t.gross_amount, t.currency, 2)}
+                meta={[t.account, t.source_file]}
+                fields={[
+                  { k: "Qty", v: `${t.qty_signed > 0 ? "+" : ""}${fmt(t.qty_signed, 2)}`, cls: cls(t.qty_signed) },
+                  { k: "Balance", v: fmt(t.balance, 2) },
+                  { k: "Price", v: t.price == null ? "—" : fmt(t.price, 4), cls: "mut" },
+                ]} />
+            ))}
+          </Cards>
+        ) : (
         <table>
           <thead><tr>
             <th className="l">Date</th><th className="l">Account</th><th className="l">Action</th>
@@ -65,12 +90,31 @@ export default function SecurityDetail({ ticker, bucket, onBack }) {
             ))}
           </tbody>
         </table>
+        )}
       </div>
 
       <div className="card">
         <h3>Dividend history ({d.dividends.length})
           <span className="pill" style={{ marginLeft: 8 }}>{sgd(divTotalSgd)} · latest FX</span></h3>
-        {d.dividends.length === 0 ? <p className="mut">No dividends recorded.</p> : (
+        {d.dividends.length === 0 ? <p className="mut">No dividends recorded.</p> : phone ? (
+          /* Pattern B: six fields, one amount. Same identity choice as the ledger above —
+             the payment date with its kind beside it, because every row is this security. */
+          <Cards>
+            {d.dividends.map((x, i) => (
+              <RowCard key={i}
+                name={<>{x.pay_date || "—"} <span className="pill">{x.kind}</span></>}
+                hero={money(x.gross_sgd, "SGD", 2)} heroClass="pos"
+                meta={[
+                  x.account,
+                  ...(x.currency !== "SGD" ? [money(x.gross, x.currency, 2)] : []),
+                ]}
+                fields={[
+                  { k: "Qty held", v: x.units == null ? "—" : fmt(x.units, 2), cls: "mut" },
+                  { k: "Rate/unit", v: money(x.rate, x.currency, 4), cls: "mut" },
+                ]} />
+            ))}
+          </Cards>
+        ) : (
           <table>
             <thead><tr>
               <th className="l">Date</th><th className="l">Account</th><th className="l">Kind</th>

--- a/web/src/modules/portfolio/Transactions.jsx
+++ b/web/src/modules/portfolio/Transactions.jsx
@@ -1,11 +1,13 @@
 import React, { useEffect, useState } from "react";
 import { get, fmt, money, cls } from "../../api.js";
+import { Cards, RowCard, usePhone } from "../../cards.jsx";
 
 export default function Transactions() {
   const [accts, setAccts] = useState([]);
   const [acct, setAcct] = useState("");
   const [ticker, setTicker] = useState("");
   const [rows, setRows] = useState(null);
+  const phone = usePhone();
 
   useEffect(() => { get("/api/accounts").then(setAccts).catch(() => {}); }, []);
   useEffect(() => {
@@ -17,14 +19,39 @@ export default function Transactions() {
 
   return (
     <div className="card">
-      <h3>Transactions
+      {/* The count moves into the title because the card list has no header to carry it —
+          see `cards.jsx`. Written at every width; it is the same number either way. */}
+      <h3>Transactions{rows ? ` (${rows.length})` : ""}
         <select value={acct} onChange={(e) => setAcct(e.target.value)} style={{ marginLeft: 12 }}>
           <option value="">All accounts</option>
           {accts.map((a) => <option key={a.name} value={a.name}>{a.name}</option>)}
         </select>
         <input placeholder="ticker…" value={ticker} onChange={(e) => setTicker(e.target.value)} style={{ marginLeft: 8, width: 100 }} />
       </h3>
-      {!rows ? <div className="loading">Loading…</div> : (
+      {!rows ? <div className="loading">Loading…</div> : phone ? (
+        /* Eight fields, but still one amount: the trade is the row and the cash it moved is
+           the hero. Qty and Price are the second and third numbers, so this one earns the
+           key/value block a six-field ledger does not. The source filename goes in the muted
+           line and is allowed to wrap — it is the longest string in the row and clipping it
+           would hide exactly the part that tells two imports apart. */
+        <Cards>
+          {rows.map((r, i) => (
+            <RowCard key={i}
+              name={<>{r.name} <span className="pill">{r.ticker}</span></>}
+              hero={r.gross_amount == null ? "—" : money(r.gross_amount, r.currency, 2)}
+              meta={[
+                r.trade_date || "—",
+                <span className="pill">{r.action}</span>,
+                r.account,
+                r.source_file,
+              ]}
+              fields={[
+                { k: "Qty", v: `${r.qty_signed > 0 ? "+" : ""}${fmt(r.qty_signed, 2)}`, cls: cls(r.qty_signed) },
+                { k: "Price", v: r.price == null ? "—" : fmt(r.price, 4), cls: "mut" },
+              ]} />
+          ))}
+        </Cards>
+      ) : (
         <table>
           <thead><tr>
             <th className="l">Date</th><th className="l">Acct</th><th className="l">Security</th>

--- a/web/src/modules/spending/Overview.jsx
+++ b/web/src/modules/spending/Overview.jsx
@@ -5,10 +5,12 @@ import {
 } from "recharts";
 import { get, sgd, fmt } from "../../api.js";
 import { COLORS, Donut } from "../../charts.jsx";
+import { Cards, RowCard, usePhone } from "../../cards.jsx";
 
 export default function SpendOverview() {
   const [sum, setSum] = useState(null);
   const [trend, setTrend] = useState(null);
+  const phone = usePhone();
   useEffect(() => { get("/api/spending/summary").then(setSum).catch(() => setSum({ error: true })); }, []);
   useEffect(() => { get("/api/spending/trends").then(setTrend).catch(() => setTrend({ groups: [], series: [] })); }, []);
   if (!sum) return <div className="loading">Loading…</div>;
@@ -17,6 +19,7 @@ export default function SpendOverview() {
   const groups = sum.by_group.map((g) => ({ name: g.category, value: Number(g.v) }));
   const total = sum.total_sgd;
   const top = groups[0];
+  const lines = sum.by_subcategory.slice(0, 14);
 
   return (
     <div>
@@ -29,11 +32,33 @@ export default function SpendOverview() {
       <div className="grid2">
         <Donut title="Spending by Category" data={groups} />
         <div className="card">
-          <h3>Top Line Items</h3>
+          {/* The count is in the title because the card list below 640 has no header to
+              carry it — see `cards.jsx`. It is the number of rows rendered, which is the
+              top 14 rather than every line item. */}
+          <h3>Top Line Items ({lines.length})</h3>
+          {phone ? (
+            /* Four columns, so this table was in the "already fits" bucket until it was
+               measured: 471px, because the line-item column is unbounded free text from the
+               database and the longest real one is 30 characters. Pattern A was rejected on
+               the same number — pinning a 232px identity column is 70% of a 330px pane. The
+               line item is the identity, its spend is the hero, and the category and share
+               ride underneath: a ranked list, which is what the donut beside it becomes too. */
+            <Cards>
+              {lines.map((r, i) => (
+                <RowCard key={i}
+                  name={r.subcategory || "—"}
+                  hero={sgd(Number(r.v))}
+                  // The table renders a null category as an empty cell rather than naming
+                  // it, so the card drops the item instead of printing an empty span.
+                  meta={[...(r.category ? [r.category] : []),
+                         `${fmt((Number(r.v) / total) * 100, 1)}%`]} />
+              ))}
+            </Cards>
+          ) : (
           <table>
             <thead><tr><th className="l">Category</th><th className="l">Line item</th><th>Spend</th><th>%</th></tr></thead>
             <tbody>
-              {sum.by_subcategory.slice(0, 14).map((r, i) => (
+              {lines.map((r, i) => (
                 <tr key={i}>
                   <td className="l mut">{r.category}</td>
                   <td className="l">{r.subcategory || "—"}</td>
@@ -43,6 +68,7 @@ export default function SpendOverview() {
               ))}
             </tbody>
           </table>
+          )}
         </div>
       </div>
       {trend && trend.series.length > 0 && (

--- a/web/src/modules/spending/Transactions.jsx
+++ b/web/src/modules/spending/Transactions.jsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from "react";
 import { get, sgd } from "../../api.js";
+import { Cards, RowCard, usePhone } from "../../cards.jsx";
 
 const SOURCES = { "": "All sources", dbs: "DBS bank", trust: "Trust card", hsbc: "HSBC card" };
 
@@ -9,6 +10,7 @@ export default function SpendTransactions() {
   const [source, setSource] = useState("");
   const [excluded, setExcluded] = useState(false);
   const [rows, setRows] = useState(null);
+  const phone = usePhone();
 
   useEffect(() => { get("/api/spending/categories").then(setCats).catch(() => {}); }, []);
   useEffect(() => {
@@ -24,7 +26,10 @@ export default function SpendTransactions() {
 
   return (
     <div className="card">
-      <h3>Transactions
+      {/* The count moves into the title because the card list has no header to carry it —
+          see `cards.jsx`. Written at every width: it is the same number either way, and one
+          title beats a title that changes shape at 640. */}
+      <h3>Transactions{rows ? ` (${rows.length})` : ""}
         <select value={group} onChange={(e) => setGroup(e.target.value)} style={{ marginLeft: 12 }}>
           <option value="">All categories</option>
           {groups.map((g) => <option key={g} value={g}>{g}</option>)}
@@ -36,7 +41,28 @@ export default function SpendTransactions() {
           <input type="checkbox" checked={excluded} onChange={(e) => setExcluded(e.target.checked)} /> show excluded
         </label>
       </h3>
-      {!rows ? <div className="loading">Loading…</div> : (
+      {!rows ? <div className="loading">Loading…</div> : phone ? (
+        /* Pattern B, and the shape it was measured on: six fields, one amount, two lines.
+           Merchant is the identity and the SGD amount is the hero; date, source, category
+           and the exclusion flag flow underneath as muted text. No key/value block — this
+           row carries no second number, which is the whole test that assigned it here. */
+        <Cards>
+          {rows.map((r, i) => (
+            <RowCard key={i} dim={!r.is_spend}
+              name={r.merchant || r.description}
+              hero={sgd(Number(r.amount_sgd))}
+              heroClass={Number(r.amount_sgd) < 0 ? "neg" : "pos"}
+              meta={[
+                r.txn_date || "—",
+                <span className="pill">{r.account_label}</span>,
+                // Unclassified spend has a null category, and the table renders that cell
+                // empty rather than inventing a word for it — so the card drops the item.
+                ...(r.category ? [r.category + (r.subcategory ? ` · ${r.subcategory}` : "")] : []),
+                ...(r.is_spend ? [] : [<span className="pill">{r.exclude_reason || "excluded"}</span>]),
+              ]} />
+          ))}
+        </Cards>
+      ) : (
         <table>
           <thead><tr>
             <th className="l">Date</th><th className="l">Source</th><th className="l">Merchant</th>

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -244,6 +244,49 @@ tr.rowlink:active > td { background: var(--hover); }
     content: "›"; position: absolute; right: 8px; top: 50%; transform: translateY(-50%);
     color: var(--mut); font-size: 15px; font-weight: 600; }
 }
+/* ─── pattern B: card per row ─────────────────────────────────────────────────────────────
+   The other half of the table story. For the tables that exist so you can read ONE ROW at a
+   time, a row becomes a card: identity and the one number it is about on line one, its
+   textual fields muted on line two, and — only where a row carries more numbers than its
+   hero — a two-column key/value block under a rule. A six-field ledger row stops at two
+   lines, which is the measurement the pattern was chosen on: 9 cards on a 390x844 screen
+   against the pinned table's 13, with nothing hidden and no interaction at all.
+
+   NO MEDIA QUERY, AND THAT IS DELIBERATE. Pattern A is a restyling of markup that renders at
+   every width, so its tier has to be written in CSS. This one is different markup — the card
+   list and the real table are two renders of the same rows and `usePhone()` in `cards.jsx`
+   picks between them, so above 640px none of these selectors matches anything. Writing the
+   tier twice, once in the hook and once around these rules, would be two places to get the
+   same number wrong. The hook is the tier; these are just the styles it reveals.
+
+   NOTHING IS CLIPPED. `overflow-wrap: anywhere` rather than the prototype's ellipsis: a
+   65-character merchant name wraps to a second line instead of being truncated, because a
+   card you have to widen to finish reading is a table with extra steps — and "nothing hidden"
+   is most of why cards beat the pin on these tables in the first place.
+
+   The hero keeps `text-align: right` even though the flex row already puts it there. Right
+   plus tabular is what the amount column had in the table and the one alignment the pattern
+   promises to preserve; leaving it implicit in a `justify-content` would lose it silently the
+   next time someone changes the head row's layout. */
+.cards { display: flex; flex-direction: column; gap: 8px; }
+.rowcard { background: var(--panel2); border: 1px solid var(--line); border-radius: 10px;
+  padding: 10px 12px; }
+/* The excluded/dimmed treatment the table row carried, restated on the card. Same 0.55 as
+   `spending/Transactions`' inline row style, because it is the same fact about the row. */
+.rowcard.dim { opacity: .55; }
+.rc-head { display: flex; align-items: baseline; gap: 8px; }
+.rc-nm { flex: 1 1 auto; min-width: 0; font-weight: 600; overflow-wrap: anywhere; }
+.rc-hero { flex: none; text-align: right; font-weight: 700; font-size: 17px;
+  font-variant-numeric: tabular-nums; }
+.rc-sub { display: flex; flex-wrap: wrap; align-items: center; gap: 4px 8px;
+  margin-top: 3px; color: var(--mut); font-size: 11px; overflow-wrap: anywhere; }
+.rc-kv { display: grid; grid-template-columns: 1fr 1fr; gap: 2px 14px;
+  margin-top: 9px; padding-top: 8px; border-top: 1px solid var(--line); }
+.rc-kv > div { display: flex; justify-content: space-between; gap: 8px; min-width: 0;
+  font-size: 12px; }
+.rc-kv .k { flex: none; color: var(--mut); }
+.rc-kv .v { text-align: right; font-variant-numeric: tabular-nums; overflow-wrap: anywhere; }
+
 /* Holdings' footnote as a disclosure — five lines of prose above a table that wants every
    row it can get. The summary is hidden by default and turned on in the phone block, which
    is the inverse of how it reads: `open` is set once at mount from the same 640 the

--- a/web/tests/cards.spec.js
+++ b/web/tests/cards.spec.js
@@ -240,7 +240,9 @@ test("the count the missing header gave up is in the card title", async ({ page,
   // at 640 is a second thing to keep in step.
   const titles = [
     { view: "Portfolio › Transactions", rows: () => readFixture("transactions.json").length },
-    { view: "Portfolio › Dividends", rows: () => readFixture("dividend-details.json").total },
+    // `rows.length`, not the fixture's `total`: the two are equal only because the flagged
+    // filter is off, and the count the title owes the missing header is the one on screen.
+    { view: "Portfolio › Dividends", rows: () => readFixture("dividend-details.json").rows.length },
     {
       view: "Portfolio › SecurityDetail",
       rows: () => readFixture("holding-pltr.json").transactions.length,

--- a/web/tests/cards.spec.js
+++ b/web/tests/cards.spec.js
@@ -1,0 +1,343 @@
+/**
+ * Pattern B: card per row, for the tables you read one row at a time.
+ *
+ * Six tables across five views. Below 640px each of them stops being a table and becomes a
+ * column of cards — identity and the row's one amount on line one, its textual fields muted
+ * underneath, and a two-column key/value block only where the row carries more numbers than
+ * its hero. At 640px and above every one of them is the table it always was.
+ *
+ * WHY THE TIER IS 640 AND NOT 1024, WHICH IS THE OTHER PATTERN'S. Cards trade density for
+ * readability on a 390px measurement. One of these ledgers is 803px natural and fits outright
+ * at 900, so cards there would cost rows and buy nothing — which is why the tablet tier
+ * extends the *pin* to anything that overflows and leaves this pattern on the phone.
+ *
+ * WHY THE TIER IS IN JAVASCRIPT AND NOT IN CSS, and why that is asserted here. Pattern A
+ * restyles markup that renders at every width, so its tier has to be a media query. This one
+ * is different markup: `usePhone()` in `cards.jsx` picks between two renders of the same
+ * rows. So the gate below reads the *stylesheet* to check no media query wraps these rules —
+ * a second copy of 640 around the CSS would be a second place to get the same number wrong —
+ * and reads the *DOM* at ten viewports to check the hook draws the line where it says it
+ * does. The rotation test is the one that separates a live hook from a read at mount: a
+ * rotated phone is 844px wide and must get its table back without a reload.
+ *
+ * WHAT THE FIXTURES CANNOT REACH. Two things, both annotated on every run rather than
+ * quietly narrowed away. The dimmed treatment for excluded spending rows has no row to land
+ * on — every captured transaction is counted spend — so it is asserted as a declaration and
+ * the gap is named. And PLTR, the security the suite drills into because it has the longest
+ * options history, has no dividends at all, so `SecurityDetail`'s dividend-history cards
+ * never mount. The fixtures are derived from the live database and are not hand-edited; the
+ * honest move is to say so rather than to invent a row.
+ */
+import { expect, test } from "@playwright/test";
+import { PHONE_TIER_BELOW, VIEWPORTS } from "./viewports.js";
+import { openView } from "./support/app.js";
+import { readFixture } from "./fixtures/index.js";
+import { declarationsFor } from "./support/css.js";
+
+const viewportOf = (projectName) => VIEWPORTS.find((v) => v.name === projectName);
+
+/**
+ * Every table assigned the pattern, in the order it appears in its view.
+ *
+ * `rows` reads the committed fixture rather than counting what rendered, because "one card
+ * per row" is a claim about the *data*: a build that dropped every other row would agree
+ * with itself perfectly if the expected number came from the DOM.
+ *
+ * `cols` is the header count of the table this becomes above the tier, and it is here for
+ * the same reason `pinned.spec.js` carries one — no table drops a column. Cards list every
+ * field a row has; the count above the tier is what says none of them went missing on the
+ * way through.
+ *
+ * `fields` is the size of the key/value block, and it is the pattern's own assignment rule
+ * made checkable: a row with one number stops at two lines and has none, and a row with more
+ * numbers than its hero gets exactly that many minus the hero.
+ *
+ * `tablesBelow` is how many `<table>` elements the view still renders on a phone — the other
+ * patterns' tables, which stay. Asserting the count rather than the absence of one table is
+ * what catches a card list rendered *next to* the table it was meant to replace.
+ */
+const CARDED = [
+  {
+    view: "Portfolio › Transactions",
+    tablesBelow: 0,
+    lists: [{
+      what: "the trade ledger",
+      rows: () => readFixture("transactions.json").length,
+      tableIndex: 0, cols: 8, fields: 2,
+    }],
+  },
+  {
+    view: "Portfolio › Dividends",
+    // The crosstab above it is pattern A and stays a table at every width.
+    tablesBelow: 1,
+    lists: [{
+      what: "the payment ledger",
+      rows: () => readFixture("dividend-details.json").rows.length,
+      tableIndex: 1, cols: 8, fields: 3,
+    }],
+  },
+  {
+    view: "Portfolio › SecurityDetail",
+    // The options wheel log is pattern A — three tables, two patterns, deliberately.
+    tablesBelow: 1,
+    lists: [{
+      what: "the transaction history",
+      rows: () => readFixture("holding-pltr.json").transactions.length,
+      tableIndex: 0, cols: 8, fields: 3,
+    }],
+    unrendered: [
+      "SecurityDetail's dividend history (6 cols) — PLTR is the row the suite drills into " +
+      "because it has 73 option trades, and it has no dividends at all, so that card list " +
+      "is never mounted",
+    ],
+  },
+  {
+    view: "Spending › Overview",
+    tablesBelow: 0,
+    lists: [{
+      what: "top line items",
+      rows: () => Math.min(14, readFixture("spending-summary.json").by_subcategory.length),
+      tableIndex: 0, cols: 4, fields: 0,
+    }],
+  },
+  {
+    view: "Spending › Transactions",
+    tablesBelow: 0,
+    lists: [{
+      what: "the spend ledger",
+      rows: () => readFixture("spending-transactions.json").length,
+      tableIndex: 0, cols: 6, fields: 0,
+    }],
+  },
+];
+
+for (const { view, lists, tablesBelow, unrendered } of CARDED) {
+  test.describe(view, () => {
+    test("is one card per row below the tier and the table it always was above it",
+      async ({ page, baseURL }, testInfo) => {
+        const vp = viewportOf(testInfo.project.name);
+        await openView(page, baseURL, view);
+
+        for (const gap of unrendered ?? []) {
+          testInfo.annotations.push({ type: "not-covered-by-fixtures", description: gap });
+        }
+
+        // Soft throughout, like the pinned spec: one page load, every gate reported. A card
+        // count that is wrong and a hero that lost its alignment are two findings.
+        if (vp.width >= PHONE_TIER_BELOW) {
+          expect.soft(await page.locator(".main .cards").count(),
+            "card-per-row reached the tablet tier — it is phone-only by decision").toBe(0);
+          for (const spec of lists) {
+            const cols = await page.locator(".main table").nth(spec.tableIndex)
+              .locator("thead th").count();
+            expect.soft(cols, `${spec.what}: a column went missing above the tier`).toBe(spec.cols);
+          }
+          return;
+        }
+
+        expect.soft(await page.locator(".main .cards").count(), "card lists in this view")
+          .toBe(lists.length);
+        expect.soft(await page.locator(".main table").count(),
+          "a table this pattern replaces is still rendering beside its cards").toBe(tablesBelow);
+
+        for (const [i, spec] of lists.entries()) {
+          const list = page.locator(".main .cards").nth(i);
+          expect.soft(await list.locator("> .rowcard").count(),
+            `${spec.what}: one card per row`).toBe(spec.rows());
+          // The key/value block is the assignment rule made visible: a row carrying one
+          // number stops at two lines, and one carrying more gets the rest under a rule.
+          const kv = await list.locator("> .rowcard").first().locator(".rc-kv > div").count();
+          expect.soft(kv, `${spec.what}: the key/value block`).toBe(spec.fields);
+        }
+      });
+
+    test("nothing in a card is clipped or has to be scrolled sideways to read",
+      async ({ page, baseURL }, testInfo) => {
+        const vp = viewportOf(testInfo.project.name);
+        test.skip(vp.width >= PHONE_TIER_BELOW, "above the tier there are no cards");
+        await openView(page, baseURL, view);
+
+        // The criterion cards were chosen for, and the one they cannot afford to lose:
+        // nothing hidden. EVERY card is measured rather than a sample — the longest string
+        // in the fixtures is a 65-character merchant name and nothing outside the
+        // measurement knows which row it is on — so this is geometry only, in one round
+        // trip. `scrollWidth`/`clientWidth` on a page nobody is mutating costs one forced
+        // layout and then plain property reads; a `getComputedStyle` in the same loop would
+        // be one style resolution per element, and at 1001 cards that starves the whole
+        // worker pool for minutes and takes unrelated specs down with it. The truncation
+        // half is a stylesheet fact and is asserted as one, once, below.
+        const bad = await page.locator(".main .cards").evaluateAll((lists) => {
+          const found = [];
+          for (const list of lists) {
+            for (const el of list.querySelectorAll(".rowcard, .rowcard *")) {
+              if (el.scrollWidth > el.clientWidth + 1) {
+                found.push(`${el.className || el.tagName} overflows by ` +
+                  `${el.scrollWidth - el.clientWidth}px: ${el.textContent.trim().slice(0, 40)}`);
+              }
+            }
+          }
+          return found.slice(0, 10);
+        });
+        expect(bad, "a card hides part of its row").toEqual([]);
+      });
+
+    test("the hero amount is right-aligned and tabular", async ({ page, baseURL }, testInfo) => {
+      const vp = viewportOf(testInfo.project.name);
+      test.skip(vp.width >= PHONE_TIER_BELOW, "above the tier there are no cards");
+      await openView(page, baseURL, view);
+
+      // The one alignment the pattern promises to keep. The rest of a card's fields line up
+      // within the card and not across cards, which is the price of the pattern and is only
+      // acceptable because it is never assigned where comparing across rows is the job — so
+      // the hero is the whole of what is asserted here, deliberately.
+      const hero = await page.locator(".main .rowcard .rc-hero").first().evaluate((el) => {
+        const s = getComputedStyle(el);
+        return { align: s.textAlign, numerals: s.fontVariantNumeric };
+      });
+      expect.soft(hero.align, "the hero amount is not right-aligned").toBe("right");
+      expect.soft(hero.numerals, "the hero amount lost its tabular numerals")
+        .toContain("tabular-nums");
+    });
+
+    test("a card is not interactive", async ({ page, baseURL }, testInfo) => {
+      const vp = viewportOf(testInfo.project.name);
+      test.skip(vp.width >= PHONE_TIER_BELOW, "above the tier there are no cards");
+      await openView(page, baseURL, view);
+
+      // "Nothing hidden and no interaction at all" is half the reason this pattern beat the
+      // priority-summary variant, which charged a tap to see the fields a card just prints.
+      // A card that grew a control would be that variant arriving by the back door, and the
+      // 44px tap floor would then apply to it — so this is cheaper to gate than to discover.
+      //
+      // One selector over the whole list rather than a walk per card, and the cursor read on
+      // one card rather than all of them: `cursor` comes from the sheet, so the first card
+      // answers for every card, and a thousand style resolutions here is what makes a suite
+      // this size expensive to work against.
+      const interactive = await page.locator(".main .cards").evaluateAll((lists) => {
+        const found = new Set();
+        for (const list of lists) {
+          for (const el of list.querySelectorAll(
+            ".rowcard a, .rowcard button, .rowcard input, .rowcard select, " +
+            ".rowcard textarea, .rowcard [role=button]")) {
+            found.add(el.tagName.toLowerCase());
+          }
+          const first = list.querySelector(".rowcard");
+          if (first && getComputedStyle(first).cursor === "pointer") found.add("cursor: pointer");
+        }
+        return [...found];
+      });
+      expect(interactive, "a card grew a control — the pattern is read-only by decision")
+        .toEqual([]);
+    });
+  });
+}
+
+test("the count the missing header gave up is in the card title", async ({ page, baseURL }) => {
+  // There is no `<thead>` under this pattern, so the two things a header carried besides its
+  // labels have to land somewhere: how many rows there are, and — in a grouped table — what
+  // they add up to. The count goes in the title above the list, at every width rather than
+  // only on a phone, because it is the same number either way and a title that changes shape
+  // at 640 is a second thing to keep in step.
+  const titles = [
+    { view: "Portfolio › Transactions", rows: () => readFixture("transactions.json").length },
+    { view: "Portfolio › Dividends", rows: () => readFixture("dividend-details.json").total },
+    {
+      view: "Portfolio › SecurityDetail",
+      rows: () => readFixture("holding-pltr.json").transactions.length,
+    },
+    {
+      view: "Spending › Overview",
+      rows: () => Math.min(14, readFixture("spending-summary.json").by_subcategory.length),
+    },
+    {
+      view: "Spending › Transactions",
+      rows: () => readFixture("spending-transactions.json").length,
+    },
+  ];
+  for (const t of titles) {
+    await openView(page, baseURL, t.view);
+    const headings = await page.locator(".main .card h3").allInnerTexts();
+    expect.soft(headings.join(" | "), `${t.view}: no card title states the row count`)
+      .toContain(String(t.rows()));
+  }
+});
+
+test("no rule under this pattern truncates or refuses to wrap", async ({ page, baseURL }) => {
+  await openView(page, baseURL, "Spending › Transactions");
+  // The other half of "nothing is clipped", and it is a fact about the sheet rather than a
+  // measurement — which is precisely why the per-card gate above cannot hold it. An
+  // `ellipsis` is invisible to a `scrollWidth` check: the element it truncates fits its box
+  // perfectly, which is the whole point of it. Two ways in, and both would read as house
+  // style to whoever adds them: the prototype this pattern came from ellipsised its name
+  // column, and the table rule these cards replace is `white-space: nowrap`.
+  for (const sel of [".cards", ".rowcard", ".rc-head", ".rc-nm", ".rc-hero", ".rc-sub",
+                     ".rc-kv", ".rc-kv > div", ".rc-kv .k", ".rc-kv .v"]) {
+    for (const r of await declarationsFor(page, sel)) {
+      expect(r.decls["text-overflow"], `\`${sel}\` truncates — a card must not hide a field`)
+        .toBeUndefined();
+      expect(r.decls["white-space"], `\`${sel}\` refuses to wrap`).not.toBe("nowrap");
+    }
+  }
+});
+
+test.describe("the tier is the hook, not a media query", () => {
+  test("no rule under this pattern is wrapped in one", async ({ page, baseURL }) => {
+    await openView(page, baseURL, "Spending › Transactions");
+    // Pattern A had to write its tier in CSS, because it restyles markup that renders at
+    // every width — and `pinned.spec.js` gates *which* tier it wrote, because 639.98 and
+    // 1023.98 are one character apart to read and a whole tier apart in effect. This pattern
+    // has no such choice to get wrong: the card list does not exist above 640 at all. What it
+    // can get wrong is writing 640 twice, so this asserts the CSS never says it.
+    for (const sel of [".cards", ".rowcard", ".rc-head", ".rc-hero", ".rc-sub", ".rc-kv"]) {
+      const rules = await declarationsFor(page, sel);
+      expect(rules.length, `no rule ships for \`${sel}\``).toBeGreaterThan(0);
+      for (const r of rules) {
+        expect(r.media, `\`${sel}\` is scoped to a tier the hook already owns`).toBeNull();
+      }
+    }
+  });
+
+  test("a rotated phone gets its table back without a reload",
+    async ({ page, baseURL }, testInfo) => {
+      // The gate that separates a live `matchMedia` from a read at mount, which is what
+      // `Holdings.jsx` does with the same query for its footnote — and the difference is
+      // deliberate there: that one seeds state the user then owns. This one *is* the layout,
+      // and 844x390 is a real phone that has left the tier by turning sideways.
+      //
+      // Run once rather than ten times: it sets its own two viewports, so the project's is
+      // the starting point and nothing else.
+      test.skip(testInfo.project.name !== "design-width", "this test drives its own viewport");
+
+      await openView(page, baseURL, "Spending › Transactions");
+      await expect(page.locator(".main .cards")).toHaveCount(1);
+      await expect(page.locator(".main table")).toHaveCount(0);
+
+      await page.setViewportSize({ width: 844, height: 390 });
+      await expect(page.locator(".main .cards")).toHaveCount(0);
+      await expect(page.locator(".main table")).toHaveCount(1);
+
+      await page.setViewportSize({ width: 390, height: 844 });
+      await expect(page.locator(".main .cards")).toHaveCount(1);
+      await expect(page.locator(".main table")).toHaveCount(0);
+    });
+});
+
+test("the excluded row's treatment survives the pattern", async ({ page, baseURL }, testInfo) => {
+  await openView(page, baseURL, "Spending › Transactions");
+  // ASSERTED AS A DECLARATION, because the fixtures hold no row it applies to: every
+  // captured spending transaction is counted spend, and the endpoint only returns the
+  // excluded ones behind `include_excluded=true`, which was never captured. So the table
+  // above the tier cannot demonstrate its dimming either — the two renderings are equally
+  // unexercised, and the check that matters is that they agree on the number.
+  testInfo.annotations.push({
+    type: "not-covered-by-fixtures",
+    description: "no excluded spending row exists in the committed fixtures, so the dimmed " +
+      "treatment is asserted as a declaration on both sides rather than observed",
+  });
+  const rules = await declarationsFor(page, ".rowcard.dim");
+  expect(rules, "no dimmed treatment for an excluded row").toHaveLength(1);
+  // The same 0.55 the table row carries inline in `spending/Transactions.jsx`. It is the
+  // same fact about the row in both renderings, so a card that dimmed differently would be
+  // the pattern quietly restating a decision it only inherited.
+  expect(rules[0].decls.opacity, "the card dims by a different amount than the row").toBe("0.55");
+});

--- a/web/tests/hscroll-baseline.js
+++ b/web/tests/hscroll-baseline.js
@@ -23,7 +23,7 @@
  * Above 1024px there is no gate and therefore no entries here — `HSCROLL_GATE_APPLIES_BELOW`
  * in `viewports.js` says why those three viewports are exempt.
  *
- * LOWERED FOUR TIMES SO FAR.
+ * LOWERED FIVE TIMES SO FAR.
  *
  * 1. The unconditional fixes. `.grid2`'s `auto-fit` did most of it: two 419px tracks side by
  *    side became one, so `Portfolio › Overview` went 619 → 288 at 360px, `Spending › By
@@ -68,6 +68,26 @@
  *    `By Category` and `Spending › Overview` is one shared cause — `.grid2`'s `minmax(420px,
  *    1fr)` track floor, which does not fit a 362px pane. None of the four holds a table
  *    this pattern was assigned to.
+ *
+ * 5. Card per row. The tier boundary is back, and this time it is the whole story: **every
+ *    phone row that was still non-zero for a table reason goes to zero, and not one row at
+ *    640, 834 or 844 moves by a pixel.** That is the pattern being phone-only by decision
+ *    rather than by accident — cards trade density for readability on a 390px measurement,
+ *    and `spending/Transactions` is 803px natural and fits outright at 900. The three views
+ *    the previous entry named as waiting — both `Transactions` ledgers and `SecurityDetail`
+ *    — are now zero from 360 to 639 and unchanged above it. What is left at 640/834/844 is
+ *    the tablet tier's, which extends the *pin* to anything that overflows there.
+ *
+ *    `Spending › Overview` is the one that reads oddly and is the most informative: it falls
+ *    114 → 74, 84 → 44, 44 → 4, landing **exactly on `Portfolio › Overview`, `Options` and
+ *    `By Category`**. The 40px it shed was the Top Line Items table; what it is left holding
+ *    is the same `.grid2` 420px track floor the other three carry, which no ticket owns and
+ *    which neither pattern can reach. Four views, one residual, now identical to the pixel —
+ *    which is the strongest evidence yet that the remaining phone overflow has a single
+ *    cause and is not four separate table problems.
+ *
+ *    `Net Worth` is untouched and still the largest phone number here. It waits for the
+ *    editors' floor; neither table pattern applies to a form.
  */
 export const HSCROLL_BASELINE = {
   "small-phone": {
@@ -76,14 +96,14 @@ export const HSCROLL_BASELINE = {
     "Portfolio › Performance": 0,
     "Portfolio › Dividends": 0,
     "Portfolio › Options": 74,
-    "Portfolio › Transactions": 891,
-    "Portfolio › SecurityDetail": 510,
+    "Portfolio › Transactions": 0,
+    "Portfolio › SecurityDetail": 0,
     "Net Worth": 349,
-    "Spending › Overview": 114,
+    "Spending › Overview": 74,
     "Spending › By Category": 74,
     "Spending › Classify": 0,
     "Spending › Recurring": 0,
-    "Spending › Transactions": 867,
+    "Spending › Transactions": 0,
   },
   "design-width": {
     "Portfolio › Overview": 44,
@@ -91,14 +111,14 @@ export const HSCROLL_BASELINE = {
     "Portfolio › Performance": 0,
     "Portfolio › Dividends": 0,
     "Portfolio › Options": 44,
-    "Portfolio › Transactions": 861,
-    "Portfolio › SecurityDetail": 480,
+    "Portfolio › Transactions": 0,
+    "Portfolio › SecurityDetail": 0,
     "Net Worth": 319,
-    "Spending › Overview": 84,
+    "Spending › Overview": 44,
     "Spending › By Category": 44,
     "Spending › Classify": 0,
     "Spending › Recurring": 0,
-    "Spending › Transactions": 837,
+    "Spending › Transactions": 0,
   },
   "large-phone": {
     "Portfolio › Overview": 4,
@@ -106,14 +126,14 @@ export const HSCROLL_BASELINE = {
     "Portfolio › Performance": 0,
     "Portfolio › Dividends": 0,
     "Portfolio › Options": 4,
-    "Portfolio › Transactions": 821,
-    "Portfolio › SecurityDetail": 440,
+    "Portfolio › Transactions": 0,
+    "Portfolio › SecurityDetail": 0,
     "Net Worth": 279,
-    "Spending › Overview": 44,
+    "Spending › Overview": 4,
     "Spending › By Category": 4,
     "Spending › Classify": 0,
     "Spending › Recurring": 0,
-    "Spending › Transactions": 797,
+    "Spending › Transactions": 0,
   },
   "phone-tier-last-pixel": {
     "Portfolio › Overview": 0,
@@ -121,14 +141,14 @@ export const HSCROLL_BASELINE = {
     "Portfolio › Performance": 0,
     "Portfolio › Dividends": 0,
     "Portfolio › Options": 0,
-    "Portfolio › Transactions": 612,
-    "Portfolio › SecurityDetail": 231,
+    "Portfolio › Transactions": 0,
+    "Portfolio › SecurityDetail": 0,
     "Net Worth": 70,
     "Spending › Overview": 0,
     "Spending › By Category": 0,
     "Spending › Classify": 0,
     "Spending › Recurring": 0,
-    "Spending › Transactions": 588,
+    "Spending › Transactions": 0,
   },
   "tablet-tier-first-pixel": {
     "Portfolio › Overview": 8,


### PR DESCRIPTION
Closes #29.

Six tables across five views stop being tables below 640px. A row becomes a card: identity and the one number it is about on line one, its textual fields muted underneath, and a two-column key/value block **only** where the row carries more numbers than its hero — so a six-field ledger stops at two lines, which is the measurement the pattern was chosen on.

The assignment test is not the word "ledger" and not the column count; it is **how many numbers a row carries**. That is why the wheel log on the same page took the pin instead, and why Top Line Items is here at four columns — its line-item column is unbounded free text from the database, measured at 471px.

| table | key/value block | hero |
|---|---|---|
| `spending/Transactions` | none — the two-line shape the pattern was measured on | amount |
| `portfolio/Transactions` | Qty, Price | gross amount |
| `Dividends` payment ledger | Qty held, Declared /u, Implied /u | gross SGD |
| `SecurityDetail` txn history | Qty, Balance, Price | amount |
| `SecurityDetail` dividend history | Qty held, Rate/unit | gross SGD |
| `spending/Overview` Top Line Items | none | spend |

## The tier is the hook, not a media query

Pattern A restyles markup that renders at every width, so its 1024 has to be a media query — and `pinned.spec.js` gates *which* tier, because 639.98 and 1023.98 are one character apart to read. This is different markup: `usePhone()` picks between two renders of the same rows, so none of the `.cards` / `.rc-*` rules is inside a media block at all. Writing 640 around them as well would be a second place to get the same number wrong. Asserted.

`usePhone` **subscribes** where `Holdings.jsx` reads the same query **once**, and the difference is deliberate: that one seeds state the user then owns, this one *is* the layout. A rotated phone is 844px wide and must get its table back without a reload — `cards.spec.js` drives that rotation rather than trusting it.

## No header, so the count moves

There is no `<thead>` under this pattern, so the count it carried goes into the card title, at every width. That is the one step past the letter of the ticket, and it is deliberate: it is the same number either way, and a title that changes shape at 640 is a second thing to keep in step.

## The ratchet, fifth drop

The tier boundary is the whole story: **every phone row still non-zero for a table reason goes to zero, and not one row at 640, 834 or 844 moves by a pixel.** Card-per-row is phone-only by decision — one of these ledgers is 803px natural and fits outright at 900, so cards there would cost rows and buy nothing.

`Spending › Overview` is the informative one: 114 → 74, 84 → 44, 44 → 4, landing **exactly** on `Portfolio › Overview`, `Options` and `By Category`. The 40px it shed was the Top Line Items table; what it still holds is the shared `.grid2` 420px track floor. Four views, one residual, identical to the pixel.

## Two acceptance criteria left open, both by ticket boundary

- **"Grouped tables render a group header carrying the group's aggregate."** None of these six is grouped. The only grouped B table in the spec is the spending drill's third level, which leaves its parent table entirely — that is #30, and it adds the header alongside the lift. `cards.jsx` documents the omission rather than shipping a component no test could reach.
- **"The main pane does not scroll horizontally below 1024px."** Holds below 640. At 640–1024 the three ledgers still overflow, and that is #33's rule — the pin extends to anything that overflows in the tier, card-per-row does not. Below 640, `Spending › Overview` keeps 74/44/4 from the `.grid2` track floor, which `RESPONSIVE.md` records as having no owner at all.

## Verification

`cards.spec.js` is the mirror image of `pinned.spec.js`. "Nothing is clipped" is split in two on purpose: the geometry runs over every card in one round trip, and the truncation half is a stylesheet fact — an `ellipsis` is invisible to a `scrollWidth` check, because the element it truncates fits its box perfectly.

Two things the fixtures cannot reach, annotated on every run rather than narrowed away: no captured spending row is excluded, and PLTR — the row the suite drills into for its 73 option trades — has no dividends at all.

`make test-web`: **798 passed, 0 failed.**

## Review fixes folded in

Dividends' title counted the server total while the list rendered the flagged-only subset — under this pattern that pill *is* the missing header's count, so it now counts what renders. Its hero also loses `pos`, because the desktop cell is unclassed. Plus three stale `file:line` anchors in the checklist, one of them inside a bullet the same commit rewrote.