### PR TITLE
The spending drill: pinned categories, lifted transaction cards

### DIFF
--- a/RESPONSIVE.md
+++ b/RESPONSIVE.md
@@ -159,7 +159,7 @@ Things the build session must be told, not left to discover.
 - `spending/Transactions.jsx:40` carries an inline `fontSize: 13` — **CSS cannot reach it**; the rule silently
   no-ops until that style moves to a class.
 - `Classify.jsx:126` carries an inline `maxHeight: 232` — same problem, accepted as-is.
-- `ByCategory.jsx:133` carries an inline `paddingLeft: 26` — same family. It is what makes that table's
+- `ByCategory.jsx:186` carries an inline `paddingLeft: 26` — same family. It is what makes that table's
   pinned column 212px rather than ~186px.
 - **A pinned column is only useful if its column is an identity.** `SecurityDetail`'s options table used to
   lead with `Type` (`Put`/`Put`/`Call`); the merged `Contract` cell that replaced it has landed, so that
@@ -245,7 +245,7 @@ Things the build session must be told, not left to discover.
 - **The app bar is `box-sizing: content-box`** against the app-wide `border-box`, so the top inset adds
   to its 48px instead of eating it. 48px is the number the whole drawer-versus-bottom-bar trade was
   decided on; under `border-box` a 47px inset would crush the bar to a line.
-- **`.tabs` is not only the navigation strip.** `ByCategory.jsx:95` borrows the class for its own view
+- **`.tabs` is not only the navigation strip.** `ByCategory.jsx:132` borrows the class for its own view
   header — an `<h3>` and a year `<select>` — with the border overridden inline. That is why the phone
   rule that hides the strip is `.main > .tabs`; a bare `.tabs` deletes that heading and the year picker
   with it, and the view still renders, so nothing fails loudly.

--- a/RESPONSIVE.md
+++ b/RESPONSIVE.md
@@ -112,7 +112,7 @@ criteria **instead of** the universal list — reading comfort, row density and 
 | Portfolio › SecurityDetail | ~~txn history **B**~~ **landed**; ~~dividend history **B**~~ **landed but never rendered** — PLTR is the row the suite drills into because it has 73 option trades, and it has no dividends at all, so `cards.spec.js` annotates that gap on every run rather than closing it with an invented row; ~~options history **A**, pinning the merged two-line `Contract` cell~~ **landed**. Three tables, two patterns, deliberately. `← Holdings` is a ≥44px target and is the **only** way back — there is no router. *(The pane no longer scrolls sideways here below 640: the 914px txn history is cards now. At 640 and above it still does, and that is the tablet tier's.)* |
 | Net Worth | editor floor; line chart has a **DOM key, not `<Legend>`**; Breakdown and History wrapped in `overflow-x: auto`; ~~`100svh`~~ *(the shell's, landed and asserted)* |
 | Spending › Overview | donut gone below 640, list is the chart; ~~Top Line Items pattern **B** (471px — A's pin would be the 232px Line item, 70% of the viewport)~~ **landed**, and it is the row that proves the map's claim about the leftover overflow: this view fell 114 → 74 / 84 → 44 / 44 → 4 and landed **exactly** on the three other `.grid2` views. Both halves of the `.grid2` end up as ranked lists |
-| Spending › By Category | donut gone below 640; Categories pattern **A** with the name column pinned — it keeps its own `▸`/`▾` and does **not** get the persistent `›`; drilled transactions render as **B** cards **below the table**, not as a nested row, headed by subcategory + count + aggregate. **The only grouped B table in the spec, and therefore the only group header** — `cards.jsx` ships none, because the six tables card-per-row landed on are all flat and an unused component is a header no test can reach. The drill's own slice adds it alongside the lift |
+| Spending › By Category | donut gone below 640; ~~Categories pattern **A** with the name column pinned — it keeps its own `▸`/`▾` and does **not** get the persistent `›`~~ **landed** — `pinned.spec.js` carries this view like the other six and `drill.spec.js` asserts the carve-out by name, plus the `.rowtap` feedback it takes *instead* of the chevron; ~~drilled transactions render as **B** cards **below the table**, headed by subcategory + count + aggregate~~ **landed**, and they leave the `.grid2` entirely rather than merely the table — inside that card they would be 386px wide in a 362px pane, clipped by the 420px track floor no ticket owns rather than by the nesting this ticket fixes. **The only grouped B table in the spec, so `CardGroup` in `cards.jsx` has exactly one call site** — it landed here because until now there was nothing grouped to head. What is left is eyes-only: whether three levels of drill read as one structure once the third leaves the grid |
 | Spending › Classify | editor floor; `.fillpane` neutralised so the page scrolls as one; **⇅ Reorder hidden on phone**; `RuleModal` uses `svh`. *(The `textarea`'s styling has landed — asserted.)* |
 | Spending › Recurring | ~~monitor **A** *(open call)* and candidates **A**~~ **landed** — both pinned; the open call is untouched by that, since it asks whether this view wants a different information design rather than whether the reflow works. **Only the candidates table is asserted**: the owner tracks nothing, so `/api/spending/recurring` is `[]` in the committed fixtures and the monitor never mounts. `pinned.spec.js` annotates that gap on every run rather than closing it with an invented row — so the monitor's pin is an eyes-only check here. Three `.link-btn`s at 44px square; **two nested scroll regions** — the feel check |
 | Spending › Transactions | ~~pattern **B** cards~~ **landed** — the six-field shape the whole pattern was measured on: merchant, one amount, and four muted fields on a second line, with no key/value block at all. Its excluded rows keep their dimming, but **no fixture holds one** — every captured transaction is counted spend and `include_excluded=true` was never captured, so both renderings are equally unexercised and `cards.spec.js` asserts the two agree on 0.55 rather than observing either |
@@ -144,7 +144,10 @@ Failing these **changes a decision**, rather than reporting a bug.
 - **Whether a phone list of 1001 cards is usable.** `spending/Transactions` fetches `limit=1000` and the
   card is ~2× an A row's height, so the pattern's own list is the app's longest render. The map routed the
   row-cap question to observation during verification and it is still open; nothing about it is decidable
-  at a desk, and the table it replaced was equally uncapped.
+  at a desk, and the table it replaced was equally uncapped. **The By Category drill is now the second
+  instance and is on screen too** — same `limit=1000`, and "Dining Out" alone is 285 transactions in one
+  year in the live DB, against the 16 the committed fixture drills into. The fixture cannot show you the
+  bad case; a real phone on the live database can.
 
 *(`Options.jsx:71` left this list: resolved to **A**, on the measurement that a 9-field card is 4 rows per
 screen against A's 12 — the same reasoning that rejected B for Holdings at 3.)*
@@ -163,7 +166,16 @@ Things the build session must be told, not left to discover.
   one is now pinnable. The rule still applies to every *other* A table — check the pin actually tells you
   which row you are on.
 - **A nested `<table>` inherits its parent's width**, so it sets the parent's min-content. This is why the
-  By Category drilldown leaves the table on phone rather than becoming cards in place.
+  By Category drilldown leaves the table on phone rather than becoming cards in place. **Leaving the
+  table is not enough** — landed, and measured: cards placed in the categories card are still 386px in a
+  362px pane, because `.grid2`'s 420px track floor (the trap below) reaches them there. They leave the
+  whole grid.
+- **A card that overflows the pane reports nothing to `scrollWidth`** — it fits its own contents
+  perfectly; what is off screen is the box it sits in. And measuring its right edge in *viewport*
+  coordinates does not catch it either, because clicking a row has already scrolled `.main` sideways and
+  dragged the card back into view. `drill.spec.js` adds `scrollLeft` back and compares in the pane's
+  scroll space; built against the rejected layout, that is the difference between a 27px failure and a
+  green run.
 - `.grid2`'s `minmax(420px, 1fr)` is **~100px optimistic against real data** — `spending/Overview.jsx:36`'s card needs
   **519px** with the live DB's longest subcategory name. `auto-fit` still behaves; the column just spills
   inside itself between 1024 and ~1256.

--- a/web/TESTING.md
+++ b/web/TESTING.md
@@ -49,7 +49,7 @@ none of it renders. It shares
 `foundations.spec.js`'s CSSOM reader (`tests/support/css.js`) for the two criteria that are
 about a notch and therefore have no geometric form in Chromium.
 
-`tests/pinned.spec.js` — pattern A: seven tables across six views that pin an identity column and
+`tests/pinned.spec.js` — pattern A: eight tables across seven views that pin an identity column and
 scroll the rest sideways below **1024px**, not 640. It is the one spec whose tier is the pin tier,
 because the pin is worth more as the window narrows: the same gates run at seven viewports and the
 other three assert the inverse — that the desktop table is untouched. It also carries the two gates
@@ -67,6 +67,17 @@ around those rules would be 640 written twice. It drives a rotation at one proje
 gate that can tell a live `matchMedia` from a read at mount, and it names two things the fixtures
 cannot reach: no captured spending row is excluded, and the security the suite drills into has no
 dividends.
+
+`tests/drill.spec.js` — the one view where both patterns land on the same thing. `By Category` is a
+three-level drill, not two tables: categories and subcategories are rows and take the pin, and the
+transactions behind a subcategory take cards — but they cannot stay nested, because a nested one
+inherits a width that puts their amounts off the screen. So this spec gates the *structure* the two
+patterns meet in, and leaves each pattern's own gates to the two files above. Its sharpest assertion
+is the one that reads most like the others and is not: a card's right edge is compared in the pane's
+**scroll space**, because clicking a row has already scrolled `.main` sideways, and in viewport
+coordinates the rejected layout passes. It also carries the group header — the only one in the app —
+and the chevron carve-out, which is the only place pattern A's affordance rule is deliberately not
+applied.
 
 `tests/inventory.spec.js` — the checks that read files rather than pixels: the table count, the
 single donut implementation, that no `100vh` survives under `web/src`, the viewport meta's

--- a/web/playwright.config.js
+++ b/web/playwright.config.js
@@ -39,7 +39,7 @@ export default defineConfig({
     { name: "inventory", testMatch: /inventory\.spec\.js/ },
     ...VIEWPORTS.map((v) => ({
       name: v.name,
-      testMatch: /(baseline|unconditional|foundations|shell|pinned|cards)\.spec\.js/,
+      testMatch: /(baseline|unconditional|foundations|shell|pinned|cards|drill)\.spec\.js/,
       use: {
         ...devices["Desktop Chrome"],
         viewport: { width: v.width, height: v.height },

--- a/web/src/cards.jsx
+++ b/web/src/cards.jsx
@@ -71,13 +71,33 @@ export function Cards({ children }) {
 }
 
 /**
- * THE GROUP HEADER IS NOT HERE, and its absence is the ticket boundary rather than a gap.
- * None of the six tables this pattern lands on is grouped — the one grouped B table in the
- * whole spec is the spending drill's third level, which leaves its parent table entirely and
- * is headed by subcategory, count and aggregate. That structure belongs to the drill's own
- * ticket, which is blocked on this module existing; it adds the header alongside the lift.
- * Shipping an unused component here would be a header no test could reach.
+ * THE GROUP HEADER — the rest of the job the missing `<thead>` handed over, and the one part
+ * of this pattern with exactly one call site.
+ *
+ * It landed with the spending drill rather than with the rest of this module, because until
+ * then there was nothing grouped to head: all six tables card-per-row first landed on are
+ * flat, and an unused component is a header no test can reach. The drill's third level is the
+ * only grouped B list in the spec — the transactions behind one subcategory, lifted out of
+ * the categories grid because a nested one would inherit a width that clips their amounts —
+ * so it is the only place a group's *aggregate* is stated in this pattern at all.
+ *
+ * It lives here rather than in that view for the reason `Cards` and `RowCard` do: this module
+ * is where the pattern's markup is decided, and a header written beside its one caller is how
+ * the second grouped list ends up with a different one.
+ *
+ * `n` is the number of cards UNDER this header, not the number the server holds — same
+ * reading the card titles take, for the same reason: the count a missing header owes you is
+ * the count on the screen.
  */
+export function CardGroup({ name, n, total }) {
+  return (
+    <div className="cardgroup">
+      <span className="cg-nm">{name}</span>
+      <span className="cg-n">{n} txn{n === 1 ? "" : "s"}</span>
+      <span className="cg-total">{total}</span>
+    </div>
+  );
+}
 
 /**
  * One row, as a card.

--- a/web/src/modules/spending/ByCategory.jsx
+++ b/web/src/modules/spending/ByCategory.jsx
@@ -116,9 +116,14 @@ export default function SpendByCategory() {
   const count = groups.reduce((a, g) => a + g.n, 0);
   const top = groups[0];
   // The row the third level was drilled from, which is where the lifted list gets its header:
-  // the same name and the same aggregate the row itself shows, so the two renderings of one
-  // group cannot disagree.
-  const drilled = open && openSub
+  // it carries the same name and the same aggregate the row above it shows, so one group does
+  // not state itself two ways.
+  //
+  // The COUNT is the one thing the header does not take from here — it is `rows.length`, what
+  // is on screen, and above 1000 that is deliberately less than this row's `n`, because the
+  // fetch is capped at `limit=1000`. A header that promised 1,284 above 1,000 cards would be
+  // the missing `<thead>`'s job done wrong rather than done elsewhere.
+  const drilledSub = open && openSub
     ? (subsOf[open] || []).find((sc) => sc.sub === openSub)
     : null;
 
@@ -171,9 +176,13 @@ export default function SpendByCategory() {
                         </tr>
                         {open === g.cat && g.cat && (subsOf[g.cat] || []).map((sc) => (
                           <React.Fragment key={g.cat + "/" + sc.name}>
-                            <tr className={sc.sub ? "rowtap" : undefined}
+                            {/* `subrow` carries the tint that was an inline background until
+                                the pin arrived — an opaque pinned cell cannot read one, so
+                                the name column rendered a different colour from its own
+                                numbers. See `styles.css`. */}
+                            <tr className={"subrow" + (sc.sub ? " rowtap" : "")}
                                 onClick={() => sc.sub && toggleSub(g.cat, sc.sub)}
-                                style={{ cursor: sc.sub ? "pointer" : "default", background: "var(--panel2)" }}>
+                                style={{ cursor: sc.sub ? "pointer" : "default" }}>
                               <td className="l" style={{ paddingLeft: 26, fontSize: 12 }}>
                                 <span className="mut">{sc.sub ? (openSub === sc.sub ? "▾" : "▸") : "·"}</span> {sc.name}
                               </td>
@@ -196,7 +205,7 @@ export default function SpendByCategory() {
             </div>
           </div>
 
-          {phone && drilled && <DrilledCards sub={drilled} rows={rows} />}
+          {phone && drilledSub && <DrilledCards sub={drilledSub} rows={rows} />}
         </>
       )}
 

--- a/web/src/modules/spending/ByCategory.jsx
+++ b/web/src/modules/spending/ByCategory.jsx
@@ -1,11 +1,33 @@
 import React, { useEffect, useRef, useState } from "react";
 import { get, sgd, fmt } from "../../api.js";
 import { COLORS, Donut } from "../../charts.jsx";
+import { CardGroup, Cards, RowCard, usePhone } from "../../cards.jsx";
 
 // Expenses for a single calendar year, broken down by category. The year selector loads that
 // year's window (from=YYYY-01-01, to=YYYY-12-31) through the existing spending endpoints;
 // clicking a category drills into its subcategories, and a subcategory into its transactions
 // for the same window.
+//
+// ONE THREE-LEVEL DRILL, NOT TWO TABLES, and that is why the two responsive patterns meet
+// here rather than being assigned independently. The drilled transactions used to render as a
+// nested grid inside a `colSpan` cell — and a nested one inherits its parent's width, so the
+// child was setting the parent's min-content: 334px collapsed, 413px with subcategories open,
+// 567px once a subcategory was drilled.
+//
+// Levels one and two stay rows and take the pinned pattern, with the name column pinned.
+// LEVEL THREE LEAVES on a phone. Its pattern is forced by identity rather than by
+// measurement — these are the same `cash_txn` rows `spending/Transactions` renders, from the
+// same endpoint, a strict subset of its columns, and that view is already card-per-row — but
+// cards cannot live in the `colSpan` cell: they would inherit its 413px inside a 330px card,
+// putting the hero amount off the edge behind a swipe, which is the exact property cards were
+// chosen for. So below 640px they render below the grid instead, headed by the subcategory,
+// its count and its aggregate.
+//
+// BELOW THE `.grid2` RATHER THAN INSIDE THE CARD, which is a second width problem and not the
+// same one. `.grid2`'s track floor is `minmax(420px, 1fr)` and does not fit the 362px pane —
+// the residual four views share and no ticket owns (`RESPONSIVE.md`'s Traps). Cards placed
+// inside that card would be 388px wide in a 362px pane and clipped again, by a cause this
+// view cannot reach. Outside the grid they take the pane's own width.
 export default function SpendByCategory() {
   const [years, setYears] = useState(null);   // null=loading, []=no data
   const [yearsErr, setYearsErr] = useState(false);
@@ -15,6 +37,10 @@ export default function SpendByCategory() {
   const [openSub, setOpenSub] = useState(null); // expanded subcategory within `open`
   const [rows, setRows] = useState(null);     // transactions for `open` + `openSub`
   const [undated, setUndated] = useState(null);
+  // Live rather than read once at mount, like the other card lists: a rotated phone is 844px
+  // wide, has left the tier, and must get its nested drill back without a reload — with the
+  // drill still open and without re-fetching it.
+  const phone = usePhone();
   // Request generation: every year switch / category click bumps it, and a response may only
   // land if it is still the newest one. Without it a slow earlier fetch resolves last and
   // paints its numbers under the newly selected year's label.
@@ -89,6 +115,12 @@ export default function SpendByCategory() {
   const total = sum && !sum.error ? sum.total_sgd : 0;
   const count = groups.reduce((a, g) => a + g.n, 0);
   const top = groups[0];
+  // The row the third level was drilled from, which is where the lifted list gets its header:
+  // the same name and the same aggregate the row itself shows, so the two renderings of one
+  // group cannot disagree.
+  const drilled = open && openSub
+    ? (subsOf[open] || []).find((sc) => sc.sub === openSub)
+    : null;
 
   return (
     <div>
@@ -113,41 +145,58 @@ export default function SpendByCategory() {
             <Donut title={`By Category · ${year}`} data={groups} />
             <div className="card">
               <h3>Categories</h3>
-              <table>
-                <thead><tr><th className="l">Category</th><th>Spend</th><th>%</th><th>Txns</th></tr></thead>
-                <tbody>
-                  {groups.map((g, i) => (
-                    <React.Fragment key={g.name}>
-                      <tr onClick={() => g.cat && toggle(g.cat)} style={{ cursor: g.cat ? "pointer" : "default" }}>
-                        <td className="l">
-                          <span style={{ color: COLORS[i % COLORS.length] }}>{g.cat ? (open === g.cat ? "▾" : "▸") : "·"}</span> {g.name}
-                        </td>
-                        <td>{sgd(g.value)}</td>
-                        <td className="mut">{fmt((g.value / total) * 100, 1)}%</td>
-                        <td className="mut">{g.n}</td>
-                      </tr>
-                      {open === g.cat && g.cat && (subsOf[g.cat] || []).map((sc) => (
-                        <React.Fragment key={g.cat + "/" + sc.name}>
-                          <tr onClick={() => sc.sub && toggleSub(g.cat, sc.sub)}
-                              style={{ cursor: sc.sub ? "pointer" : "default", background: "var(--panel2)" }}>
-                            <td className="l" style={{ paddingLeft: 26, fontSize: 12 }}>
-                              <span className="mut">{sc.sub ? (openSub === sc.sub ? "▾" : "▸") : "·"}</span> {sc.name}
-                            </td>
-                            <td style={{ fontSize: 12 }}>{sgd(sc.value)}</td>
-                            <td className="mut" style={{ fontSize: 12 }}>{fmt((sc.value / g.value) * 100, 1)}%</td>
-                            <td className="mut" style={{ fontSize: 12 }}>{sc.n}</td>
-                          </tr>
-                          {openSub === sc.sub && sc.sub && (
-                            <tr><td colSpan={4} style={{ padding: 0 }}><TxnList rows={rows} /></td></tr>
-                          )}
-                        </React.Fragment>
-                      ))}
-                    </React.Fragment>
-                  ))}
-                </tbody>
-              </table>
+              {/* Levels one and two, read through the pinned pattern below 1024px: the name
+                  column stays put and Spend / % / Txns scroll under it. The pin is 212px
+                  rather than ~186px because of the inline 26px indent on the subcategory
+                  cell below — an inline value the stylesheet cannot reach. */}
+              <div className="pinned">
+                <table>
+                  <thead><tr><th className="l">Category</th><th>Spend</th><th>%</th><th>Txns</th></tr></thead>
+                  <tbody>
+                    {groups.map((g, i) => (
+                      <React.Fragment key={g.name}>
+                        {/* `rowtap`, not `rowlink`. Both take the same `:active` flash, and
+                            only `rowlink` grows the persistent `›` in the pinned cell — which
+                            means "this row navigates away". These expand in place, and the
+                            coloured marker already says so, so this is the one carve-out from
+                            that affordance rule. */}
+                        <tr className={g.cat ? "rowtap" : undefined}
+                            onClick={() => g.cat && toggle(g.cat)} style={{ cursor: g.cat ? "pointer" : "default" }}>
+                          <td className="l">
+                            <span style={{ color: COLORS[i % COLORS.length] }}>{g.cat ? (open === g.cat ? "▾" : "▸") : "·"}</span> {g.name}
+                          </td>
+                          <td>{sgd(g.value)}</td>
+                          <td className="mut">{fmt((g.value / total) * 100, 1)}%</td>
+                          <td className="mut">{g.n}</td>
+                        </tr>
+                        {open === g.cat && g.cat && (subsOf[g.cat] || []).map((sc) => (
+                          <React.Fragment key={g.cat + "/" + sc.name}>
+                            <tr className={sc.sub ? "rowtap" : undefined}
+                                onClick={() => sc.sub && toggleSub(g.cat, sc.sub)}
+                                style={{ cursor: sc.sub ? "pointer" : "default", background: "var(--panel2)" }}>
+                              <td className="l" style={{ paddingLeft: 26, fontSize: 12 }}>
+                                <span className="mut">{sc.sub ? (openSub === sc.sub ? "▾" : "▸") : "·"}</span> {sc.name}
+                              </td>
+                              <td style={{ fontSize: 12 }}>{sgd(sc.value)}</td>
+                              <td className="mut" style={{ fontSize: 12 }}>{fmt((sc.value / g.value) * 100, 1)}%</td>
+                              <td className="mut" style={{ fontSize: 12 }}>{sc.n}</td>
+                            </tr>
+                            {/* Level three, above the tier only — see the header. On a phone
+                                it is the lifted card list below this grid instead. */}
+                            {!phone && openSub === sc.sub && sc.sub && (
+                              <tr><td colSpan={4} style={{ padding: 0 }}><TxnList rows={rows} /></td></tr>
+                            )}
+                          </React.Fragment>
+                        ))}
+                      </React.Fragment>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
             </div>
           </div>
+
+          {phone && drilled && <DrilledCards sub={drilled} rows={rows} />}
         </>
       )}
 
@@ -157,6 +206,38 @@ export default function SpendByCategory() {
           which carry no date and so fall in no year.
         </div>
       )}
+    </div>
+  );
+}
+
+/**
+ * Level three on a phone: the drilled subcategory's transactions, out of the grid entirely.
+ *
+ * The card shape is `spending/Transactions`' minus the two fields this context already
+ * answers — the source pill and the category, since you arrived here by tapping the category
+ * and the subcategory. Merchant is the identity and the SGD amount the hero, as there.
+ *
+ * `CardGroup` is the header the pattern has been missing — see `cards.jsx`, which is where it
+ * lives and why. It is handed the count on screen and the aggregate of the row that was
+ * tapped, so the subcategory row and its lifted list state one group the same way.
+ *
+ * No `dim`: this fetch does not pass `include_excluded`, so every row it can return is
+ * counted spend. The dimming is `spending/Transactions`' business, where the filter exists.
+ */
+function DrilledCards({ sub, rows }) {
+  if (!rows) return <div className="loading" style={{ padding: "12px 0" }}>Loading…</div>;
+  return (
+    <div style={{ marginTop: 14 }}>
+      <Cards>
+        <CardGroup name={sub.name} n={rows.length} total={sgd(sub.value)} />
+        {rows.length ? rows.map((r, i) => (
+          <RowCard key={i}
+            name={r.merchant || r.description}
+            hero={sgd(Number(r.amount_sgd))}
+            heroClass={Number(r.amount_sgd) < 0 ? "neg" : "pos"}
+            meta={[r.txn_date || "—"]} />
+        )) : <div className="mut" style={{ fontSize: 12 }}>No transactions.</div>}
+      </Cards>
     </div>
   );
 }

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -143,6 +143,13 @@ tr:hover td { background: var(--hover); }
    row already takes on hover costs desktop nothing, and the alternative was a second rule
    in a tablet tier whose whole claim is that it holds exactly one. */
 tr.rowlink:active > td { background: var(--hover); }
+/* The same feedback, for the rows that expand IN PLACE rather than navigating. They are the
+   one carve-out from the chevron below — a `›` on a row that opens nothing is a lie about
+   where the tap goes — so this is the whole of what says "that tap registered" on touch, and
+   the coloured `▸`/`▾` is what says the row is tappable at all. Same declaration block as the
+   two rules above on purpose: the build folds them into one, and a literal here is how one
+   feedback state quietly becomes two. */
+tr.rowtap:active > td { background: var(--hover); }
 /* Dividends' total rule, moved off the `<tr>` and onto its cells. `border-collapse:
    separate` — which the pinned block below switches that table to — does not paint a border
    declared on a row at all. Identical under both modes, so it is unconditional. */
@@ -233,7 +240,8 @@ tr.rowlink:active > td { background: var(--hover); }
   /* The pinned cell is opaque, so it needs the row's two feedback states restated on it or
      it stays flat while the rest of the row lights up. */
   .pinned tbody > tr:not(.grouprow):hover > :first-child,
-  .pinned tbody > tr.rowlink:active > :first-child { background: var(--hover); }
+  .pinned tbody > tr.rowlink:active > :first-child,
+  .pinned tbody > tr.rowtap:active > :first-child { background: var(--hover); }
   /* The chevron: persistent, at the right edge of the *pinned* cell, so "this row opens
      something" is visible without hovering and cannot be scrolled away. Absolutely
      positioned against the sticky cell with the padding reserving its lane, so it never
@@ -286,6 +294,29 @@ tr.rowlink:active > td { background: var(--hover); }
   font-size: 12px; }
 .rc-kv .k { flex: none; color: var(--mut); }
 .rc-kv .v { text-align: right; font-variant-numeric: tabular-nums; overflow-wrap: anywhere; }
+
+/* THE GROUP HEADER — the other half of the job pattern B took off the `<thead>`, and the only
+   place in the app it is visible. `cards.jsx` deliberately shipped none: all six tables that
+   pattern landed on are flat, so the header's remaining job there is the row count and the
+   card title carries it. The spending drill is the one grouped B list in the spec — the
+   transactions behind one subcategory, lifted out of the categories grid entirely — so it is
+   the only list whose header has an *aggregate* to state as well as a count.
+
+   Written unconditionally, like every other `.rc-*`/`.cards` rule and for the same reason:
+   the tier is `usePhone()` and nothing else. Above 640 this list is not rendered at all, so a
+   media query around these rules would be 640 written a sixth time.
+
+   Nothing truncates, for the reason the cards do not: the name here is a subcategory straight
+   out of the database, and the longest one in the live data is 30 characters in a 362px pane.
+   It wraps. */
+.cardgroup { display: flex; flex-wrap: wrap; align-items: baseline; gap: 2px 8px;
+  padding: 2px 2px 6px; }
+.cardgroup .cg-nm { flex: 1 1 auto; min-width: 0; font-weight: 600; overflow-wrap: anywhere; }
+.cardgroup .cg-n { flex: none; color: var(--mut); font-size: 11px; }
+/* Right-aligned and tabular like the hero it sits above — it is the same column of money one
+   level up, and the group's total lining up with the rows it totals is the point of it. */
+.cardgroup .cg-total { flex: none; text-align: right; font-weight: 700;
+  font-variant-numeric: tabular-nums; }
 
 /* Holdings' footnote as a disclosure — five lines of prose above a table that wants every
    row it can get. The summary is hidden by default and turned on in the phone block, which

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -146,10 +146,22 @@ tr.rowlink:active > td { background: var(--hover); }
 /* The same feedback, for the rows that expand IN PLACE rather than navigating. They are the
    one carve-out from the chevron below — a `›` on a row that opens nothing is a lie about
    where the tap goes — so this is the whole of what says "that tap registered" on touch, and
-   the coloured `▸`/`▾` is what says the row is tappable at all. Same declaration block as the
-   two rules above on purpose: the build folds them into one, and a literal here is how one
-   feedback state quietly becomes two. */
+   the coloured `▸`/`▾` is what says the row is tappable at all. The token rather than a
+   literal for the reason the rule above uses it: the pinned cell has to restate this colour,
+   and a second literal is how one feedback state quietly becomes two. */
 tr.rowtap:active > td { background: var(--hover); }
+/* The drill's second level, tinted so it reads as nested under the category above it.
+   A CLASS RATHER THAN THE INLINE STYLE IT REPLACES, and the pin is why. An opaque pinned cell
+   paints its own background, so it has to restate whatever the row it sits in is doing — the
+   same reason `--hover` is written twice in the pinned block — and CSS cannot read an inline
+   value, so as an inline style this tint stopped dead at the pinned column: the name cell
+   rendered `--panel` while its own three number cells stayed `--panel2`. Only visible below
+   1024px, because that is where the pin exists.
+   WRITTEN AFTER `tr:hover td` ON PURPOSE. Equal specificity, so source order decides, and
+   after is what preserves today's desktop exactly: an inline background already beat hover on
+   these rows, so they have never lit up on hover and still do not. `:active` carries more
+   specificity than this and so still flashes, which is the point of `.rowtap`. */
+tr.subrow > td { background: var(--panel2); }
 /* Dividends' total rule, moved off the `<tr>` and onto its cells. `border-collapse:
    separate` — which the pinned block below switches that table to — does not paint a border
    declared on a row at all. Identical under both modes, so it is unconditional. */
@@ -237,6 +249,11 @@ tr.rowtap:active > td { background: var(--hover); }
      keeps the row identifiable once it has. */
   .pinned tbody > tr:not(.grouprow) > :first-child {
     position: sticky; left: 0; z-index: 2; background: var(--panel); }
+  /* The tint restated on the pinned cell — same job the two feedback states below have, and
+     the same reason: the cell is opaque, so whatever the row is doing has to be said again
+     here or the pin renders in the wrong colour while the rest of the row is right. Written
+     after the rule above at equal specificity, so source order is what makes it win. */
+  .pinned tbody > tr.subrow > :first-child { background: var(--panel2); }
   /* The pinned cell is opaque, so it needs the row's two feedback states restated on it or
      it stays flat while the rest of the row lights up. */
   .pinned tbody > tr:not(.grouprow):hover > :first-child,
@@ -304,7 +321,8 @@ tr.rowtap:active > td { background: var(--hover); }
 
    Written unconditionally, like every other `.rc-*`/`.cards` rule and for the same reason:
    the tier is `usePhone()` and nothing else. Above 640 this list is not rendered at all, so a
-   media query around these rules would be 640 written a sixth time.
+   media query around these rules would be 640 written a fifth time — `RESPONSIVE.md`'s Traps
+   counts the four that exist and reserves the fifth for the charts.
 
    Nothing truncates, for the reason the cards do not: the name here is a subcategory straight
    out of the database, and the longest one in the live data is 30 characters in a 362px pane.
@@ -449,7 +467,7 @@ input, select, textarea { background: var(--panel2); border: 1px solid var(--lin
   /* The desktop strip goes whole, `.tabs-right` with it: the six tabs become the app bar's
      `<select>` and Refresh becomes its icon. Nothing in that group needs a phone home.
 
-     `.main > .tabs`, not `.tabs`. `ByCategory.jsx:95` borrows this class for its own view
+     `.main > .tabs`, not `.tabs`. `ByCategory.jsx:132` borrows this class for its own view
      header — an `<h3>` and a year `<select>` — for the flex row and nothing else, with the
      border overridden inline. It is nested inside the view, so the child combinator is what
      separates the navigation strip from a heading that happens to reuse its layout. */

--- a/web/tests/cards.spec.js
+++ b/web/tests/cards.spec.js
@@ -20,6 +20,12 @@
  * does. The rotation test is the one that separates a live hook from a read at mount: a
  * rotated phone is 844px wide and must get its table back without a reload.
  *
+ * A SEVENTH CARD LIST IS NOT IN THIS FILE, and that is a reachability fact rather than an
+ * omission. The spending drill's third level is card-per-row too, but it exists only behind
+ * two taps — `openView` opens a view, it does not drill one — and it is the only *grouped*
+ * list in the spec, so its group header has gates none of the six below do. `drill.spec.js`
+ * owns it, and `cards.jsx`'s `CardGroup` is the markup they share.
+ *
  * WHAT THE FIXTURES CANNOT REACH. Two things, both annotated on every run rather than
  * quietly narrowed away. The dimmed treatment for excluded spending rows has no row to land
  * on — every captured transaction is counted spend — so it is asserted as a declaration and

--- a/web/tests/drill.spec.js
+++ b/web/tests/drill.spec.js
@@ -109,6 +109,42 @@ test.describe("Spending › By Category", () => {
         "the cards are still nested inside the table they were lifted out of").toBe(0);
     });
 
+  test("the second level is pinned too, and its pinned cell keeps the row's own tint",
+    async ({ page, baseURL }, testInfo) => {
+      const vp = viewportOf(testInfo.project.name);
+      await openView(page, baseURL, "Spending › By Category");
+      await rowFor(page, CATEGORY).click();
+
+      // `pinned.spec.js` carries this view, but `openView` does not drill — so every gate it
+      // holds runs against level-one rows only, and level two is where this pattern is at its
+      // most fragile. The subcategory row is the one row in the app with a background of its
+      // own, and an opaque pinned cell paints over it: the cell has to restate the tint or the
+      // name column renders a different colour from its own three numbers. That was an inline
+      // style CSS could not reach, which is the third instance of a family `RESPONSIVE.md`
+      // already names — and it failed silently, because nothing drilled.
+      // The pinned cell is compared against a SIBLING CELL rather than against the `<tr>`.
+      // The tint sits on the cells — it has to, because `border-collapse: separate` and an
+      // opaque pin both ignore a background declared on a row — so the row itself is
+      // transparent and comparing to it would pass whenever the pin was transparent too,
+      // which is the failure. The two cells either match or the column is visibly wrong.
+      const seen = await rowFor(page, SUB).evaluate((tr) => ({
+        position: getComputedStyle(tr.children[0]).position,
+        left: getComputedStyle(tr.children[0]).left,
+        pin: getComputedStyle(tr.children[0]).backgroundColor,
+        sibling: getComputedStyle(tr.children[1]).backgroundColor,
+      }));
+
+      if (vp.width >= PIN_TIER_BELOW) {
+        expect.soft(seen.position, "the pin reached desktop").toBe("static");
+        return;
+      }
+      expect.soft(seen.position, "the subcategory row's identity column is not pinned")
+        .toBe("sticky");
+      expect.soft(seen.left, "the subcategory row's pin is not at the left edge").toBe("0px");
+      expect.soft(seen.pin, "the pinned cell paints over the second level's tint")
+        .toBe(seen.sibling);
+    });
+
   test("the lifted cards carry a header with the subcategory, its count and its aggregate",
     async ({ page, baseURL }, testInfo) => {
       const vp = viewportOf(testInfo.project.name);
@@ -159,7 +195,11 @@ test.describe("Spending › By Category", () => {
         const main = document.querySelector(".main");
         const origin = main.getBoundingClientRect().left - main.scrollLeft;
         const found = [];
-        for (const card of main.querySelectorAll(".cards > .rowcard")) {
+        // THE GROUP HEADER IS MEASURED WITH THE CARDS, not left out as chrome. It is the only
+        // new markup this ticket adds, it holds the 30-character subcategory name beside an
+        // aggregate, and it is a sibling of the cards rather than one of them — so a selector
+        // that said `.rowcard` alone would skip the widest string on the screen.
+        for (const card of main.querySelectorAll(".cards > .rowcard, .cards > .cardgroup")) {
           const box = card.getBoundingClientRect();
           const right = box.right - origin;
           if (right > main.clientWidth + 1) {

--- a/web/tests/drill.spec.js
+++ b/web/tests/drill.spec.js
@@ -1,0 +1,256 @@
+/**
+ * The spending drill: one three-level structure, not two tables.
+ *
+ * `By Category` is the one view where both patterns land on the *same* thing. Categories and
+ * their subcategories are levels one and two and stay table rows — pattern A, the name column
+ * pinned. Level three, the transactions behind a subcategory, is pattern B by identity rather
+ * than by measurement: they are the same `cash_txn` rows `spending/Transactions` renders, from
+ * the same endpoint, a strict subset of its columns, and that table is already B.
+ *
+ * WHY LEVEL THREE LEAVES THE TABLE, which is the whole reason this view needed its own slice.
+ * A nested table inherits its parent's width and therefore *sets* the parent's min-content:
+ * the category table measures 334px collapsed, 413px with subcategories open and 567px once a
+ * subcategory is drilled. Cards left in that `colSpan` cell would be 413px wide in a 330px
+ * card — hero amounts off the edge, a swipe to read them — which is the exact property cards
+ * were chosen for. So on a phone they render BELOW the table instead, headed by the
+ * subcategory, its count and its aggregate. The gate for that is not `scrollWidth` on a card:
+ * a card that is wider than the pane fits its own contents perfectly. It is the card's right
+ * edge against the pane's, below.
+ *
+ * WHAT THIS FILE DOES NOT COVER, deliberately. Every pattern-A gate on the category table —
+ * the pin, the sticky header, the border model, the 60svh cap — belongs to `pinned.spec.js`,
+ * which carries this view in its `PINNED` list like the other six. Every pattern-B gate that
+ * is a fact about the sheet — no truncation, no media query — belongs to `cards.spec.js`.
+ * What is here is the structure those two patterns meet in, plus the group header and the
+ * chevron carve-out, neither of which exists anywhere else in the app.
+ */
+import { expect, test } from "@playwright/test";
+import { PHONE_TIER_BELOW, PIN_TIER_BELOW, VIEWPORTS } from "./viewports.js";
+import { openView } from "./support/app.js";
+import { readFixture } from "./fixtures/index.js";
+import { declarationsFor } from "./support/css.js";
+
+const viewportOf = (projectName) => VIEWPORTS.find((v) => v.name === projectName);
+
+/**
+ * The one drill path the fixtures can walk, and it is not an arbitrary one: `Personal` is the
+ * largest category of the default year and `Life/Health/Surgical Insurance` is the
+ * 30-character subcategory name the fixtures exist to carry — the string that makes the
+ * category table 413px and the top-line-items card 519px. Drilling anywhere else would test
+ * the structure against the easiest row in the data rather than the hardest.
+ *
+ * `spending/transactions?…&group=Personal&subcategory=Life/Health/Surgical Insurance` is the
+ * only drilled response the capture script recorded, so this is also the only path that
+ * answers with rows rather than a 404 through the seam.
+ */
+const CATEGORY = "Personal";
+const SUB = "Life/Health/Surgical Insurance";
+const drilled = () => readFixture("spending-transactions-drilled.json");
+
+/** The subcategory row's own aggregate, as the summary states it — see `groupHeader` below. */
+const subTotal = () =>
+  readFixture("spending-summary-2026.json").by_subcategory
+    .find((r) => r.category === CATEGORY && r.subcategory === SUB).v;
+
+const escapeRe = (s) => s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+
+/**
+ * A level-one or level-two row, found by its own disclosure marker plus its name.
+ *
+ * Matched on the identity *cell* rather than on the row, because a row's text is its name
+ * with three numbers run onto the end of it and nothing to anchor against. The marker is part
+ * of the pattern here — `▸` shut, `▾` open, `·` for the rows that are not drillable — so
+ * matching it also means this locator cannot accidentally find the "Personal Taxes"
+ * subcategory when it is asked for the "Personal" category.
+ */
+const rowFor = (page, name) =>
+  page.locator(".main tbody tr").filter({
+    has: page.locator("td.l").filter({ hasText: new RegExp(`^[▸▾] ${escapeRe(name)}$`) }),
+  });
+
+/** Open the view and drive all three levels: category, subcategory, transactions. */
+async function drill(page, baseURL) {
+  await openView(page, baseURL, "Spending › By Category");
+  await rowFor(page, CATEGORY).click();
+  await expect(rowFor(page, SUB), "the category did not expand into its subcategories")
+    .toHaveCount(1);
+  await rowFor(page, SUB).click();
+  // The third level is a fetch, so wait for whichever rendering this viewport gets rather
+  // than for a timeout: the cards below the table on a phone, the nested rows above it.
+  const landed = page.viewportSize().width < PHONE_TIER_BELOW
+    ? page.locator(".main .cards .rowcard")
+    : page.locator(".main table table tbody tr");
+  await expect(landed.first(), "the drilled transactions never arrived").toBeVisible();
+}
+
+test.describe("Spending › By Category", () => {
+  test("levels one and two are one table and level three is not in it",
+    async ({ page, baseURL }, testInfo) => {
+      const vp = viewportOf(testInfo.project.name);
+      await drill(page, baseURL);
+
+      const phone = vp.width < PHONE_TIER_BELOW;
+      // Counting the view's tables is what separates "the cards replaced the nested table"
+      // from "the cards rendered next to it" — the same gate `cards.spec.js` holds with
+      // `tablesBelow`, and here it is the whole claim of the ticket.
+      expect.soft(await page.locator(".main table").count(),
+        phone ? "level three is still a table inside the table" : "the view changed above the tier")
+        .toBe(phone ? 1 : 2);
+      expect.soft(await page.locator(".main .cards").count(), "card lists in this view")
+        .toBe(phone ? 1 : 0);
+
+      if (!phone) return;
+
+      expect.soft(await page.locator(".main .cards > .rowcard").count(),
+        "one card per drilled transaction").toBe(drilled().length);
+      // Not merely "below" in source order: `.cards` must not be a descendant of the table
+      // at all, because the width a nested element inherits is what the lift exists to shed.
+      expect.soft(await page.locator(".main table .cards").count(),
+        "the cards are still nested inside the table they were lifted out of").toBe(0);
+    });
+
+  test("the lifted cards carry a header with the subcategory, its count and its aggregate",
+    async ({ page, baseURL }, testInfo) => {
+      const vp = viewportOf(testInfo.project.name);
+      test.skip(vp.width >= PHONE_TIER_BELOW, "above the tier the drill stays in the table");
+      await drill(page, baseURL);
+
+      // Pattern B ships no `<thead>`, so the two things a header carried besides its labels
+      // have to land somewhere. In the flat B tables that is the card title's count; this is
+      // the one grouped B table in the spec, so it is the only place the *aggregate* half of
+      // that job is actually visible.
+      const header = page.locator(".main .cards .cardgroup");
+      await expect(header, "the lifted cards have no group header").toHaveCount(1);
+      const text = await header.innerText();
+
+      expect.soft(text, "the header does not name the subcategory it is showing").toContain(SUB);
+      // The count is what is ON SCREEN — the same reading `cards.spec.js` takes for the card
+      // titles, because the number the missing header owes you is the number of cards under
+      // it. The aggregate is the tapped row's own, so the two renderings of one group agree.
+      expect.soft(text, "the header's count is not the number of cards under it")
+        .toContain(String(drilled().length));
+      expect.soft(text.replace(/,/g, ""), "the header does not carry the group's aggregate")
+        .toContain(String(Math.round(subTotal())));
+    });
+
+  test("nothing in a drilled card is clipped or has to be swiped to reach",
+    async ({ page, baseURL }, testInfo) => {
+      const vp = viewportOf(testInfo.project.name);
+      test.skip(vp.width >= PHONE_TIER_BELOW, "above the tier there are no cards");
+      await drill(page, baseURL);
+
+      // TWO MEASUREMENTS, because either alone passes the case the other exists for.
+      //
+      // `scrollWidth > clientWidth` catches a field that overflows its own card. It does NOT
+      // catch the failure this ticket is about: a card sitting in a box wider than the pane
+      // fits its contents perfectly and reports nothing, while its right edge — where the
+      // hero amount is — sits off the screen behind a horizontal swipe. That is precisely
+      // what a card left inside the drill's own grid would do at 390px.
+      //
+      // So the second measurement is the card's right edge against the pane's client width,
+      // TAKEN IN THE PANE'S SCROLL SPACE rather than in viewport coordinates — and that is
+      // the difference between a gate and a coincidence. `.main` is already scrolled
+      // sideways by the time this runs, because clicking a row scrolled it into view, so a
+      // viewport-coordinate comparison measures a card that has been dragged back on screen
+      // by the very scroll the criterion forbids. Adding `scrollLeft` back is what asks the
+      // question the ticket asks: is the whole card reachable *without* swiping. Verified by
+      // building the rejected layout and watching this fail by 27px.
+      const bad = await page.evaluate(() => {
+        const main = document.querySelector(".main");
+        const origin = main.getBoundingClientRect().left - main.scrollLeft;
+        const found = [];
+        for (const card of main.querySelectorAll(".cards > .rowcard")) {
+          const box = card.getBoundingClientRect();
+          const right = box.right - origin;
+          if (right > main.clientWidth + 1) {
+            found.push(`a card runs ${Math.round(right - main.clientWidth)}px past the pane`);
+          }
+          for (const el of [card, ...card.querySelectorAll("*")]) {
+            if (el.scrollWidth > el.clientWidth + 1) {
+              found.push(`${el.className || el.tagName} hides ` +
+                `${el.scrollWidth - el.clientWidth}px: ${el.textContent.trim().slice(0, 40)}`);
+            }
+          }
+        }
+        return [...new Set(found)].slice(0, 10);
+      });
+      expect(bad, "a drilled card hides part of its row").toEqual([]);
+    });
+
+  test("the category rows keep their own marker and get no chevron",
+    async ({ page, baseURL }, testInfo) => {
+      const vp = viewportOf(testInfo.project.name);
+      await openView(page, baseURL, "Spending › By Category");
+
+      // THE ONE CARVE-OUT from the affordance rule pattern A ships. Everywhere else, a
+      // tappable row in a pinned table carries a persistent `›` in its pinned cell, because
+      // hover is dead on touch and the state between taps needs to say "this opens
+      // something". Here the row does not navigate anywhere — it expands in place — and the
+      // coloured `▸`/`▾` already says so. A `›` beside it would be a lie about where the tap
+      // goes, so this view is the only place the chevron is deliberately absent.
+      const marker = await page.locator(".main tbody td.l").first().evaluate((el) => ({
+        text: el.textContent.trim(),
+        chevron: getComputedStyle(el, "::after").content,
+      }));
+      expect.soft(marker.text, "the category row lost its disclosure marker")
+        .toMatch(/^[▸▾·]/);
+      expect.soft(marker.chevron, "the category table got the chevron — it expands in place")
+        .toBe("none");
+
+      if (vp.width >= PIN_TIER_BELOW) return;
+      // The chevron's absence is not permission to leave a tappable row with no feedback at
+      // all: hover is still dead here. `.rowtap` is what these rows take instead — the
+      // `:active` half of the affordance without the half that claims a destination.
+      const rules = await declarationsFor(page, "tr.rowtap:active > td");
+      expect(rules, "no `:active` feedback — with no chevron this row says nothing on touch")
+        .toHaveLength(1);
+      expect(rules[0].media, "the tap feedback was scoped to a tier").toBeNull();
+      // The token rather than a literal, for the reason `pinned.spec.js` gives at length: the
+      // opaque pinned cell has to restate this colour, and two literals is how one feedback
+      // state drifts into two.
+      expect(rules[0].text, "the row flashes nothing on tap").toContain("var(--hover)");
+    });
+});
+
+test("the group header is the hook's, like the rest of pattern B, and truncates nothing",
+  async ({ page, baseURL }) => {
+    await openView(page, baseURL, "Spending › By Category");
+    // Both halves of what `cards.spec.js` asserts for the card itself, for the one part of
+    // the pattern that landed with this ticket rather than with that one. The truncation half
+    // is not theoretical here: the group header's name is `Life/Health/Surgical Insurance`,
+    // the 30-character string the fixtures exist to carry, in a 362px pane.
+    for (const sel of [".cardgroup", ".cardgroup .cg-nm", ".cardgroup .cg-n",
+                       ".cardgroup .cg-total"]) {
+      const rules = await declarationsFor(page, sel);
+      expect(rules.length, `no rule ships for \`${sel}\``).toBeGreaterThan(0);
+      for (const r of rules) {
+        expect(r.media, `\`${sel}\` is scoped to a tier the hook already owns`).toBeNull();
+        expect(r.decls["text-overflow"], `\`${sel}\` truncates`).toBeUndefined();
+        expect(r.decls["white-space"], `\`${sel}\` refuses to wrap`).not.toBe("nowrap");
+      }
+    }
+  });
+
+test("the whole drill survives a rotation, in both directions", async ({ page, baseURL }, testInfo) => {
+  // 390x844 and 844x390 are the two orientations the ticket names, and they are on opposite
+  // sides of the tier: a rotated phone is 844px wide, so it has left the phone block and must
+  // get the nested table back — with the drill still open, without a reload, and without
+  // re-fetching. This is the same gate `cards.spec.js` holds for its own hook, driven through
+  // a structure that has state in it.
+  //
+  // Run once rather than ten times: it sets its own two viewports.
+  test.skip(testInfo.project.name !== "design-width", "this test drives its own viewport");
+
+  await drill(page, baseURL);
+  await expect(page.locator(".main .cards > .rowcard")).toHaveCount(drilled().length);
+  await expect(page.locator(".main table")).toHaveCount(1);
+
+  await page.setViewportSize({ width: 844, height: 390 });
+  await expect(page.locator(".main .cards")).toHaveCount(0);
+  await expect(page.locator(".main table")).toHaveCount(2);
+  await expect(page.locator(".main table table tbody tr")).toHaveCount(drilled().length);
+
+  await page.setViewportSize({ width: 390, height: 844 });
+  await expect(page.locator(".main .cards > .rowcard")).toHaveCount(drilled().length);
+  await expect(page.locator(".main table")).toHaveCount(1);
+});

--- a/web/tests/pinned.spec.js
+++ b/web/tests/pinned.spec.js
@@ -1,7 +1,7 @@
 /**
  * Pattern A: the pinned identity column, and the scroll ownership that comes with it.
  *
- * Seven tables across six views exist so you can compare a number DOWN the column. Below
+ * Eight tables across seven views exist so you can compare a number DOWN the column. Below
  * 1024px they are read through a window: the identity column is pinned, the rest scrolls
  * horizontally inside a wrapper, and the header stays put while the rows go by. This file
  * is the gate on all three halves plus the traps that make them fragile.
@@ -60,6 +60,9 @@ const PINNED = [
   { view: "Portfolio › Dividends", tables: [{ pin: "Bucket", cols: null }] },
   { view: "Portfolio › Options", tables: [{ pin: "Underlying", cols: 8 }] },
   { view: "Portfolio › SecurityDetail", tables: [{ pin: "Contract", cols: 6 }] },
+  // Levels one and two of the spending drill. Level three is not a table on a phone at all —
+  // `drill.spec.js` owns that half, and the structure the two levels meet in.
+  { view: "Spending › By Category", tables: [{ pin: "Category", cols: 4 }] },
   {
     view: "Spending › Recurring",
     tables: [{ pin: "Merchant", cols: 7 }],


### PR DESCRIPTION
Closes #30.

By Category is one three-level structure rather than two tables, which is why both responsive patterns land on it at once. Levels one and two — categories and their subcategories — stay rows and take the pinned pattern, name column pinned. Level three leaves.

It has to. A nested table inherits its parent's width and therefore sets the parent's min-content: 334px collapsed, 413px with subcategories open, 567px once a subcategory is drilled. Cards left in that `colSpan` cell would be 413px wide in a 330px card, putting the hero amount off the edge behind a swipe — the exact property cards were chosen for. Their pattern is forced by identity rather than by measurement: the same `cash_txn` rows `spending/Transactions` renders, from the same endpoint, a strict subset of its columns.

### Two things the ticket did not already know

**Leaving the table is not sufficient.** Cards placed in the categories card still measure 386px in a 362px pane — clipped again, by `.grid2`'s 420px track floor, the residual four views share and no ticket owns. So they leave the whole grid. Built the rejected layout, watched the gate fail by 27px, restored.

**The pin painted over the second level's tint.** The subcategory row carried its tint as an inline background on the `<tr>`; an opaque pinned cell paints its own and CSS cannot read an inline value, so below 1024px the name column rendered `--panel` while its own three number cells stayed `--panel2`. Third instance of a family `RESPONSIVE.md` already names, and the first where the pin rather than a media query is what made it matter. Found by review, not by the suite — `openView` opens a view but does not drill one, so every pin gate ran against level-one rows, which are the one level with no background of their own.

### What is asserted

`drill.spec.js` gates the structure the two patterns meet in; each pattern's own gates stay in `pinned.spec.js` (which gains this view) and `cards.spec.js` (whose six flat lists are unchanged). Its sharpest assertion reads like the others and is not: a card's right edge is compared in the pane's **scroll space**, because clicking a row has already scrolled `.main` sideways — in viewport coordinates the rejected layout passes.

`CardGroup` lands in `cards.jsx`, where that module said it would: card-per-row ships no `<thead>`, the count job went to the card title, and the aggregate job had nowhere to land until there was a grouped list. This is the only one in the spec.

`hscroll-baseline.js` is deliberately untouched — By Category's 74 / 44 / 4 was already `.grid2`'s track floor rather than its table, so taking the table's scroll off the pane moves nothing.

### Acceptance criteria

- [x] Categories and subcategories render as a pinned table below 640px
- [x] Drilling a subcategory renders its transactions as cards below the table, not nested inside it
- [x] Those cards carry a header with subcategory name, transaction count and aggregate
- [x] Nothing in a drilled card is clipped at 390px
- [x] Category rows keep their disclosure marker and show no chevron
- [x] The full three-level drill works at 390×844 and at 844×390
- [x] The view is unchanged at 640px and above apart from the tier's pinned-table rule

### Calls worth a second opinion

- **`.rowtap` is arguably scope creep.** The issue asks only that the row not get the chevron. Removing it with nothing in its place leaves a tappable row that says nothing on touch, which is what the affordance exists for — so the row takes the `:active` half without the half that claims a destination.
- **The header's count is `rows.length`, beside the summary's aggregate.** Above `limit=1000` they diverge. Raised and resolved as not worth acting on; the comment records where rather than claiming they agree.

Playwright suite 871 passed / 230 skipped; pytest 258 passed.