### PR TITLE
The tablet tier (640-1024)

### DIFF
--- a/RESPONSIVE.md
+++ b/RESPONSIVE.md
@@ -37,6 +37,15 @@ drift apart.
 where the spec knowingly ships a compromise. 10 exists because one desktop width cannot tell "the tab
 strip fits" from "the tab strip fits at exactly 1280".
 
+**The tablet tier is covered at three of these — 640, 834 and 844×390 — and that is two short of the
+four widths its own criteria name.** 768 and 1000 are not in the list and are not being added: the
+suite is ten projects deep already and both sit inside a band whose two ends are measured. They were
+measured by hand at the tier's landing instead, on the production build against the committed
+fixtures, and every view read **0** at both. 640 is the worst case in the tier by construction — the
+narrowest pane behind the widest rail — so a width that passes at 640 and at 834 passing between them
+is an interpolation rather than an assumption. Recorded here because an untested width should be
+written down rather than implied by a green run.
+
 **Chrome device emulation is sufficient for 1–10 except four items**, which need a real iPhone:
 
 - iOS focus-zoom on form controls — emulation does not reproduce Safari's zoom at all
@@ -48,24 +57,29 @@ strip fits" from "the tab strip fits at exactly 1280".
 
 Applied to all 12 tab views, SecurityDetail, and sign-in. Must pass.
 
-1. **`.main` never scrolls horizontally.** Sideways scroll is confined to a container that is visibly a
-   table. *(Not "no horizontal page scroll" — `.main { overflow: auto }` absorbs everything before it
-   reaches the page, so that criterion can never fail.)* **Five of the thirteen views now hold it
-   outright at every gated viewport** — Holdings, Performance, Dividends and Recurring, because the
-   pinned column took their scroll off the pane, plus Classify, which was already there. **Card-per-row
-   adds three more *below 640* — both Transactions ledgers and SecurityDetail — but not at 640 and above,
-   because that pattern is phone-only by decision.** The ratchet in `hscroll-baseline.js` records what is
-   left and why: those three at 640/834/844 wait for the tablet tier's pin, and **four views now share
-   one residual to the pixel** — `.grid2`'s 420px track floor against a 362px pane, which **Net Worth
-   joined exactly when the editors' floor landed**. `Spending › Overview` is the fifth at six of the
-   seven gated viewports and carries 40px of its own at 640. Every remaining non-zero number below 640
-   now has that one cause, and it is **#44**'s — filed once this was the only thing left holding those
-   five rows.
+1. ~~**`.main` never scrolls horizontally.** Sideways scroll is confined to a container that is visibly a
+   table.~~ **Landed for every table in the app**, which is the tablet tier's one rule finishing a job
+   five tickets started. *(Not "no horizontal page scroll" — `.main { overflow: auto }` absorbs
+   everything before it reaches the page, so that criterion can never fail.)* Eight of the thirteen
+   views hold it outright at every gated viewport, and **two whole viewports — `ipad-portrait` and
+   `rotated-phone` — are now zero across all thirteen**. `tablet.spec.js` asserts the structural half
+   directly: every table that overflows **its own container** has a wrapper, the wrapper holds the table
+   and nothing else, it fits its parent, and the identity column inside it is `sticky`. That last clause
+   is what found the sixth table — `Dividends`' detail ledger had been inside an inline 520px scroll box
+   since before this work, so it was *contained* and never appeared in the ratchet at all.
+   **What is left is not a table.** Five views — `Portfolio › Overview`, `Options`, `Net Worth` and both
+   `Spending` views — share one residual to the pixel at all seven gated viewports: `.grid2`'s
+   `minmax(420px, 1fr)` track floor against a narrower pane. It is **#44**'s, and it is the only thing
+   standing between `hscroll-baseline.js` and being deleted for a `<= 0` gate.
 2. No overlapping or clipped content.
-3. Every control reachable and tappable — **44px square** in fully-responsive views. *(The 24px
-   editor floor has landed and is asserted by `unconditional.spec.js`; it is not checked here any
-   more. Recurring's three `.link-btn`s take their width from the 44px rule rather than twice, so
-   they are still this line's business.)*
+3. Every control reachable and tappable — **44px square** in fully-responsive views, **below 640 only**.
+   *(The 24px editor floor has landed and is asserted by `unconditional.spec.js`; it is not checked here
+   any more. Recurring's three `.link-btn`s take their width from the 44px rule rather than twice, so
+   they are still this line's business.)* **The tablet tier keeps 33px rows by decision and
+   `tablet.spec.js` asserts it** — above WCAG 2.5.8's 24px floor, below comfort; `@media (pointer:
+   coarse)` was rejected for firing on touchscreen laptops. The residual worth an eye on a real device
+   is the one this creates: at **844×390 the drawer is open on a phone with ~38px rows**, because the
+   shell travels on the height guard and the tap floor deliberately does not.
 4. ~~Navigation reachable from every screen: drawer opens, scrim tap closes it, the tab `<select>`
    works.~~ **Landed** — `shell.spec.js` asserts the drawer, the scrim, the picker and the app bar,
    and the suite now *drives* every phone viewport through them, so all thirteen views being
@@ -126,16 +140,16 @@ criteria **instead of** the universal list — reading comfort, row density and 
 | Portfolio › Overview | tiles reflow to 2 columns; ~~**donuts gone below 640**~~ **landed** — `charts.spec.js` asserts both of this view's donuts absent below the tier, present at 640 and above, and the `.barrow` list filling the card at every width. *(`.grid2` collapsing to one column and the S2 inline rows landed earlier — both asserted.)* |
 | Portfolio › Holdings | ~~pattern **A**: Security pinned, h-scroll inside the wrapper, sticky `th` stays put as the wrapper scrolls; `tr:active` feedback and a persistent `›` in the pinned cell; footnote collapsed into `<details>`~~ **landed** — all of it asserted by `pinned.spec.js`, at seven viewports rather than at 390 alone. What is left here is eyes-only: row tap opens SecurityDetail, and whether the pin reads as an identity |
 | Portfolio › Performance | ~~pattern **A**, grouping key pinned (its `th` is `{by}` — lowercase, changes with the `<select>`)~~ **landed** — the `{by}` header is asserted by name, which is what says the *grouping key* got pinned rather than a label. Row count is bounded by the grouping dimension (max 8), so the whole table is on screen and `max-height: 60svh` never bites — asserted as the short half of the cap's one-rule claim |
-| Portfolio › Dividends | ~~crosstab pattern **A** (grows in columns, so h-scroll never expires)~~ **landed**; ~~payment ledger pattern **B** cards~~ **landed** — asserted by `cards.spec.js`, including that the 520px scroll box the table sits in does *not* come with the cards: a capped box inside a page that already scrolls is a second scroll region. Its `payments` pill now counts what is **rendered** rather than what the server holds, because under cards that pill is where the missing header's count went and the flagged-only filter moves it. The two `title=` explanations on `Declared /u` / `Implied /u` go with the `<thead>` — no loss on touch, where a tooltip never existed, and the kv keys carry the labels. ~~`LabelList` dropped below 640~~ **landed** — asserted by count against the fixture's eleven years, and the chart itself stays: dropping chrome is not dropping the chart, and the shape of the series is the one thing the crosstab above does not carry. Its `height="100%"`-inside-a-220px-wrapper is `height={220}` on the container now — never live, fixed while here |
-| Portfolio › Options | ~~contract ledger **A** — pinned Underlying; it already has an `overflow-x: auto` wrapper at `:70`, so this keeps behaviour rather than replacing it~~ **landed** — the wrapper's own 480px cap moved to `.selfscroll` so the phone tier's `60svh` can win over it, which an inline `max-height` could not. By-ticker and by-type unchanged (273/261px, they genuinely fit); ~~monthly P/L halved to 6 bars with a reserved band so negative labels clear the ticks~~ **landed** — 6 bars below the tier against 24 above it, labels raised 9px → 11px (the app's stated minimum, and this chart's labels are the only place its numbers appear anywhere), and the band **only when the window actually holds a loss** — it shrinks the scale's range from the bottom, so on a positive-only window it lifts the baseline clear of the axis and leaves every bar floating above a rule it should stand on. Both branches are exercised: the phone's six-month window is all positive in the fixture and asserts the *absence* of a band, and the 24-month window above the tier carries three losses, so the criterion itself — no value label overlapping an axis tick — is measured against real negative labels rather than asserted vacuously. Its bare `<ResponsiveContainer>`s carry explicit heights now. *(The merged `Contract` cell landed earlier — asserted.)* |
-| Portfolio › Transactions | ~~pattern **B** cards~~ **landed** — eight fields, but still one amount, so the trade is the row and the cash it moved is the hero; Qty and Price take the key/value block. Asserted at every viewport, including that the table is what renders at 640 and above |
-| Portfolio › SecurityDetail | ~~txn history **B**~~ **landed**; ~~dividend history **B**~~ **landed but never rendered** — PLTR is the row the suite drills into because it has 73 option trades, and it has no dividends at all, so `cards.spec.js` annotates that gap on every run rather than closing it with an invented row; ~~options history **A**, pinning the merged two-line `Contract` cell~~ **landed**. Three tables, two patterns, deliberately. `← Holdings` is a ≥44px target and is the **only** way back — there is no router. *(The pane no longer scrolls sideways here below 640: the 914px txn history is cards now. At 640 and above it still does, and that is the tablet tier's.)* |
+| Portfolio › Dividends | ~~crosstab pattern **A** (grows in columns, so h-scroll never expires)~~ **landed**; ~~payment ledger pattern **B** cards~~ **landed** — asserted by `cards.spec.js`, including that the 520px scroll box the table sits in does *not* come with the cards: a capped box inside a page that already scrolls is a second scroll region. ~~That table at 640 and above~~ **landed with the tablet tier, and it is the one this work nearly missed**: it was already inside an inline `{ maxHeight: 520, overflow: "auto" }` box, so it never overflowed the pane and never appeared in the ratchet — *contained* read as done. Contained is not pinned: at 640 you scrolled that box sideways and lost the security name with the date. It takes **A** on `Date`, and the inline `max-height` had to go, because an inline declaration beats any stylesheet and 520px would have overridden the pattern's `60svh` outright. The *number* stays, as `--selfscroll: 520px` — a custom property is not a `max-height`, so it loses to the pattern below 1024 and still gives this box the height it has always had above it. **Desktop is unchanged to the pixel**, which is what ruled out simply taking `.selfscroll`'s 480. Its `payments` pill now counts what is **rendered** rather than what the server holds, because under cards that pill is where the missing header's count went and the flagged-only filter moves it. The two `title=` explanations on `Declared /u` / `Implied /u` go with the `<thead>` — no loss on touch, where a tooltip never existed, and the kv keys carry the labels. ~~`LabelList` dropped below 640~~ **landed** — asserted by count against the fixture's eleven years, and the chart itself stays: dropping chrome is not dropping the chart, and the shape of the series is the one thing the crosstab above does not carry. Its `height="100%"`-inside-a-220px-wrapper is `height={220}` on the container now — never live, fixed while here |
+| Portfolio › Options | ~~contract ledger **A** — pinned Underlying; it already has an `overflow-x: auto` wrapper at `:70`, so this keeps behaviour rather than replacing it~~ **landed** — the wrapper's own 480px cap moved to `.selfscroll` so the pattern's `60svh` can win over it, which an inline `max-height` could not. **`.selfscroll` has two call sites now** — Dividends' detail ledger joined it with the tablet tier, for the same reason, and its 480px became `var(--selfscroll, 480px)` so the second site keeps its own 520 without keeping an inline declaration the pattern cannot beat. By-ticker and by-type unchanged (273/261px, they genuinely fit); ~~monthly P/L halved to 6 bars with a reserved band so negative labels clear the ticks~~ **landed** — 6 bars below the tier against 24 above it, labels raised 9px → 11px (the app's stated minimum, and this chart's labels are the only place its numbers appear anywhere), and the band **only when the window actually holds a loss** — it shrinks the scale's range from the bottom, so on a positive-only window it lifts the baseline clear of the axis and leaves every bar floating above a rule it should stand on. Both branches are exercised: the phone's six-month window is all positive in the fixture and asserts the *absence* of a band, and the 24-month window above the tier carries three losses, so the criterion itself — no value label overlapping an axis tick — is measured against real negative labels rather than asserted vacuously. Its bare `<ResponsiveContainer>`s carry explicit heights now. *(The merged `Contract` cell landed earlier — asserted.)* |
+| Portfolio › Transactions | ~~pattern **B** cards~~ **landed** — eight fields, but still one amount, so the trade is the row and the cash it moved is the hero; Qty and Price take the key/value block. Asserted at every viewport, including that the table is what renders at 640 and above. ~~And that table waits for the tablet tier~~ **landed** — it takes **A** from 640 to 1024, pinning `Date`, the column that was already first. 1220px against a 440px pane at 640, so "untouched" was Date and Acct and not one number. Residual written down rather than fixed: two trades on the same day are told apart by `Security`, 269px and one scroll-step to the right — a merged identity cell on `contract.jsx`'s precedent was rejected because a date, unlike `Put / Put / Call`, varies per row and the ledger arrives ordered by it |
+| Portfolio › SecurityDetail | ~~txn history **B**~~ **landed**; ~~dividend history **B**~~ **landed but never rendered** — PLTR is the row the suite drills into because it has 73 option trades, and it has no dividends at all, so `cards.spec.js` annotates that gap on every run rather than closing it with an invented row; ~~options history **A**, pinning the merged two-line `Contract` cell~~ **landed**. Three tables, two patterns below 640 — and **B, A, A above it**, since the tablet tier gives both histories the pin as well: `Date` is the identity on this page outright rather than second-best, because every row is the same security. The dividend history's wrapper is the one thing in the tier no fixture can reach, and `pinned.spec.js` annotates it. `← Holdings` is a ≥44px target and is the **only** way back — there is no router. *(The pane no longer scrolls sideways here at any gated viewport: cards below 640, the pin from 640 to 1024.)* |
 | Net Worth | editor floor; ~~line chart has a **DOM key, not `<Legend>`**~~ **landed** — and it was the only chart in the app with no legend of any kind at any width, so `name="Net Worth"` / `name="Excl. Housing"` reached the tooltip and nowhere else. Two anonymous coloured lines, on desktop as much as on touch. Asserted by the key's text *and* by its chips matching the lines' own strokes — a key with an independent palette goes wrong silently. ~~Breakdown and History wrapped in `overflow-x: auto`~~ **landed** — as `.contained`, **below 1024 rather than unconditionally**, because an `overflow-x: auto` wrapper is the sticky scrollport for the `th` inside it and a scrollport sized to its content never scrolls: unconditional, it would kill a header that sticks to `.main` today at every width, and "unchanged at 1024 and above" has to include what a wrapper kills silently. Below the tier the header stops sticking and that is accepted — row density is below this floor by decision. It is the whole of Net Worth's phone overflow: 349 → 74 at 360, and the view lands **exactly** on the `.grid2` residual `Portfolio › Overview`, `Options` and `By Category` already share, to the pixel, at all seven gated viewports. ~~The row grid is unchanged~~ **asserted** rather than merely left alone — one rule, no media query, its 120px and 70px tracks measured, because the instinct is to shrink the column that at this gutter is 124px and not the ~200px it looks like; ~~`100svh`~~ *(the shell's, landed and asserted)* |
-| Spending › Overview | ~~donut gone below 640, list is the chart~~ **landed and asserted**; the stacked bar chart's `<Legend>` is a `.chartkey` now, which is **the only chart change the suite cannot see** — `/api/spending/trends` was captured as a 500 from the live database, so `trend.series.length > 0` is false and that chart never mounts. `inventory.spec.js` gates it from the source instead, and `charts.spec.js` annotates the gap on every run; ~~Top Line Items pattern **B** (471px — A's pin would be the 232px Line item, 70% of the viewport)~~ **landed**, and it is the row that proves the map's claim about the leftover overflow: this view fell 114 → 74 / 84 → 44 / 44 → 4 and landed **exactly** on the three other `.grid2` views. Both halves of the `.grid2` end up as ranked lists |
+| Spending › Overview | ~~donut gone below 640, list is the chart~~ **landed and asserted**; the stacked bar chart's `<Legend>` is a `.chartkey` now, which is **the only chart change the suite cannot see** — `/api/spending/trends` was captured as a 500 from the live database, so `trend.series.length > 0` is false and that chart never mounts. `inventory.spec.js` gates it from the source instead, and `charts.spec.js` annotates the gap on every run; ~~Top Line Items pattern **B** (471px — A's pin would be the 232px Line item, 70% of the viewport)~~ **landed**, and it is the row that proves the map's claim about the leftover overflow: this view fell 114 → 74 / 84 → 44 / 44 → 4 and landed **exactly** on the three other `.grid2` views. Both halves of the `.grid2` end up as ranked lists. **The table above 640 takes A, pinning `Category`** — the 390px rejection does not transfer, because the column that is already first is 82px rather than the 232px `Line item`, and `Line item` sits beside it inside the window at every width in the tier. It shed the last 40px this view carried alone at 640 |
 | Spending › By Category | ~~donut gone below 640~~ **landed and asserted**; ~~Categories pattern **A** with the name column pinned — it keeps its own `▸`/`▾` and does **not** get the persistent `›`~~ **landed** — `pinned.spec.js` carries this view like the other six and `drill.spec.js` asserts the carve-out by name, plus the `.rowtap` feedback it takes *instead* of the chevron; ~~drilled transactions render as **B** cards **below the table**, headed by subcategory + count + aggregate~~ **landed**, and they leave the `.grid2` entirely rather than merely the table — inside that card they would be 386px wide in a 362px pane, clipped by the 420px track floor #44 owns rather than by the nesting this ticket fixes. **The only grouped B table in the spec, so `CardGroup` in `cards.jsx` has exactly one call site** — it landed here because until now there was nothing grouped to head. What is left is eyes-only: whether three levels of drill read as one structure once the third leaves the grid |
 | Spending › Classify | editor floor; ~~`.fillpane` neutralised so the page scrolls as one~~ **landed** — `.fillpane` and `.grow` become blocks below 640 and `.scroll` is **deliberately untouched**: it keeps the `overflow: auto` that still confines the table sideways, and with no flex parent left to cap it, it sizes to its own content, so the scrollport that remains never scrolls. `overflow-x: auto; overflow-y: visible` is not available — the first forces the second. This deletes the app's deepest nesting; what survives is the rules list's inline `maxHeight: 232`, which CSS cannot reach and which is accepted (see the trap). ~~**⇅ Reorder hidden on phone**~~ **landed** — `display: none`, not `disabled`, because a control that is present and does nothing is what criterion 4 forbids; the reorder modal is therefore unreachable below the tier **by design**. ~~`RuleModal` uses `svh`~~ **landed**, and `inventory.spec.js`'s `100vh` gate widened to the *unit* on the way past — `6vh`/`84vh` were the whole remaining population. Its two control rows wrap and `CatSelect` takes `max-width: 100%`, without which a 19-option select plus its button pushed the 358px sheet into a sideways scroll and took Cancel with it; `MatchTable` is `.contained` for the same reason. *(The `textarea`'s styling has landed — asserted.)* |
 | Spending › Recurring | ~~monitor **A** *(open call)* and candidates **A**~~ **landed** — both pinned; the open call is untouched by that, since it asks whether this view wants a different information design rather than whether the reflow works. **Only the candidates table is asserted**: the owner tracks nothing, so `/api/spending/recurring` is `[]` in the committed fixtures and the monitor never mounts. `pinned.spec.js` annotates that gap on every run rather than closing it with an invented row — so the monitor's pin is an eyes-only check here. Three `.link-btn`s at 44px square; **two nested scroll regions** — the feel check |
-| Spending › Transactions | ~~pattern **B** cards~~ **landed** — the six-field shape the whole pattern was measured on: merchant, one amount, and four muted fields on a second line, with no key/value block at all. Its excluded rows keep their dimming, but **no fixture holds one** — every captured transaction is counted spend and `include_excluded=true` was never captured, so both renderings are equally unexercised and `cards.spec.js` asserts the two agree on 0.55 rather than observing either |
+| Spending › Transactions | ~~pattern **B** cards~~ **landed** — the six-field shape the whole pattern was measured on: merchant, one amount, and four muted fields on a second line, with no key/value block at all. Its excluded rows keep their dimming, but **no fixture holds one** — every captured transaction is counted spend and `include_excluded=true` was never captured, so both renderings are equally unexercised and `cards.spec.js` asserts the two agree on 0.55 rather than observing either. ~~The table at 640 and above waits for the tablet tier~~ **landed** — **A**, pinning `Date`, and that pin is a *choice* rather than the default: `Merchant` is what the card leads with and its column measures **561px**, unbounded free text out of the statements, which in a 440px window is a pinned column that covers the screen and never lets a number through. Bounding it would be a second rule in a tier that holds exactly one |
 | Sign-in | ~~`100vh` → `100svh` at `auth.jsx:50` and `:125`~~ **landed** — asserted, along with the box filling the screen, optical centring and the absence of any phone rule. GSI button **carved out** of the 44px floor; no `env()` padding anywhere. What is left here is eyes-only: whether the carved-out button looks right beside a 44px world |
 
 ## Observations
@@ -204,9 +218,10 @@ Things the build session must be told, not left to discover.
   Overview`, `Options`, `By Category` **and now `Net Worth`** all carry the *same* residual —
   74 / 44 / 4 / 0 / 8 / 0 / 0 by viewport, one cause, no table involved. `Net Worth` joined the moment
   the editors' floor took its two tables off the pane, which is the strongest evidence the file can
-  offer that the remaining phone overflow is one defect rather than four. `Spending › Overview` is on
-  the same number at six of the seven and **48 rather than 8 at 640**, so it carries 40px of its own
-  there on top of the shared floor. The pinned column
+  offer that the remaining phone overflow is one defect rather than four. **`Spending › Overview` is
+  the fifth and is now on that number at all seven** — the 40px it used to carry alone at 640 was the
+  Top Line Items table, and the tablet tier's pin took it. So the ratchet is five views, one cause,
+  and nothing else at all. The pinned column
   cannot reach it and neither can card-per-row or the editors' floor. The usual remedy is
   `minmax(min(420px, 100%), 1fr)`. **Written down here because a residual with no owner is precisely
   how the four unassigned tables happened.**
@@ -221,6 +236,12 @@ Things the build session must be told, not left to discover.
   and it checks the two JS queries **character for character** against the tier edge. Counting is not
   agreeing — `(max-width: 640px)` in `cards.jsx` keeps the count at four, keeps every comment true to
   the word, and moves the whole card-per-row tier into the 1px dead zone the `.98` exists to prevent.
+- **`500` is the tier's own second number, written twice**: `styles.css`'s shell block and
+  `tests/viewports.js`'s `SHELL_GUARD_EDGE` / `SHELL_HEIGHT_GUARD`. It is gated differently from the
+  other two and deliberately so — `tablet.spec.js` **enumerates every media condition in the shipped
+  sheet** and names each by the number that identifies it, which is stronger than a count of source
+  sites: it reads what the build actually emitted, so `500` appearing on the wrong block, or a fourth
+  block appearing at all, fails there. It also fails if the shell's two arms stop being one condition.
 - **The two `matchMedia` readers differ on purpose, and the difference is not an inconsistency.**
   `Holdings.jsx` reads the query **once, at mount**, because it only seeds a disclosure's initial state
   and the user then owns it — a footnote that reopens itself on rotate is worse than a stale one.
@@ -252,7 +273,12 @@ Things the build session must be told, not left to discover.
   identifiable once it has. Any new grouped pattern-A table needs the same class.
 - **An inline `max-height` beats the pattern's `60svh`.** `Options`' trades wrapper shipped its cap
   inline; it is `.selfscroll` now precisely so the cascade can reach it. Nothing else may put a height
-  on a `.pinned` wrapper inline.
+  on a `.pinned` wrapper inline. **`Dividends`' detail ledger is the second instance and shows the way
+  out when the two boxes disagree on the number**: `.selfscroll` reads `var(--selfscroll, 480px)` and
+  that site sets `--selfscroll: 520px` inline. A custom property is not a `max-height` declaration, so
+  it never enters the specificity fight — the pattern still wins below 1024, and desktop keeps the
+  height it always had. Reach for that, not for a second class and not for a shared literal that
+  quietly moves one of the two.
 - **`overflow-x: auto` forces `overflow-y` from `visible` to `auto`.** So a `.pinned` wrapper is the
   sticky scrollport for its own header *whether or not anyone gave it a height* — and a scrollport that
   sizes to content never scrolls, so the header rides the page away instead of sticking. Measured at
@@ -289,9 +315,27 @@ Things the build session must be told, not left to discover.
   and landscape is the only orientation where the notch is at the side. Same for `.main`'s
   `max(28px, env(...))`. The *value* follows the width; the *guard* does not. The **drawer's**
   guard is the exception and stays inside the block, because `position: absolute` and the transform
-  are in that rule too — the whole rule travels together when the tablet tier's height guard brings
-  it to 844×390. **`.side` as a *rail* — 640 and up — has no guard at all**, so in landscape above
-  the tier the notch cuts into the sidebar. That belongs to the tablet tier, not the shell.
+  are in that rule too — and the whole rule **has now travelled** onto the shell's
+  `(max-height: 500px)` arm, guard included, which is what puts it on the one screen it was written
+  for. **`.side` as a *rail* still has no guard at all**, and that residual is smaller than it looks:
+  the only landscape screens that keep the rail are tablets, which have no side notch.
+- **The shell follows *height*; everything else follows *width*.** This is the tablet tier's landscape
+  answer and the easiest thing in the stylesheet to get wrong, because the two blocks now sit next to
+  each other and their conditions differ by one clause. The split is not taste — each half follows the
+  axis its own decision was argued on. The shell was chosen on a vertical budget (48px against a bottom
+  bar's 147px), so it takes `(max-height: 500px)`; the pin, the cards, the charts, the gutter and the
+  44px floor were all chosen on horizontal room and stay width-only, which is also why `usePhone()` is
+  untouched by the tier and why `640` is still a literal in exactly four files. Two consequences to
+  keep straight: at **844×390 the navigation is a phone's and the content is not**, and the height arm
+  fires on a desktop window under 500px tall, which is accepted — that window has the same vertical
+  problem a rotated phone does. Adding a rule to the shell block that belongs to the phone hands it to
+  that window too; `tablet.spec.js` asserts the tap floor did not make that move.
+- **A table can be *contained* and still not pinned, and the ratchet cannot tell.** `Dividends`' detail
+  ledger sat in an inline `{ maxHeight: 520, overflow: "auto" }` box, so it never overflowed `.main`
+  and read as done through five tickets — while at 640 you scrolled it sideways and lost the identity
+  column exactly as the untouched tables did. Two lessons, both now gates: the pane-overflow number is
+  evidence about the *pane*, not about a table, and a scroll box that predates the pattern has to be a
+  **class** before the pattern can reach it, because an inline `max-height` beats any stylesheet.
 - **The app bar is `box-sizing: content-box`** against the app-wide `border-box`, so the top inset adds
   to its 48px instead of eating it. 48px is the number the whole drawer-versus-bottom-bar trade was
   decided on; under `border-box` a 47px inset would crush the bar to a line.

--- a/RESPONSIVE.md
+++ b/RESPONSIVE.md
@@ -162,6 +162,14 @@ Record the value. These **cannot fail** — nothing here changes the work.
 - **Whether iPadOS Safari focus-zooms form controls.** The spec assumes it does not, and keeps 16px
   inputs phone-only on that basis. This is the least-verified claim in the whole map.
 - Rows actually achieved vs the spec's 12–13 portrait / 4 landscape on Holdings.
+- **The drawer's row height at 844×390**, which is the residual the tablet tier's height guard creates
+  and the one place two of that tier's decisions pull against each other. The shell travels to a
+  rotated phone on `(max-height: 500px)`; the 44px floor stays behind `max-width`, because 44px targets
+  are on the tier's "explicitly not done" list. The result is a phone, in the hand, with ~38px
+  navigation rows — above WCAG 2.5.8's 24px floor and below the comfort target the same effort set for
+  the same control in portrait. `shell.spec.js` asserts a 24px floor there rather than skipping, so the
+  geometry is gated; what is not gated is whether it is *comfortable*, which is the fourth iPhone item
+  in a new place. If it reads badly, the fix is one condition on one rule and the tier's boundary moves.
 
 ## Open calls
 
@@ -182,6 +190,25 @@ Failing these **changes a decision**, rather than reporting a bug.
   instance and is on screen too** — same `limit=1000`, and "Dining Out" alone is 285 transactions in one
   year in the live DB, against the 16 the committed fixture drills into. The fixture cannot show you the
   bad case; a real phone on the live database can.
+
+- **Whether a date is enough of an identity on the two multi-security ledgers.** The tablet tier pins
+  the column that was already first, which on `Portfolio › Transactions` and `Spending › Transactions`
+  is `Date`. That is a real identity — it varies per row and both ledgers arrive ordered by it, which
+  is exactly what `contract.jsx`'s merged cell existed to supply for a column of `Put / Put / Call`.
+  What it does not do is separate two rows on the same day: on those you are reading the pin, seeing
+  one date twice, and relying on `Security` or `Merchant` being one scroll-step to the right.
+  **The alternative was rejected on a measurement, not on principle** — `Merchant` is 561px of
+  unbounded free text against a 440px window at 640, so pinning it covers the screen and never lets a
+  number through, and bounding it would be a second rule in a tier whose whole claim is that it holds
+  one. If reading a same-day run is genuinely confusing on a tablet, the answer is a merged identity
+  cell on `contract.jsx`'s precedent — which changes those tables at *every* width, and is therefore a
+  decision rather than a fix.
+- **Whether 768 and 1000 deserve to be viewports.** The tier's own criteria name four widths and the
+  suite gates three of them (640, 834, and 844×390 for the height guard). Both missing widths sit
+  strictly inside a band whose ends are measured, and both read **0** on every view when measured by
+  hand at the tier's landing — but that measurement is a moment in time and the suite is what makes a
+  fact durable. Adding them is two more projects on a suite that is already ten deep and ~10 minutes
+  per full run, which is the cost side. Decide it once, here, rather than each time someone notices.
 
 *(`Options.jsx:71` left this list: resolved to **A**, on the measurement that a 9-field card is 4 rows per
 screen against A's 12 — the same reasoning that rejected B for Holdings at 3.)*

--- a/web/TESTING.md
+++ b/web/TESTING.md
@@ -22,17 +22,25 @@ authority on what it asserts and, more importantly, **what it can never assert**
 before treating a green run as "verified on a phone"; it is not. Four things need a real
 iPhone and are named there.
 
-**Below 640px, "open a view" means different clicks**, and `tests/support/app.js` makes them:
-the hamburger, then the section in the drawer, then the tab in the `<select>`. Every spec keeps
-asking for `"Spending › Recurring"` and gets there the way a person on that viewport would. So
-the phone half of the whole suite depends on the navigation shell — which is why that ticket
-landed before the tables and the charts.
+**Where the shell is the phone's, "open a view" means different clicks**, and
+`tests/support/app.js` makes them: the hamburger, then the section in the drawer, then the tab in
+the `<select>`. Every spec keeps asking for `"Spending › Recurring"` and gets there the way a
+person on that viewport would. So the phone half of the whole suite depends on the navigation
+shell — which is why that ticket landed before the tables and the charts.
+
+**That is not "below 640" any more.** The tablet tier put the shell on a *height* guard as well —
+`(max-height: 500px)` — so 844×390 gets the drawer and the picker at 844px wide. `onPhoneShell` in
+`tests/viewports.js` is the one place that question is answered, and only the *navigation* asks
+it: the pin, the cards, the charts and the content gutter are all still width-only, which is the
+split the tier was decided on. A spec that skips on `viewport.width < 640` when it means "where
+the strip renders" will go looking for a control that is `display: none`.
 
 `tests/unconditional.spec.js` — the gates that hold at *every* width, checked at every width their
 subject exists at, and only on the views that carry them: `.grid2`'s collapse, the wrapping tab
 strip, the editors' 24px floor, the rule textarea's styling, the S2 list rows, the merged options
-identity cell, and the labelled refresh control — that last one at 640 and up, because below it
-the label does not render at all. Each one moved **out of** `RESPONSIVE.md` when it moved in here.
+identity cell, and the labelled refresh control — that last one wherever the tab strip renders,
+because elsewhere the label does not exist to measure. Each one moved **out of** `RESPONSIVE.md`
+when it moved in here.
 
 `tests/foundations.spec.js` — the mechanism every phone rule sits in: the shell's `100svh`, the
 `viewport-fit=cover` opt-in, the `max(<literal>, env(...))` content gutter inside the one
@@ -44,13 +52,31 @@ answers the session endpoint 401.
 
 `tests/shell.spec.js` — the phone navigation shell: the drawer and its scrim, the native tab
 picker at 16px, the icon-only refresh with its toast strip *displacing* content rather than
-covering it and then leaving on its own, the `100svh` column, and — at 640 and above — that
-none of it renders. It shares
-`foundations.spec.js`'s CSSOM reader (`tests/support/css.js`) for the two criteria that are
-about a notch and therefore have no geometric form in Chromium.
+covering it and then leaving on its own, the `100svh` column, and — wherever the rail survives —
+that none of it renders. Since the height guard landed, its first group **runs at 844×390 too**,
+so the guard is exercised eleven tests deep rather than asserted once; what did *not* travel with
+the shell is the 44px tap floor, and that split is asserted both as geometry inside the drawer and
+as a fact about which media block each rule sits in. It shares `foundations.spec.js`'s CSSOM
+reader (`tests/support/css.js`) for the two criteria that are about a notch and therefore have no
+geometric form in Chromium.
 
-`tests/pinned.spec.js` — pattern A: eight tables across seven views that pin an identity column and
-scroll the rest sideways below **1024px**, not 640. It is the one spec whose tier is the pin tier,
+`tests/tablet.spec.js` — the tablet tier, 640–1024. The shortest spec with the strongest claim:
+the tier holds **exactly one rule**, so most of this file asserts that things did *not* happen —
+no card-per-row at 640 and above, no enlarged tap targets, no resized inputs, and no media block
+of the tier's own in the shipped sheet (a `min-width` condition appearing at all is the second
+design the brief forbids). What it does assert positively is the rule itself, as a sweep over the
+eleven fully-responsive views: any table that overflows **its own container** gets a wrapper, the
+wrapper holds the table and nothing else, it fits its parent, and — the part a scroll box alone
+does not give you — the identity column inside it is `sticky`. That last gate is what found the
+sixth table: `Dividends`' detail ledger had been inside an inline 520px scroll box since long
+before this work, so it never appeared in the pane ratchet and read as done.
+
+`tests/pinned.spec.js` — pattern A: fourteen tables across ten views that pin an identity column and
+scroll the rest sideways below **1024px**, not 640. Eight of them are tables you read *down* a
+column; the other six arrived with the tablet tier, which extends the pin to anything that
+overflows in it regardless of that table's phone assignment — and every one of those six is a card
+list below 640, so the wrapper count in a view is a function of the viewport and `SecurityDetail`'s
+pinned tables change *index* across the tier boundary. It is the one spec whose tier is the pin tier,
 because the pin is worth more as the window narrows: the same gates run at seven viewports and the
 other three assert the inverse — that the desktop table is untouched. It also carries the two gates
 that have no geometry. **The column count of every pinned table is asserted**, because "no table
@@ -137,11 +163,13 @@ tickets. Three prototypes live in `web/prototypes/`.
 
 ## Two things to know before you touch the suite
 
-**`tests/hscroll-baseline.js` is a list of defects, not a specification.** The main pane
-overflows horizontally at every viewport below 1024px today — that is the problem the
-responsive work exists to fix. The suite ratchets against the measured numbers so it can run
-green now and still catch a regression. Lower them as the work lands; never raise one to make
-a test pass.
+**`tests/hscroll-baseline.js` is a list of defects, not a specification.** The suite ratchets
+against the measured numbers so it can run green now and still catch a regression. Lower them as
+the work lands; never raise one to make a test pass. **It is nearly done**: seven lowerings in,
+two of the seven gated viewports are zero across all thirteen views and every number left is the
+same one cause — `.grid2`'s `minmax(420px, 1fr)` track floor against a narrower pane, which is
+#44's. Nothing table-shaped is left in it, and `tablet.spec.js` asserts that half separately,
+because the ratchet would go green on a build that swapped one table's overflow for another's.
 
 **No screenshots, ever.** Geometry and structure only. Visual-regression diffing is out of
 scope by decision, and a test asserts that no `toHaveScreenshot` creeps in.

--- a/web/playwright.config.js
+++ b/web/playwright.config.js
@@ -39,7 +39,7 @@ export default defineConfig({
     { name: "inventory", testMatch: /inventory\.spec\.js/ },
     ...VIEWPORTS.map((v) => ({
       name: v.name,
-      testMatch: /(baseline|unconditional|foundations|shell|pinned|cards|drill|charts|editors)\.spec\.js/,
+      testMatch: /(baseline|unconditional|foundations|shell|pinned|cards|drill|charts|editors|tablet)\.spec\.js/,
       use: {
         ...devices["Desktop Chrome"],
         viewport: { width: v.width, height: v.height },

--- a/web/src/modules/portfolio/Dividends.jsx
+++ b/web/src/modules/portfolio/Dividends.jsx
@@ -142,7 +142,25 @@ export default function Dividends() {
             ))}
           </Cards>
         ) : (
-        <div style={{ maxHeight: 520, overflow: "auto" }}>
+        /* Pattern A above the card tier — the sixth table the tablet tier's one rule reaches,
+           and the one that was hiding. Its inline `{ maxHeight: 520, overflow: "auto" }` box
+           already stopped the width reaching `.main`, so the pane-overflow ratchet has read
+           zero for this view since the phone gutter landed. Contained is not pinned: at 640
+           you scrolled that box sideways and lost the security name along with the date.
+
+           IT ALSO EXPLAINS WHY THE TABLE OVERFLOWED AT ALL WITHOUT EVER OVERFLOWING THE PANE.
+           The tier's rule is "any table that overflows", and this one overflows *its own box*
+           — which is the failure the pin exists for, not a smaller version of it: you swipe
+           the box sideways to reach `Gross SGD` and the date and the security name go with it.
+
+           THE INLINE `max-height` HAD TO GO, WHICH IS THE TRAP `.selfscroll` WAS EXTRACTED FOR.
+           An inline declaration beats any stylesheet, so a 520px box would have overridden the
+           pattern's `60svh` outright — 520 against 234 at 844×390 — and the sticky header the
+           cap exists to make work would have gone with it. The NUMBER stays, as `--selfscroll`:
+           a custom property is not a `max-height`, so it loses to the pattern below 1024 and
+           still gives this box the 520px it has always had above it. Desktop is unchanged to
+           the pixel, which is the claim that ruled out simply taking `.selfscroll`'s 480. */
+        <div className="pinned selfscroll" style={{ "--selfscroll": "520px" }}>
           <table>
             <thead><tr>
               <th className="l">Date</th><th className="l">Security</th><th className="l">Acct</th>

--- a/web/src/modules/portfolio/SecurityDetail.jsx
+++ b/web/src/modules/portfolio/SecurityDetail.jsx
@@ -70,6 +70,14 @@ export default function SecurityDetail({ ticker, bucket, onBack }) {
             ))}
           </Cards>
         ) : (
+        /* Pattern A above the card tier, which makes this page B-then-A rather than the
+           B, A, A the phone renders — the third table below was already pinned at every
+           width under 1024. 839px natural against a 440px pane at 640.
+
+           The pin is `Date`, and on this table it is the identity outright rather than a
+           second-best: every row is the same security, so what tells two rows apart is when
+           the trade happened — which is exactly what the card beside it leads with. */
+        <div className="pinned">
         <table>
           <thead><tr>
             <th className="l">Date</th><th className="l">Account</th><th className="l">Action</th>
@@ -90,6 +98,7 @@ export default function SecurityDetail({ ticker, bucket, onBack }) {
             ))}
           </tbody>
         </table>
+        </div>
         )}
       </div>
 
@@ -115,6 +124,16 @@ export default function SecurityDetail({ ticker, bucket, onBack }) {
             ))}
           </Cards>
         ) : (
+          /* Pattern A above the card tier, on the same `Date` identity as the ledger above
+             and for the same reason: one security, so the row is its payment date.
+
+             THE ONE TABLE IN THIS TICKET THE FIXTURES CANNOT REACH. PLTR is the row the suite
+             drills into — 73 option trades, the longest options history captured — and it has
+             no dividends at all, so this branch never mounts under test. `pinned.spec.js`
+             annotates that on every run rather than closing it with an invented row. The
+             wrapper is here because the table overflows the tier's pane by measurement
+             (~580px natural against 440 at 640), not because a gate asked for it. */
+          <div className="pinned">
           <table>
             <thead><tr>
               <th className="l">Date</th><th className="l">Account</th><th className="l">Kind</th>
@@ -137,6 +156,7 @@ export default function SecurityDetail({ ticker, bucket, onBack }) {
               ))}
             </tbody>
           </table>
+          </div>
         )}
       </div>
 

--- a/web/src/modules/portfolio/Transactions.jsx
+++ b/web/src/modules/portfolio/Transactions.jsx
@@ -52,6 +52,21 @@ export default function Transactions() {
           ))}
         </Cards>
       ) : (
+        /* Pattern A above the card tier, and the tablet tier is the whole of why: this table
+           is 1220px natural against a 440px pane at 640, so "untouched" means Date and Acct
+           and not one number — and because `.main` owns the scroll, reaching the amount takes
+           the date away with it. Card-per-row is not the alternative here by decision: it
+           trades density for readability on a 390px measurement, and this ledger is read at
+           tablet widths with room the phone did not have.
+
+           THE PIN IS `Date`, THE COLUMN THAT IS ALREADY FIRST. No merge, no reorder, nothing
+           that reaches desktop. `contract.jsx`'s merged identity cell exists because that
+           table led with `Type` — 46px of Put / Put / Call, a column that cannot tell any two
+           rows apart however wide the screen. A date is not that: it varies per row and the
+           ledger arrives ordered by it, so scrolling right keeps you on a row you can name.
+           Residual, written down rather than fixed: two trades on the same day are told apart
+           by `Security`, which is 269px wide and one scroll-step to the right of the pin. */
+        <div className="pinned">
         <table>
           <thead><tr>
             <th className="l">Date</th><th className="l">Acct</th><th className="l">Security</th>
@@ -72,6 +87,7 @@ export default function Transactions() {
             ))}
           </tbody>
         </table>
+        </div>
       )}
     </div>
   );

--- a/web/src/modules/spending/Overview.jsx
+++ b/web/src/modules/spending/Overview.jsx
@@ -55,6 +55,19 @@ export default function SpendOverview() {
               ))}
             </Cards>
           ) : (
+          /* Pattern A above the card tier, and the smallest overflow in the ticket: 443px
+             natural against a 388px card at 640 — 40px, the last table-shaped number left in
+             the ratchet at that viewport once the two ledgers were pinned. It reaches zero
+             everywhere else in the tier, which is what a `max-content` table in an `auto-fit`
+             track looks like: 478px in a 478px card at 768 and wider.
+
+             `Category` IS THE PIN, AND THE 390px REJECTION DOES NOT TRANSFER. Pattern A was
+             turned down for this table on a phone because pinning `Line item` — unbounded
+             free text, 232px measured — is 70% of a 330px pane. That is not what happens
+             here: the column that is already first is `Category`, 82px, and `Line item` sits
+             beside it inside the window at every width in the tier, so the pin costs 19% and
+             hides nothing. */
+          <div className="pinned">
           <table>
             <thead><tr><th className="l">Category</th><th className="l">Line item</th><th>Spend</th><th>%</th></tr></thead>
             <tbody>
@@ -68,6 +81,7 @@ export default function SpendOverview() {
               ))}
             </tbody>
           </table>
+          </div>
           )}
         </div>
       </div>

--- a/web/src/modules/spending/Transactions.jsx
+++ b/web/src/modules/spending/Transactions.jsx
@@ -63,6 +63,18 @@ export default function SpendTransactions() {
           ))}
         </Cards>
       ) : (
+        /* Pattern A above the card tier — the same reasoning as `portfolio/Transactions`, on
+           a table that is 1196px natural against a 440px pane at 640.
+
+           THE PIN IS `Date`, AND HERE THAT IS A CHOICE RATHER THAN THE DEFAULT. `Merchant` is
+           the identity this row's card leads with, and pinning it was rejected on one
+           measurement: the column is 561px, because the merchant string is unbounded free
+           text out of the bank statements and the longest real one is what sets the width. A
+           561px pin in a 440px window is a pinned column that covers the whole screen and
+           never lets a number through — the pattern inverted. Bounding it would mean a second
+           rule in a tier whose whole claim is that it holds exactly one, so the pin takes the
+           column that was already first and `Merchant` stays one scroll-step to its right. */
+        <div className="pinned">
         <table>
           <thead><tr>
             <th className="l">Date</th><th className="l">Source</th><th className="l">Merchant</th>
@@ -81,6 +93,7 @@ export default function SpendTransactions() {
             ))}
           </tbody>
         </table>
+        </div>
       )}
     </div>
   );

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -177,7 +177,10 @@ tr.subrow > td { background: var(--panel2); }
 
 /* The two wrappers that predate this pattern, keeping the behaviour they shipped with so the
    pin is additive rather than a replacement — and so both still hold above 1024, where
-   `.pinned` does nothing. Dividends' crosstab is `.hscroll`; the trades ledger is both.
+   `.pinned` does nothing. Dividends' crosstab is `.hscroll`; the trades ledger is both, and
+   so is Dividends' detail ledger, which took `.selfscroll` when the tablet tier reached it —
+   its inline `maxHeight: 520` was the exact trap the paragraph below describes, and 480 is
+   what it costs to have one self-scrolling box in the app rather than two constants.
 
    Classes rather than the inline styles they replace, and declared ABOVE the pattern rather
    than below it, for one reason each. Inline first: `.selfscroll`'s 480px would otherwise
@@ -188,7 +191,15 @@ tr.subrow > td { background: var(--panel2); }
    unguarded, so `pinned.spec.js` measures every wrapper against the cap rather than trusting
    it. That gate caught this exact rule in the wrong place. */
 .hscroll { overflow-x: auto; }
-.selfscroll { overflow: auto; max-height: 480px; }
+/* `--selfscroll` IS HOW THE SECOND CALL SITE KEEPS ITS OWN NUMBER WITHOUT KEEPING AN INLINE
+   `max-height`. The two boxes were written at different heights — Options' trades ledger at
+   480, Dividends' detail ledger at 520 — and "desktop is unchanged" is a locked claim, so
+   unifying them on one literal was not free. A custom property in an inline style is not a
+   `max-height` declaration, so it does not join the specificity fight the paragraph above
+   describes: `.pinned`'s `60svh` still wins below 1024, and above it each box is the height
+   it always was. The fallback is the value with no override, so the token has one consumer
+   rather than two. */
+.selfscroll { overflow: auto; max-height: var(--selfscroll, 480px); }
 
 /* THE EDITORS' CONTAINMENT — the two desktop-optimised views' answer to "sideways scroll
    is confined to a container that visibly is a table". Not a pattern: `A` and `B` both
@@ -227,6 +238,23 @@ tr.subrow > td { background: var(--panel2); }
    because `.main` owns the scroll there, reaching a number takes the identity away with it —
    strictly worse than the phone. Above 1024 none of this applies and the desktop table is
    what it always was; pattern A at desktop widths is a separate, open question.
+
+   THE PATTERN NOW REACHES TABLES CARD-PER-ROW OWNS ON A PHONE, and that is the tablet tier's
+   one rule rather than a second decision here: any table that overflows between 640 and 1024
+   is pinned, *regardless of its phone assignment*. Six wrappers arrived that way — both
+   `Transactions` ledgers, `SecurityDetail`'s two histories, `Spending › Overview`'s top line
+   items and `Dividends`' detail ledger — and every one of them renders only above the card
+   tier, because `usePhone()` swaps the whole table out below it. So these selectors gain
+   nothing on a phone and the two patterns never meet on one screen; the tier is the hook
+   below 640 and this media query from 640 to 1024. Card-per-row does not follow: it trades
+   density for readability on a 390px measurement, and a ledger that fits outright at 900
+   would lose rows and buy nothing.
+
+   THE SIXTH IS THE ONE WORTH KNOWING ABOUT, because it says what "overflows" means here.
+   `Dividends`' detail ledger already sat in a `max-height` scroll box, so it never overflowed
+   `.main` and never showed up in the pane ratchet — it read as done. What it overflowed was
+   *its own box*, which is the failure this pattern exists for rather than a smaller version
+   of it. A table can be contained and still lose its identity column the moment you swipe.
 
    THE TRAP. Under `border-collapse: collapse` the borders belong to the *table*'s border
    grid, and a cell that has left the flow leaves them behind — a sticky header and a pinned
@@ -444,6 +472,86 @@ input, select, textarea { background: var(--panel2); border: 1px solid var(--lin
 .logout-btn { font-size: 12px; font-weight: 600; color: var(--mut); background: none; border: 1px solid var(--line); border-radius: 6px; padding: 4px 10px; cursor: pointer; }
 .logout-btn:hover { color: var(--txt); border-color: var(--mut); }
 
+/* ─── the navigation shell ──────────────────────────────────────────────────────────────
+   The drawer, the app bar, its toast strip and the scrim — everything that makes the
+   navigation a phone's rather than a desktop's. The shell becomes a column and the two bars
+   become ordinary flex children of it; the rail leaves the flow entirely, so `.main` is the
+   only thing left to take the width and stays the scroll owner it already was.
+
+   TWO CONDITIONS, NOT ONE, AND THE SECOND IS A HEIGHT. This is the tablet tier's landscape
+   answer, and it splits on how each decision was originally made rather than on taste. The
+   shell was chosen on a *vertical* budget — 48px of chrome against a bottom section bar's
+   147px, 181px with the home bar, 21% of an 844px screen — so height is the axis it was
+   always arguing about. Tables and charts were chosen on *horizontal* room, so they stay
+   width-only, which is also what leaves `cards.jsx`'s `matchMedia` hook untouched: the tier
+   costs the JS side nothing at all.
+
+   FORCED BY MEASUREMENT. At 844×390 the tablet tier's own chrome — the 200px rail plus a
+   `.tabs` strip that wraps to two lines — costs 107px, 27% of the screen, where the shell
+   rejected its own always-visible variant at 21%. The rail is not the whole cause: without
+   it the strip still wraps, 788px of content against ~850px needed. The phone shell costs
+   48px, 12%, on the same screen.
+
+   `500px` RATIFIED. Every phone landscape height is at most 430 (430×932 rotated is the
+   tallest phone in the suite); every iPad landscape height is at least 744. There is no
+   device between them, so the number has ~314px of slack on both sides. It does also fire
+   on a desktop window dragged below 500px tall, and that is accepted: a 1440×450 window has
+   the same vertical problem a rotated phone does, and the alternative — `(orientation:
+   landscape)` — fires on every desktop monitor ever made.
+
+   `640` IS NOT WRITTEN A FIFTH TIME HERE. This block shares the phone tier's own edge as
+   the first arm of its condition; `inventory.spec.js` counts *files*, and this is the same
+   file. What is new is `500`, which is written twice — here and in `tests/viewports.js` —
+   for the reason `640` is written four times: no build step makes a shared constant. */
+@media (max-width: 639.98px), (max-height: 500px) {
+  .app { flex-direction: column; }
+  .bar { display: flex; }
+  .toast { display: block; }
+  /* The desktop strip goes whole, `.tabs-right` with it: the six tabs become the app bar's
+     `<select>` and Refresh becomes its icon. Nothing in that group needs a phone home.
+
+     `.main > .tabs`, not `.tabs`. `ByCategory.jsx:132` borrows this class for its own view
+     header — an `<h3>` and a year `<select>` — for the flex row and nothing else, with the
+     border overridden inline. It is nested inside the view, so the child combinator is what
+     separates the navigation strip from a heading that happens to reuse its layout. */
+  .main > .tabs { display: none; }
+
+  /* TODAY'S RAIL, RESTYLED — not a second navigation built beside it. There is exactly one
+     `.side` in the app, so "the drawer holds every item the sidebar holds" is a structural
+     fact rather than two lists somebody has to keep in step; brand, sections, the dimmed
+     Settings entry and the signed-in footer all arrive unchanged.
+
+     `absolute`, never `fixed` — see `.app`'s comment. `visibility` alongside the transform
+     because a panel that is only translated off-canvas is still in the focus order, which
+     is how a keyboard or switch user lands on items they cannot see; it animates because
+     `visibility` transitions discretely, flipping at the far end of the slide out.
+
+     The `env()` guard here stays INSIDE the block, unlike the app bar's. The bar renders
+     wherever it is turned on, so its guard has to outlive the condition; the drawer does not
+     exist outside this rule at all — `position: absolute` and the transform are in it too —
+     so hoisting one declaration out of a rule the element depends on would leave a guard for
+     a rail. The whole rule travelled here together, guard included, which is what makes the
+     drawer's landscape inset live at 844×390 rather than in a block that width exits.
+
+     THE RAIL ABOVE THIS BLOCK STILL HAS NO GUARD, and that is now a smaller residual than it
+     was: the only landscape screens that keep the rail are tablets, which have no side
+     notch. */
+  .side { position: absolute; top: 0; bottom: 0; left: 0; z-index: 6; width: 246px;
+    display: flex; flex-direction: column; overflow-y: auto;
+    transform: translateX(-100%); visibility: hidden;
+    transition: transform .2s, visibility .2s;
+    padding-bottom: max(16px, env(safe-area-inset-bottom));
+    padding-left: max(0px, env(safe-area-inset-left)); }
+  .side.on { transform: none; visibility: visible; }
+  .scrim { display: block; position: absolute; inset: 0; z-index: 5;
+    background: rgba(0, 0, 0, .55); opacity: 0; visibility: hidden; pointer-events: none;
+    transition: opacity .18s, visibility .18s; }
+  .scrim.on { opacity: 1; visibility: visible; pointer-events: auto; }
+  /* `.side` is a flex column only here, so this is where `margin-top: auto` can sink the
+     footer to the bottom of the drawer. Wherever the rail is a rail it keeps its 24px. */
+  .side-user { margin-top: auto; }
+}
+
 /* ─── the phone tier ────────────────────────────────────────────────────────────────────
    One block, literal values, no token layer. Most of what a phone changes cannot be
    expressed as a token override at all — the shell flips to a column, charts lose chrome,
@@ -503,57 +611,26 @@ input, select, textarea { background: var(--panel2); border: 1px solid var(--lin
      being one. The flex centres the label in the box `min-height` grew — `.nw-del`'s shape. */
   .navitem { min-height: var(--tap); min-width: var(--tap); display: flex; align-items: center; }
 
-  /* ── the navigation shell ──
-     The shell becomes a column and the two bars become ordinary flex children of it. The
-     rail leaves the flow entirely — it is the drawer now — so `.main` is the only thing
-     left to take the width, and it stays the scroll owner it already was. */
-  .app { flex-direction: column; }
-  .bar { display: flex; }
-  .toast { display: block; }
-  /* The desktop strip goes whole, `.tabs-right` with it: the six tabs become the app bar's
-     `<select>` and Refresh becomes its icon. Nothing in that group needs a phone home.
-
-     `.main > .tabs`, not `.tabs`. `ByCategory.jsx:132` borrows this class for its own view
-     header — an `<h3>` and a year `<select>` — for the flex row and nothing else, with the
-     border overridden inline. It is nested inside the view, so the child combinator is what
-     separates the navigation strip from a heading that happens to reuse its layout. */
-  .main > .tabs { display: none; }
-
-  /* TODAY'S RAIL, RESTYLED — not a second navigation built beside it. There is exactly one
-     `.side` in the app, so "the drawer holds every item the sidebar holds" is a structural
-     fact rather than two lists somebody has to keep in step; brand, sections, the dimmed
-     Settings entry and the signed-in footer all arrive unchanged.
-
-     `absolute`, never `fixed` — see `.app`'s comment. `visibility` alongside the transform
-     because a panel that is only translated off-canvas is still in the focus order, which
-     is how a keyboard or switch user lands on items they cannot see; it animates because
-     `visibility` transitions discretely, flipping at the far end of the slide out.
-
-     The `env()` guard here stays INSIDE the block, unlike the app bar's. The bar renders
-     wherever it is turned on, so its guard has to outlive the width condition; the drawer
-     does not exist outside this rule at all — `position: absolute` and the transform are
-     in it too — so hoisting one declaration out of a rule the element depends on would
-     leave a guard for a rail. When the tablet tier brings this shell to 844×390 on its
-     height guard, the whole rule travels and the guard travels with it. */
-  .side { position: absolute; top: 0; bottom: 0; left: 0; z-index: 6; width: 246px;
-    display: flex; flex-direction: column; overflow-y: auto;
-    transform: translateX(-100%); visibility: hidden;
-    transition: transform .2s, visibility .2s;
-    padding-bottom: max(16px, env(safe-area-inset-bottom));
-    padding-left: max(0px, env(safe-area-inset-left)); }
-  .side.on { transform: none; visibility: visible; }
-  .scrim { display: block; position: absolute; inset: 0; z-index: 5;
-    background: rgba(0, 0, 0, .55); opacity: 0; visibility: hidden; pointer-events: none;
-    transition: opacity .18s, visibility .18s; }
-  .scrim.on { opacity: 1; visibility: visible; pointer-events: auto; }
-  /* `.side` is a flex column only here, so this is where `margin-top: auto` can sink the
-     footer to the bottom of the drawer. Above the tier it keeps its 24px. */
-  .side-user { margin-top: auto; }
   /* Square, like every other call site of `--tap` — a floor one selector writes differently
-     stops being a floor. Free here: the label is already ~76px wide. */
+     stops being a floor. Free here: the label is already ~76px wide.
+
+     A TAP FLOOR, NOT A SHELL RULE, which is why it stayed behind when the drawer left this
+     block for the height guard below. The tier that brings the drawer to 844×390 lists 44px
+     targets under "explicitly not done" — so the drawer a rotated phone opens holds ~38px
+     rows, and that is the boundary being enforced rather than an oversight. It costs a
+     landscape phone comfort on a control it opens by choice; extending the floor on height
+     would hand it to any short desktop window too, which is the tier's own "desktop is
+     unchanged" line. */
   .logout-btn { min-height: var(--tap); min-width: var(--tap); }
 
-  /* PATTERN A'S HEIGHT IS NOT HERE, and its absence is the decision. `60svh` reads like a
+  /* THE NAVIGATION SHELL IS NOT HERE ANY MORE — see the `(max-height: 500px)` block above.
+     It moved out whole rather than being duplicated: the shell was chosen on a *vertical*
+     budget (48px of chrome against a bottom bar's 147px), so height is the condition it was
+     always arguing about, and a rotated phone at 844×390 is exactly the screen that argument
+     was about. What stayed here is what was chosen on horizontal room: the 14px gutter, the
+     tap floors, the footnote disclosure and the editors' floor.
+
+     PATTERN A'S HEIGHT IS NOT HERE EITHER, and its absence is the decision. `60svh` reads like a
      phone rule and 020 wrote it as one, but the height is what makes the sticky header work
      at all — and a phone-only version would leave the header broken from 640 to 1024 and,
      because a rotated phone is 844px wide, in landscape too. It travels with the pattern

--- a/web/tests/editors.spec.js
+++ b/web/tests/editors.spec.js
@@ -38,51 +38,12 @@ import { expect, test } from "@playwright/test";
 import { HSCROLL_GATE_APPLIES_BELOW, PHONE_TIER_BELOW, VIEWPORTS } from "./viewports.js";
 import { openView } from "./support/app.js";
 import { declarationsFor } from "./support/css.js";
+// One reader for both halves of this criterion — `support/tables.js` says why it is shared.
+import { tableFacts } from "./support/tables.js";
 
 const viewportOf = (projectName) => VIEWPORTS.find((v) => v.name === projectName);
 
 const EDITORS = ["Net Worth", "Spending › Classify"];
-
-/**
- * Every `<table>` under `.main`, with the nearest ancestor that absorbs its sideways
- * scroll — and whether that ancestor is a box holding the table and nothing else.
- *
- * "Visibly is a table" is not a claim about appearance that a test can make. What it
- * reduces to structurally is: the scrolling box wraps the table alone, so what slides under
- * your finger is the grid of numbers rather than the card, the heading and the save button
- * with it. A sheet or a card with `overflow: auto` on it satisfies "the pane does not
- * scroll" and fails this.
- */
-function tableContainment(page) {
-  return page.evaluate(() => {
-    const main = document.querySelector(".main");
-    const name = (el) => {
-      const cls = typeof el.className === "string" && el.className
-        ? "." + el.className.trim().split(/\s+/).join(".") : "";
-      return el.tagName.toLowerCase() + cls;
-    };
-    return [...main.querySelectorAll("table")].map((t) => {
-      let box = null;
-      for (let el = t.parentElement; el && el !== main; el = el.parentElement) {
-        const ox = getComputedStyle(el).overflowX;
-        if (ox === "auto" || ox === "scroll") { box = el; break; }
-      }
-      const headers = [...t.querySelectorAll("thead th")]
-        .map((th) => th.textContent.trim()).filter(Boolean);
-      return {
-        table: headers.slice(0, 2).join("/") || "(unheaded)",
-        container: box ? name(box) : null,
-        // The box holds the table and nothing else.
-        wrapsTableAlone: box ? box.children.length === 1 && box.firstElementChild === t : null,
-        // ...and does not itself push its parent wide, which is how an "absorbing" wrapper
-        // that absorbs nothing passes the first two checks and still overflows the pane.
-        fitsItsParent: box
-          ? box.getBoundingClientRect().width <= box.parentElement.clientWidth + 1
-          : null,
-      };
-    });
-  });
-}
 
 /**
  * Every element under `.main` carrying a `title=`, described.
@@ -106,7 +67,7 @@ test.describe("sideways scroll is confined to a container that is the table alon
   for (const viewName of EDITORS) {
     test(viewName, async ({ page, baseURL }) => {
       await openView(page, baseURL, viewName);
-      const tables = await tableContainment(page);
+      const tables = await tableFacts(page);
       expect(tables.length, `${viewName} rendered no table`).toBeGreaterThan(0);
 
       for (const t of tables) {

--- a/web/tests/hscroll-baseline.js
+++ b/web/tests/hscroll-baseline.js
@@ -23,7 +23,7 @@
  * Above 1024px there is no gate and therefore no entries here — `HSCROLL_GATE_APPLIES_BELOW`
  * in `viewports.js` says why those three viewports are exempt.
  *
- * LOWERED SIX TIMES SO FAR.
+ * LOWERED SEVEN TIMES SO FAR.
  *
  * 1. The unconditional fixes. `.grid2`'s `auto-fit` did most of it: two 419px tracks side by
  *    side became one, so `Portfolio › Overview` went 619 → 288 at 360px, `Spending › By
@@ -117,6 +117,31 @@
  *    `minmax(min(420px, 100%), 1fr)`. What is
  *    left at 640/834/844 for both `Transactions` ledgers and `SecurityDetail` is the tablet
  *    tier's, and is the only table-shaped overflow the file still holds.
+ *
+ * 7. The tablet tier. **Every table-shaped number left in this file goes to zero, and two
+ *    whole viewports go to zero with them.** The tier holds one rule — the pin extends to any
+ *    table that overflows between 640 and 1024, whatever its phone assignment — so the three
+ *    rows the entry above named as waiting are gone: both `Transactions` ledgers from 825 and
+ *    801 at 640, `SecurityDetail` from 444, all at 640, 834 and 844 alike. `Spending ›
+ *    Overview` sheds the 40px it carried alone at 640 and joins the shared residual, so the
+ *    five `.grid2` views are now identical to the pixel at every gated viewport rather than
+ *    at six of seven.
+ *
+ *    THE TWO ROWS THAT WENT TO ZERO OUTRIGHT ARE THE CLEAREST READING OF THE TIER. `ipad-
+ *    portrait` is the pin doing the whole job on its own: 834px is above every `.grid2`
+ *    collapse, so nothing was left there but tables. `rotated-phone` is the pin *and* the
+ *    height guard together — the shell's `(max-height: 500px)` arm hands 844×390 the drawer,
+ *    which takes the 200px rail out of the flow, and the pin absorbs what is left. Neither
+ *    number could have reached zero without the other: at 844×390 the ledgers still wanted
+ *    1196px against a 788px pane once the rail had gone.
+ *
+ *    WHAT IS LEFT IS ONE CAUSE AT SEVEN VIEWPORTS AND FIVE VIEWS: 74 / 44 / 4 / 0 / 8 / 0 / 0
+ *    on `Portfolio › Overview`, `Options`, `Net Worth`, `Spending › Overview` and `By
+ *    Category`, which is `.grid2`'s `minmax(420px, 1fr)` track floor against a pane narrower
+ *    than 420. It is **#44's**, the remedy has been written here since entry 4
+ *    (`minmax(min(420px, 100%), 1fr)`), and this file now holds nothing else. When it lands,
+ *    every number here is zero and the file can be deleted for the `<= 0` gate it was always
+ *    standing in for.
  */
 export const HSCROLL_BASELINE = {
   "small-phone": {
@@ -185,43 +210,45 @@ export const HSCROLL_BASELINE = {
     "Portfolio › Performance": 0,
     "Portfolio › Dividends": 0,
     "Portfolio › Options": 8,
-    "Portfolio › Transactions": 825,
-    "Portfolio › SecurityDetail": 444,
+    "Portfolio › Transactions": 0,
+    "Portfolio › SecurityDetail": 0,
     "Net Worth": 8,
-    "Spending › Overview": 48,
+    "Spending › Overview": 8,
     "Spending › By Category": 8,
     "Spending › Classify": 0,
     "Spending › Recurring": 0,
-    "Spending › Transactions": 801,
+    "Spending › Transactions": 0,
   },
+  // Zero, every view. The pin and the shell's height guard together — see entry 7.
   "rotated-phone": {
     "Portfolio › Overview": 0,
     "Portfolio › Holdings": 0,
     "Portfolio › Performance": 0,
     "Portfolio › Dividends": 0,
     "Portfolio › Options": 0,
-    "Portfolio › Transactions": 621,
-    "Portfolio › SecurityDetail": 240,
+    "Portfolio › Transactions": 0,
+    "Portfolio › SecurityDetail": 0,
     "Net Worth": 0,
     "Spending › Overview": 0,
     "Spending › By Category": 0,
     "Spending › Classify": 0,
     "Spending › Recurring": 0,
-    "Spending › Transactions": 597,
+    "Spending › Transactions": 0,
   },
+  // Zero, every view. Above every `.grid2` collapse, so the pin was the whole job here.
   "ipad-portrait": {
     "Portfolio › Overview": 0,
     "Portfolio › Holdings": 0,
     "Portfolio › Performance": 0,
     "Portfolio › Dividends": 0,
     "Portfolio › Options": 0,
-    "Portfolio › Transactions": 631,
-    "Portfolio › SecurityDetail": 250,
+    "Portfolio › Transactions": 0,
+    "Portfolio › SecurityDetail": 0,
     "Net Worth": 0,
     "Spending › Overview": 0,
     "Spending › By Category": 0,
     "Spending › Classify": 0,
     "Spending › Recurring": 0,
-    "Spending › Transactions": 607,
+    "Spending › Transactions": 0,
   },
 };

--- a/web/tests/pinned.spec.js
+++ b/web/tests/pinned.spec.js
@@ -1,16 +1,30 @@
 /**
  * Pattern A: the pinned identity column, and the scroll ownership that comes with it.
  *
- * Eight tables across seven views exist so you can compare a number DOWN the column. Below
- * 1024px they are read through a window: the identity column is pinned, the rest scrolls
- * horizontally inside a wrapper, and the header stays put while the rows go by. This file
- * is the gate on all three halves plus the traps that make them fragile.
+ * Fourteen tables across ten views are read through a window below 1024px: the identity
+ * column is pinned, the rest scrolls horizontally inside a wrapper, and the header stays put
+ * while the rows go by. This file is the gate on all three halves plus the traps that make
+ * them fragile.
  *
  * WHY THE TIER IS 1024 AND NOT 640. The pin is worth *more* as the window narrows. At 640,
  * behind the 200px rail, the desktop table shows two identity columns and not one number,
  * and because `.main` owns the scroll there, reaching a number takes the identity away with
  * it — strictly worse than the phone. So every gate here runs at seven of the ten viewports,
  * and the other three assert the inverse: that nothing changed above the tier.
+ *
+ * EIGHT OF THE FOURTEEN EXIST BECAUSE A TABLE IS READ DOWN A COLUMN. The other six are the
+ * tablet tier's one rule: any table that overflows between 640 and 1024 is pinned regardless
+ * of its phone assignment, so both `Transactions` ledgers, `SecurityDetail`'s two histories,
+ * `Spending › Overview`'s top line items and `Dividends`' detail ledger joined — all of them
+ * tables that are a card list below 640 and so not in the DOM there at all. `tablesAt` is
+ * what keeps the two populations straight; `cardsBelow` on the entry is what marks them.
+ *
+ * THE SIXTH WAS FOUND BY A GATE RATHER THAN BY THE INVENTORY, which is worth the sentence.
+ * `Dividends`' detail ledger was already inside an inline `{ maxHeight: 520, overflow:
+ * "auto" }` box, so it never appeared in the pane-overflow ratchet and read as done — the
+ * same shape of blind spot that let four tables through the whole planning effort. What
+ * caught it is `tablet.spec.js` asserting that a *contained* table is not the tier's rule;
+ * the rule is the pin.
  *
  * WHAT IS ASSERTED AS A DECLARATION RATHER THAN AS GEOMETRY, and why — the same reasoning
  * `foundations.spec.js` opens with. `overscroll-behavior` being *unset* has no geometry: the
@@ -46,6 +60,14 @@ const viewportOf = (projectName) => VIEWPORTS.find((v) => v.name === projectName
  * Dividends is `null` because its column count is one per year and grows with time — which
  * is exactly why that table got horizontal scroll rather than anything that expires.
  *
+ * `cardsBelow` is the tablet tier showing through, and it is why this list is filtered by
+ * viewport rather than read straight. Five wrappers arrived with that tier — the pin now
+ * reaches any table that overflows between 640 and 1024, whatever its phone assignment — and
+ * every one of them sits in a branch `usePhone()` swaps for a card list below 640. So those
+ * tables are not merely unpinned on a phone, they are not in the DOM: the count of `.pinned`
+ * wrappers in a view is a function of the viewport, and `SecurityDetail`'s pinned tables even
+ * change *index*, which is the sort of thing a fixed list gets quietly wrong.
+ *
  * `unrendered` is the seam showing through, and it is written down rather than left as a
  * shorter list. Recurring's tracked monitor is behind a non-empty tracked list and the owner
  * tracks nothing, so the committed fixture is `[]` and that table does not render at all —
@@ -57,9 +79,35 @@ const viewportOf = (projectName) => VIEWPORTS.find((v) => v.name === projectName
 const PINNED = [
   { view: "Portfolio › Holdings", tables: [{ pin: "Security", cols: 13 }] },
   { view: "Portfolio › Performance", tables: [{ pin: "market", cols: 9 }] },
-  { view: "Portfolio › Dividends", tables: [{ pin: "Bucket", cols: null }] },
+  {
+    // The crosstab, then the detail ledger — which the tablet tier reached and which had
+    // been hiding behind an inline `{ maxHeight: 520, overflow: "auto" }`: contained, so the
+    // pane ratchet read zero for this view, and unpinned, so scrolling that box sideways at
+    // 640 lost the security name along with the date.
+    view: "Portfolio › Dividends",
+    tables: [{ pin: "Bucket", cols: null }, { pin: "Date", cols: 8, cardsBelow: true }],
+  },
   { view: "Portfolio › Options", tables: [{ pin: "Underlying", cols: 8 }] },
-  { view: "Portfolio › SecurityDetail", tables: [{ pin: "Contract", cols: 6 }] },
+  {
+    // Card-per-row on a phone, so at 390 there is one wrapper here and it is the options
+    // ledger; from 640 up there are two and the options ledger is the *second*. That index
+    // shift is the whole reason `tablesAt` exists rather than a per-view count.
+    view: "Portfolio › Transactions",
+    tables: [{ pin: "Date", cols: 8, cardsBelow: true }],
+  },
+  {
+    view: "Portfolio › SecurityDetail",
+    tables: [
+      { pin: "Date", cols: 8, cardsBelow: true },
+      { pin: "Contract", cols: 6 },
+    ],
+    unrendered: [
+      "SecurityDetail.jsx's dividend history (6 cols, pin `Date`) — PLTR is the row the " +
+      "suite drills into because it has the longest options history in the fixtures, and " +
+      "it has no dividends at all, so that branch never mounts",
+    ],
+  },
+  { view: "Spending › Overview", tables: [{ pin: "Category", cols: 4, cardsBelow: true }] },
   // Levels one and two of the spending drill. Level three is not a table on a phone at all —
   // `drill.spec.js` owns that half, and the structure the two levels meet in.
   { view: "Spending › By Category", tables: [{ pin: "Category", cols: 4 }] },
@@ -71,7 +119,19 @@ const PINNED = [
       "is `[]` in the committed fixtures, so the table is never mounted",
     ],
   },
+  { view: "Spending › Transactions", tables: [{ pin: "Date", cols: 6, cardsBelow: true }] },
 ];
+
+/**
+ * The tables of one view that are actually in the DOM at one viewport, in DOM order.
+ *
+ * Width alone, not the shell's width-or-height: card-per-row follows `usePhone()`, which the
+ * tablet tier deliberately left width-only. At 844×390 the navigation is the drawer and the
+ * tables are still tables — which is the split the tier was decided on, and this line is
+ * where the suite would notice it eroding.
+ */
+const tablesAt = (view, vp) =>
+  view.tables.filter((t) => !(t.cardsBelow && vp.width < PHONE_TIER_BELOW));
 
 /** The measurements one wrapper can be asked for, taken in a single round trip. */
 const wrapperFacts = (page, index) =>
@@ -110,11 +170,13 @@ const wrapperFacts = (page, index) =>
     };
   });
 
-for (const { view, tables, unrendered } of PINNED) {
+for (const entry of PINNED) {
+  const { view, unrendered } = entry;
   test.describe(view, () => {
     test("pins its identity column and scrolls the rest, with the header and its borders intact",
       async ({ page, baseURL }, testInfo) => {
         const vp = viewportOf(testInfo.project.name);
+        const tables = tablesAt(entry, vp);
         await openView(page, baseURL, view);
 
         for (const gap of unrendered ?? []) {
@@ -181,6 +243,7 @@ for (const { view, tables, unrendered } of PINNED) {
     test("the identity stays put while the numbers scroll under it", async ({ page, baseURL }, testInfo) => {
       const vp = viewportOf(testInfo.project.name);
       test.skip(vp.width >= PIN_TIER_BELOW, "above the tier there is no pin to hold still");
+      const tables = tablesAt(entry, vp);
       await openView(page, baseURL, view);
 
       for (let i = 0; i < tables.length; i++) {
@@ -213,6 +276,7 @@ for (const { view, tables, unrendered } of PINNED) {
     test("the header stays put while the rows go by", async ({ page, baseURL }, testInfo) => {
       const vp = viewportOf(testInfo.project.name);
       test.skip(vp.width >= PIN_TIER_BELOW, "above the tier the wrapper is not a scroll box");
+      const tables = tablesAt(entry, vp);
       await openView(page, baseURL, view);
 
       for (let i = 0; i < tables.length; i++) {
@@ -250,11 +314,12 @@ test.describe("the height that makes the sticky header work", () => {
 
       // Every wrapper first, because the criterion is about all of them and the pair below
       // only proves the two ends of it.
-      for (const { view, tables } of PINNED) {
+      for (const entry of PINNED) {
+        const { view } = entry;
         await openView(page, baseURL, view);
         const heights = await page.locator(".pinned")
           .evaluateAll((els) => els.map((el) => el.getBoundingClientRect().height));
-        expect(heights, `${view}: pattern-A wrappers`).toHaveLength(tables.length);
+        expect(heights, `${view}: pattern-A wrappers`).toHaveLength(tablesAt(entry, vp).length);
         for (const [i, h] of heights.entries()) {
           expect.soft(h, `${view} table ${i + 1} is taller than the cap`).toBeLessThanOrEqual(cap + 1);
         }
@@ -428,14 +493,16 @@ test.describe("Holdings' footnote", () => {
     });
 });
 
-test("numbers stay right-aligned and tabular in every pinned table", async ({ page, baseURL }) => {
+test("numbers stay right-aligned and tabular in every pinned table", async ({ page, baseURL }, testInfo) => {
+  const vp = viewportOf(testInfo.project.name);
   // Most of why the pattern won: you are reading the real table through a window rather than
   // a translation of it, so the two properties that make a column of money comparable at a
   // glance are untouched. They are asserted at every viewport including desktop, because the
   // claim is that the pattern costs them nothing anywhere.
-  for (const { view, tables } of PINNED) {
+  for (const entry of PINNED) {
+    const { view } = entry;
     await openView(page, baseURL, view);
-    for (let i = 0; i < tables.length; i++) {
+    for (let i = 0; i < tablesAt(entry, vp).length; i++) {
       const numeric = await page.locator(".pinned").nth(i).evaluate((wrap) => {
         // The first body cell with no `.l` — the app marks left-aligned columns and leaves
         // the numeric ones to the sheet's default.

--- a/web/tests/shell.spec.js
+++ b/web/tests/shell.spec.js
@@ -17,13 +17,24 @@
  *
  * THE LANDSCAPE CRITERION, PRECISELY. A rotated phone is 844px wide and therefore *exits*
  * the `max-width: 639.98px` block entirely, which is why the app bar's inset guard is
- * written unconditionally rather than inside it. The height guard that will make the shell
- * itself appear at 844×390 belongs to the tablet tier, not here; what this ticket owes is
- * that the guard is already in place wherever the bar renders. Both halves are asserted
- * below: the declaration is unconditional, and it is *not* in the phone block.
+ * written unconditionally rather than inside it. Both halves are asserted below: the
+ * declaration is unconditional, and it is *not* in the phone block.
+ *
+ * THE HEIGHT GUARD HAS LANDED, and it changed what this file covers rather than adding a
+ * section to it. `(max-height: 500px)` is the shell's second condition, so 844×390 now gets
+ * the drawer, the picker and the app bar — which means every gate in the first group runs
+ * there too and the guard is exercised eleven tests deep. What it did *not* bring is the tap
+ * floors: 44px targets are on the tier's "explicitly not done" list, so those stay behind
+ * `max-width` and the drawer at 844×390 holds ~38px rows. That split is asserted twice —
+ * once as geometry inside the drawer, once as a fact about which block each rule sits in.
  */
 import { expect, test } from "@playwright/test";
-import { PHONE_TIER_BELOW, PHONE_TIER_EDGE } from "./viewports.js";
+import {
+  PHONE_TIER_BELOW,
+  PHONE_TIER_EDGE,
+  SHELL_GUARD_EDGE,
+  onPhoneShell,
+} from "./viewports.js";
 import {
   VIEWS,
   drawer,
@@ -54,12 +65,18 @@ const boxOf = (locator) => locator.evaluate((el) => {
 
 // ─── the phone tier ─────────────────────────────────────────────────────────────────────
 
-test.describe("below 640px the navigation is a drawer and a picker", () => {
+test.describe("where the shell is the phone's, the navigation is a drawer and a picker", () => {
   // The `viewport` option fixture is the project's own size, which is what makes this read
-  // as "this group is the phone tier" rather than as a lookup into a table of names.
+  // as "this group is the shell's tier" rather than as a lookup into a table of names.
+  //
+  // WIDTH *OR* HEIGHT since the tablet tier landed, and that is the point of the group name
+  // changing: every gate below now runs at 844×390 as well, so the height guard is not
+  // asserted once in a dedicated test but exercised by the whole file. The three tests that
+  // still say "below 640" inside themselves are the tap floors, which the tier keeps
+  // width-only on purpose.
   test.skip(
-    ({ viewport }) => viewport.width >= PHONE_TIER_BELOW,
-    "the phone tier only — above 640 the rail and the tab strip are the navigation"
+    ({ viewport }) => !onPhoneShell(viewport),
+    "the shell's tier only — elsewhere the rail and the tab strip are the navigation"
   );
 
   test("the app bar replaces the rail and the strip", async ({ page, baseURL }) => {
@@ -117,7 +134,7 @@ test.describe("below 640px the navigation is a drawer and a picker", () => {
     });
 
   test("the drawer is the rail itself, holding every item it holds today",
-    async ({ page, baseURL }) => {
+    async ({ page, baseURL, viewport }) => {
       await openView(page, baseURL, "Portfolio › Overview");
       await menuButton(page).click();
 
@@ -150,11 +167,19 @@ test.describe("below 640px the navigation is a drawer and a picker", () => {
         })
       );
       expect(targets.length).toBeGreaterThan(0);
+
+      // THE FLOOR IS WIDTH-ONLY, AND THIS IS WHERE THAT DECISION IS VISIBLE. The drawer
+      // reaches 844×390 on the tablet tier's height guard, but 44px targets are on that
+      // tier's "explicitly not done" list — so at that one viewport the drawer holds the
+      // ~38px rows the rail has always had. Asserted as a *floor of its own* rather than
+      // skipped, because "the tap rule stopped applying" and "the drawer stopped rendering
+      // its items" look identical from a skip: 24px is WCAG 2.5.8, which holds everywhere.
+      const floor = viewport.width < PHONE_TIER_BELOW ? 44 : 24;
       for (const t of targets) {
         // Square, not tall: `--tap` was decided as a square floor, and `min(w, h)` is what
         // stops one selector writing it as height-only.
         expect.soft(Math.min(t.w, t.h), `"${t.text}" is ${Math.round(t.w)}x${Math.round(t.h)}`)
-          .toBeGreaterThanOrEqual(44);
+          .toBeGreaterThanOrEqual(floor);
       }
     });
 
@@ -339,8 +364,11 @@ test.describe("below 640px the navigation is a drawer and a picker", () => {
 
 // ─── above the tier ─────────────────────────────────────────────────────────────────────
 
-test.describe("at 640px and above the navigation is untouched", () => {
-  test.skip(({ viewport }) => viewport.width < PHONE_TIER_BELOW, "the tablet tier and up");
+test.describe("where the rail survives, the navigation is untouched", () => {
+  // The inverse of the group above, and it has to be written as the inverse rather than as
+  // "≥ 640": 844×390 is 844px wide and gets the drawer, so a width test alone would go
+  // looking for a 200px rail that is off-canvas and fail on the tier working correctly.
+  test.skip(({ viewport }) => onPhoneShell(viewport), "the tablet tier and up, in portrait");
 
   test("the rail is a rail, the strip is a strip, and the shell's new parts do not render",
     async ({ page, baseURL }) => {
@@ -393,9 +421,14 @@ test("the app bar's safe-area guard is unconditional, not inside the phone block
       .toBe("content-box");
 
     const phone = rules.filter((r) => r.media?.includes(PHONE_TIER_EDGE));
-    expect(phone, "`.bar` has more than a display flip in the phone block").toHaveLength(1);
-    expect(Object.keys(phone[0].decls), "the phone block should only turn the bar on")
+    expect(phone, "`.bar` has more than a display flip in the shell block").toHaveLength(1);
+    expect(Object.keys(phone[0].decls), "the shell block should only turn the bar on")
       .toEqual(["display"]);
+    // ...and it is the *shell* block, not the phone block. The bar is what a rotated phone
+    // navigates by, so a `display: flex` behind width alone would leave 844×390 with a
+    // hidden bar, no rail-replacement and no way to change tab at all.
+    expect(phone[0].media, "the app bar is turned on by width alone — 844×390 gets no bar")
+      .toContain(SHELL_GUARD_EDGE);
   });
 
 test("the content pane's landscape guard is unconditional too", async ({ page, baseURL }) => {

--- a/web/tests/support/app.js
+++ b/web/tests/support/app.js
@@ -6,16 +6,21 @@
  * test, not a shortcut: the same clicks are what a person does, which is what makes the
  * gates measure a real render rather than a mounted component.
  *
- * BELOW 640px THE CLICKS ARE DIFFERENT ONES, because the navigation is. The rail is behind
- * a hamburger and the tab strip is a native `<select>`, so `openView` branches on the
- * viewport rather than on a flag: every caller keeps asking for "Spending › Recurring" and
- * gets there the way a person on that viewport would. This is the whole reason the phone
- * shell is the ticket that unblocks the rest — until it lands, no phone behaviour past the
- * first screen can be reached at all.
+ * WHERE THE SHELL IS THE PHONE'S, THE CLICKS ARE DIFFERENT ONES, because the navigation is.
+ * The rail is behind a hamburger and the tab strip is a native `<select>`, so `openView`
+ * branches on the viewport rather than on a flag: every caller keeps asking for
+ * "Spending › Recurring" and gets there the way a person on that viewport would. This is the
+ * whole reason the phone shell is the ticket that unblocks the rest — until it lands, no
+ * phone behaviour past the first screen can be reached at all.
+ *
+ * THAT BRANCH IS NOT "BELOW 640px" ANY MORE. The tablet tier put the shell on a height guard
+ * as well, so 844×390 gets the drawer and the picker with a 844px width — see `onPhoneShell`
+ * in `viewports.js`. Every gate that reaches a view at that viewport goes through this file,
+ * so the guard is exercised thirteen views deep rather than only where it is asserted.
  */
 import { expect } from "@playwright/test";
 import { fixtureFor } from "../fixtures/index.js";
-import { PHONE_TIER_BELOW } from "../viewports.js";
+import { onPhoneShell } from "../viewports.js";
 
 /**
  * Serve every API call from committed fixtures and cut the page off from the network.
@@ -84,8 +89,17 @@ async function settle(page, anchor) {
   await expect(anchor(page).first()).toBeVisible({ timeout: 20_000 });
 }
 
-/** True when the viewport is inside the phone tier, where navigation is the drawer. */
-export const onPhone = (page) => page.viewportSize().width < PHONE_TIER_BELOW;
+/**
+ * True when the viewport gets the phone navigation shell, where navigation is the drawer.
+ *
+ * WIDTH *OR* HEIGHT, since the tablet tier landed. A rotated phone is 844px wide and so
+ * leaves the phone tier by width, but its 390px of height is what the drawer was chosen
+ * against in the first place — so the shell follows `(max-height: 500px)` too, and this
+ * helper has to ask the same question the stylesheet does or every gate at 844×390 would go
+ * looking for a tab strip that is `display: none`. It is the navigation alone: the pin, the
+ * cards, the charts and the gutter are all still width-only.
+ */
+export const onPhone = (page) => onPhoneShell(page.viewportSize());
 
 /** The drawer's parts, named once so a rename breaks in one place rather than eleven. */
 export const menuButton = (page) => page.getByTestId("menu");

--- a/web/tests/support/tables.js
+++ b/web/tests/support/tables.js
@@ -1,0 +1,72 @@
+/**
+ * Reading the tables in a rendered view: how wide each one is, and what absorbs its width.
+ *
+ * Two specs ask the same question of different views, which is why this is a module and not
+ * a helper in either of them — `support/css.js` opens with the same sentence for the same
+ * reason. `editors.spec.js` asks it of the two desktop-optimised views, against their own
+ * four criteria; `tablet.spec.js` asks it of the other eleven, against the tablet tier's one
+ * rule. The measurement is identical and the *verdicts* differ: an editor owes a container,
+ * a fully-responsive view owes a container **and a pin**. Keeping one reader is what stops
+ * those two verdicts drifting apart on the evidence rather than on the standard.
+ */
+
+/**
+ * Every `<table>` under `.main`, described.
+ *
+ * `container` is the nearest ancestor short of `.main` that scrolls horizontally — the box a
+ * sideways swipe actually moves. "Sideways scroll is confined to a container that visibly is
+ * a table" is not a claim about appearance that a test can make; what it reduces to
+ * structurally is the next three fields:
+ *
+ *   - `wrapsTableAlone` — the box holds the table and nothing else, so what slides under your
+ *     finger is the grid of numbers rather than the card, the heading and the save button
+ *     with it. The rule modal's own `overflow: auto` absorbs its table's width and would pass
+ *     any weaker reading while sliding Cancel off the edge.
+ *   - `fitsItsParent` — and the box does not itself push its parent wide, which is how an
+ *     "absorbing" wrapper that absorbs nothing passes the other two.
+ *   - `pinnedFirstCell` — the identity column inside it is `sticky`. Only the fully-responsive
+ *     views owe this one; the editors' cells hold live inputs and neither table pattern
+ *     applies to them.
+ *
+ * `room` IS THE TABLE'S OWN PARENT, NOT THE PANE, and the difference is a whole other ticket.
+ * `.grid2`'s `minmax(420px, 1fr)` track floor is wider than a 360px pane, so on four views a
+ * table that fits its card perfectly well sits inside a box that does not fit the pane.
+ * Measured against the pane those read as unpinned overflowing tables and a sweep would
+ * demand a wrapper that fixes nothing; measured against the parent they are what they are —
+ * #44's residual, and the pane ratchet's.
+ */
+export function tableFacts(page) {
+  return page.evaluate(() => {
+    const main = document.querySelector(".main");
+    const name = (el) => {
+      const cls = typeof el.className === "string" && el.className
+        ? "." + el.className.trim().split(/\s+/).join(".") : "";
+      return el.tagName.toLowerCase() + cls;
+    };
+    return [...main.querySelectorAll("table")].map((t) => {
+      let box = null;
+      for (let el = t.parentElement; el && el !== main; el = el.parentElement) {
+        const ox = getComputedStyle(el).overflowX;
+        if (ox === "auto" || ox === "scroll") { box = el; break; }
+      }
+      const headers = [...t.querySelectorAll("thead th")]
+        .map((th) => th.textContent.trim()).filter(Boolean);
+      return {
+        table: headers.slice(0, 2).join("/") || "(unheaded)",
+        width: t.getBoundingClientRect().width,
+        room: t.parentElement.clientWidth,
+        pinned: box ? box.classList.contains("pinned") : null,
+        container: box ? name(box) : null,
+        wrapsTableAlone: box ? box.children.length === 1 && box.firstElementChild === t : null,
+        fitsItsParent: box
+          ? box.getBoundingClientRect().width <= box.parentElement.clientWidth + 1
+          : null,
+        // `:not(.grouprow)` for the reason the stylesheet excludes it: Holdings' group banner
+        // is a `colSpan` cell as wide as seven columns and is deliberately not pinned.
+        pinnedFirstCell: box
+          ? getComputedStyle(t.querySelector("tbody tr:not(.grouprow) > *") ?? t).position
+          : null,
+      };
+    });
+  });
+}

--- a/web/tests/tablet.spec.js
+++ b/web/tests/tablet.spec.js
@@ -1,0 +1,336 @@
+/**
+ * The tablet tier, 640–1024px — and the shorter half of this file is the point.
+ *
+ * The tier holds **exactly one rule**: the pinned-column pattern extends to any table that
+ * overflows in it, regardless of that table's phone assignment. Everything the tier was
+ * expected to hold went unconditional and stopped being a tier item (`.grid2`'s `auto-fit`,
+ * `.tabs`' wrap, `.refresh-btn`'s `flex: none`, `.main`'s landscape inset guards), stayed
+ * unchanged (the 200px rail), or moved to a *height* guard (the navigation shell). So most
+ * of what this file asserts is that things did **not** happen — no cards, no enlarged tap
+ * targets, no resized inputs, no second design — because a cheap tier is exactly the kind of
+ * thing that quietly turns into an expensive one.
+ *
+ * WHY THE LANDSCAPE SPLIT IS A HEIGHT AND NOT AN ORIENTATION. Each half follows the axis its
+ * own decision was argued on. The shell was chosen on a vertical budget — 48px of chrome
+ * against a bottom section bar's 147px — so it takes `(max-height: 500px)`; tables and charts
+ * were chosen on horizontal room, so they stay width-only, which is also what leaves
+ * `cards.jsx`'s `matchMedia` hook untouched by this tier. The forcing measurement: at 844×390
+ * the tier's own chrome costs 107px, 27% of the screen, where the shell rejected its own
+ * always-visible alternative at 21%.
+ *
+ * WHAT IS ASSERTED ELSEWHERE, so this file does not restate it. `pinned.spec.js` owns the
+ * pattern itself — the border model, the z-index layering, the sticky header, the cap — for
+ * all thirteen wrappers including the five that arrived with this tier. `shell.spec.js` owns
+ * the drawer, and since the height guard landed its first group *runs* at 844×390, so the
+ * guard is exercised eleven tests deep there rather than asserted once. `hscroll-baseline.js`
+ * owns the pane-overflow ratchet, which this tier took to zero at `ipad-portrait` and
+ * `rotated-phone` outright. What is here is the tier's own boundary.
+ */
+import { expect, test } from "@playwright/test";
+import {
+  HSCROLL_GATE_APPLIES_BELOW,
+  PHONE_TIER_BELOW,
+  PHONE_TIER_EDGE,
+  PIN_TIER_BELOW,
+  PIN_TIER_EDGE,
+  SHELL_GUARD_EDGE,
+  SHELL_HEIGHT_GUARD,
+  VIEWPORTS,
+} from "./viewports.js";
+import { VIEWS, loadApp, openView } from "./support/app.js";
+import { declarationsFor } from "./support/css.js";
+// The same reader `editors.spec.js` uses, and deliberately the same one: the measurement is
+// identical across all thirteen views and only the *verdict* differs — an editor owes a
+// container, a fully-responsive view owes a container and a pin. See `support/tables.js`.
+import { tableFacts } from "./support/tables.js";
+
+const viewportOf = (projectName) => VIEWPORTS.find((v) => v.name === projectName);
+
+/**
+ * The eleven views the universal gates apply to.
+ *
+ * `Classify` and `NetWorth` are desktop-optimised by decision and are checked against their
+ * own four criteria instead — `editors.spec.js` holds those, including the containment gate
+ * this file's first sweep is the fully-responsive twin of. Naming them here rather than
+ * filtering on a flag keeps the carve-out visible: two views are exempt, and it is a
+ * decision rather than an omission.
+ */
+const EDITORS = ["Spending › Classify", "Net Worth"];
+const RESPONSIVE_VIEWS = VIEWS.map((v) => v.name).filter((n) => !EDITORS.includes(n));
+
+test.describe("the tier's one rule: any table that overflows is pinned", () => {
+  // The pin's tier, which is also the pane-overflow gate's — see `PIN_TIER_BELOW`. Above it
+  // the desktop table is what it always was and `.main` absorbing a wide table is what
+  // desktop has always done; Holdings is 1272px against 1024px at a 1280px viewport.
+  test.skip(({ viewport }) => viewport.width >= PIN_TIER_BELOW,
+    "at and above 1024 the pin does not apply and the pane may scroll");
+
+  for (const viewName of RESPONSIVE_VIEWS) {
+    test(viewName, async ({ page, baseURL }, testInfo) => {
+      await openView(page, baseURL, viewName);
+      const tables = await tableFacts(page);
+
+      // A view can legitimately render no table at a given viewport — card-per-row replaces
+      // six of them below 640 — so an empty sweep is reported rather than failed. What it
+      // must not do is pass silently as "all tables contained".
+      if (tables.length === 0) {
+        testInfo.annotations.push({
+          type: "no-tables-here", description: `${viewName} renders no <table> at this viewport`,
+        });
+        return;
+      }
+
+      for (const t of tables) {
+        if (!t.container) {
+          // No wrapper is the right answer for a table that fits — adding one for symmetry
+          // is how a tier stops being cheap. So the gate on an unwrapped table is that it
+          // genuinely fits, and the wrapped ones fall through to the four below.
+          expect.soft(Math.round(t.width),
+            `"${t.table}" overflows its container by ${Math.round(t.width - t.room)}px with ` +
+            "nothing to absorb it — the tier's rule is that it gets the pin")
+            .toBeLessThanOrEqual(t.room + 1);
+          testInfo.annotations.push({
+            type: "fits-outright",
+            description: `${viewName} · "${t.table}" ${Math.round(t.width)}px in ${t.room}px`,
+          });
+          continue;
+        }
+        expect.soft(t.wrapsTableAlone,
+          `"${t.table}" scrolls inside ${t.container}, which holds more than the table`).toBe(true);
+        expect.soft(t.fitsItsParent,
+          `${t.container} is wider than its own parent — it absorbs nothing`).toBe(true);
+        // The tier's rule is the *pin*, not merely a scroll box. A wrapper with no pinned
+        // identity column passes both gates above and is exactly the "untouched" answer this
+        // tier measured and rejected: you reach a number and lose the row it belongs to.
+        expect.soft(t.pinned,
+          `"${t.table}" is contained but not pinned — the tier's rule is pattern A`).toBe(true);
+        expect.soft(t.pinnedFirstCell,
+          `"${t.table}" has a .pinned wrapper but its identity column is not sticky`)
+          .toBe("sticky");
+      }
+    });
+  }
+});
+
+test("card-per-row does not render at 640px or above", async ({ page, baseURL }, testInfo) => {
+  const vp = viewportOf(testInfo.project.name);
+  test.skip(vp.width < PHONE_TIER_BELOW, "below 640 the cards are the point");
+
+  // Pattern B is phone-only by decision, and the decision is a measurement rather than a
+  // preference: cards trade density for readability at 390px, and `spending/Transactions` is
+  // 1196px natural but fits a 900px pane outright, so cards there would lose rows and buy
+  // nothing. The tier extends the *pin* instead.
+  //
+  // ASSERTED AT 844×390 TOO, WHICH IS THE INTERESTING ONE. That viewport gets the phone
+  // *shell*, so the temptation — and the mistake this gate exists to catch — is to hand it
+  // the phone's tables as well by putting `usePhone()` behind the same guard. The tier
+  // deliberately did not: the hook is width-only and untouched by this ticket.
+  for (const viewName of RESPONSIVE_VIEWS) {
+    await openView(page, baseURL, viewName);
+    expect.soft(await page.locator(".rowcard").count(), `${viewName} renders row cards`).toBe(0);
+    expect.soft(await page.locator(".cardgroup").count(), `${viewName} renders a card group`).toBe(0);
+  }
+});
+
+test.describe("the shell follows height; the tables and charts follow width", () => {
+  test("the shell block carries both arms, and the tap floors carry only the width one",
+    async ({ page, baseURL }) => {
+      await loadApp(page, baseURL);
+
+      // The drawer is the shell's centrepiece and the rule that makes it one is `.side`'s
+      // `position: absolute`. It has to be under both arms or a rotated phone keeps the rail.
+      const drawer = (await declarationsFor(page, ".side"))
+        .filter((r) => r.decls.position === "absolute");
+      expect(drawer, "`.side` is turned into a drawer in more than one place").toHaveLength(1);
+      expect(drawer[0].media, "the drawer is width-only — 844×390 keeps the 200px rail")
+        .toContain(SHELL_GUARD_EDGE);
+
+      // And the floor that is NOT the shell's. 44px targets are on the tier's "explicitly
+      // not done" list, so `.navitem`'s floor stays behind width alone. Written as an
+      // assertion rather than left implicit because the two rules now sit in adjacent blocks
+      // whose conditions differ by one clause, which is the easiest edit in the file to get
+      // wrong — and getting it wrong hands a 44px pitch to any desktop window under 500px
+      // tall, which is the "desktop is unchanged" line.
+      const tap = (await declarationsFor(page, ".navitem"))
+        .filter((r) => r.decls["min-height"] !== undefined);
+      expect(tap, "`.navitem`'s tap floor is declared in more than one place").toHaveLength(1);
+      expect(tap[0].media, "the tap floor followed the shell onto the height guard")
+        .not.toContain(SHELL_GUARD_EDGE);
+    });
+
+  test("at 844×390 the navigation is the phone's and the content is not",
+    async ({ page, baseURL }, testInfo) => {
+      const vp = viewportOf(testInfo.project.name);
+      test.skip(vp.height > SHELL_HEIGHT_GUARD, "the height-guarded viewport only");
+
+      // The shell half: a column, an app bar, and the rail off-canvas — at 844px wide, which
+      // is a width the phone tier does not reach. Nothing here is a width claim.
+      await openView(page, baseURL, "Spending › Transactions");
+      await expect(page.locator(".bar"), "no app bar at 844×390 — the guard is not firing")
+        .toBeVisible();
+      await expect(page.locator(".main > .tabs")).toBeHidden();
+      expect(await page.locator(".app").evaluate((el) => getComputedStyle(el).flexDirection))
+        .toBe("column");
+      expect(await page.locator(".side").evaluate((el) => getComputedStyle(el).position))
+        .toBe("absolute");
+
+      // The content half, which did *not* follow: the ledger is a real table behind a pin,
+      // not a card list. This is the split the tier was decided on, in one screen.
+      await expect(page.locator(".rowcard"), "the tables followed the shell onto height")
+        .toHaveCount(0);
+      await expect(page.locator(".pinned table")).toHaveCount(1);
+
+      // ...and the charts did not follow either. `charts.jsx` drops the donut through the
+      // same width-only hook, so a rotated phone keeps all three.
+      await openView(page, baseURL, "Spending › Overview");
+      expect(await page.locator(".recharts-responsive-container").count(),
+        "the donut was dropped at 844×390 — the chart hook is following height")
+        .toBeGreaterThan(0);
+      testInfo.annotations.push({ type: "height-guard", description: `${vp.name} · shell yes, content no` });
+    });
+});
+
+test("tap targets are not enlarged and inputs are not resized above the phone tier",
+  async ({ page, baseURL }, testInfo) => {
+    const vp = viewportOf(testInfo.project.name);
+    test.skip(vp.width < PHONE_TIER_BELOW, "below 640 both floors apply and are asserted elsewhere");
+
+    // The tier's "explicitly not done" list, as geometry. A tablet row keeps desktop's
+    // `th, td { padding: 7px 10px }` and its measured ~33px pitch: above WCAG 2.5.8's 24px
+    // floor, below the phone's 44px comfort target. `@media (pointer: coarse)` is the
+    // technically right instrument for the real complaint and was rejected — it fires on
+    // touchscreen laptops, handing desktop the 44px pitch and breaking "desktop unchanged".
+    // Residual accepted and written down: an iPad user gets 33px rows.
+    //
+    // `Performance` RATHER THAN `Holdings`, and the difference is what the number means.
+    // Holdings' identity cell carries a second line — the accounts a position is held in —
+    // so it measures 52px whatever the tier does, and a gate that read it would be asserting
+    // the shape of that one cell rather than the tier's row pitch. Performance is
+    // single-line in every column, so its rows are the padding rule and nothing else.
+    await openView(page, baseURL, "Portfolio › Performance");
+    const row = await page.locator(".pinned tbody tr:not(.grouprow) > *").first()
+      .evaluate((el) => el.getBoundingClientRect().height);
+    expect(row, "table rows grew to the phone's tap floor above 640").toBeLessThan(44);
+    expect(row, "table rows fell below WCAG 2.5.8's floor").toBeGreaterThanOrEqual(24);
+
+    // ...and neither floor arrived anywhere else in the pane, ACROSS EVERY VIEW rather than
+    // on the one the row above came from. Both mistakes take the same shape — a phone rule
+    // reaching the tier through a selector nobody thought of — and a sweep of a single view
+    // would be the weakest possible reading of "not enlarged anywhere".
+    //
+    // 16 IS THE NUMBER FOR THE SECOND HALF, not "unchanged". The inputs exist at 16px for
+    // iOS Safari's `16/fontSize` focus-zoom, which iPadOS Safari does not do — the
+    // least-verified claim in the tier, flagged for a real device rather than trusted, but
+    // the *rule* not existing above 640 is checkable here. The set is legitimately more than
+    // one size: the "show excluded" checkbox inherits 13px from its label at every width. A
+    // control that arrived at exactly 16 arrived from the phone tier. Scoped under `.main`,
+    // because the app bar's tab picker is 16px unconditionally — a property of that control
+    // rather than a tier rule — and at 844×390 the bar is on screen.
+    for (const viewName of RESPONSIVE_VIEWS) {
+      await openView(page, baseURL, viewName);
+      const found = await page.evaluate(() => {
+        const describe = (el) => el.tagName.toLowerCase()
+          + (el.className ? "." + String(el.className).trim().split(/\s+/).join(".") : "");
+        const out = { tapped: [], sizes: [] };
+        // EXACTLY `44px`, ON EITHER AXIS, rather than ">= 44". The subject is the `--tap`
+        // token reaching the tier, and the token is a specific number; ">= 44" is a different
+        // claim — "nothing in the pane is tall or wide" — which the app contradicts for
+        // ordinary layout reasons that have nothing to do with touch. Holdings' Net cell is
+        // `min-width: 110px` so its bar has a lane to draw in, and two of Recurring's inputs
+        // are 150 and 180 so their placeholders fit. A gate that flagged those would be
+        // reporting the layout back to itself.
+        for (const el of document.querySelectorAll(".main *")) {
+          const s = getComputedStyle(el);
+          if (s.minHeight === "44px" || s.minWidth === "44px") out.tapped.push(describe(el));
+        }
+        for (const el of document.querySelectorAll(".main input, .main select, .main textarea")) {
+          if (parseFloat(getComputedStyle(el).fontSize) >= 16) out.sizes.push(describe(el));
+        }
+        return out;
+      });
+      expect.soft([...new Set(found.tapped)],
+        `${viewName}: the 44px floor reached the content pane above 640`).toEqual([]);
+      expect.soft([...new Set(found.sizes)],
+        `${viewName}: a form control was resized to the iOS focus-zoom floor above the phone tier`)
+        .toEqual([]);
+    }
+    testInfo.annotations.push({
+      type: "tier-boundary",
+      description: `${vp.name} · row ${Math.round(row)}px · ${RESPONSIVE_VIEWS.length} views swept`,
+    });
+  });
+
+test("the tier invents nothing — no rule of its own between 640 and 1024",
+  async ({ page, baseURL }) => {
+    await loadApp(page, baseURL);
+
+    // THE CLAIM THE WHOLE TIER RESTS ON, asserted against the shipped stylesheet: there is no
+    // `min-width: 640px` block, and no `(max-width: 1023.98px)` block beyond the two that
+    // predate this ticket — `.contained`, which is the editors' containment, and `.pinned`,
+    // which is pattern A. The tier extends an existing rule to more tables; it does not add
+    // a rule. A `@media (min-width: 640px) and (max-width: 1023.98px)` appearing here is the
+    // second design the map's brief forbids, arriving one convenient block at a time.
+    const conditions = await page.evaluate(() => {
+      const found = [];
+      const walk = (rules) => {
+        for (const rule of rules) {
+          if (rule.conditionText !== undefined && rule.cssRules) found.push(rule.conditionText);
+          if (rule.cssRules) walk(rule.cssRules);
+        }
+      };
+      for (const sheet of document.styleSheets) {
+        try { walk(sheet.cssRules); } catch { /* a cross-origin sheet, if one ever appears */ }
+      }
+      return found;
+    });
+    expect(conditions.filter((c) => /min-width|width>=/.test(c)),
+      "a tier floor appeared — the tablet tier is relaxations of existing rules only")
+      .toEqual([]);
+    // EVERY MEDIA CONDITION IN THE SHIPPED SHEET, ENUMERATED — three, and each one named by
+    // the number that identifies it. A count on its own would be satisfied by deleting the
+    // phone block, and a `<=` bound asserts nothing at all; what makes this a gate is that
+    // the three are the three, and that the tier added none of its own.
+    //
+    // THIS IS ALSO WHERE `500` IS CROSS-CHECKED. It is written twice — the stylesheet's shell
+    // block and `tests/viewports.js`'s `SHELL_GUARD_EDGE` — for the reason `640` is written
+    // four times: no build step makes a shared constant. `inventory.spec.js` counts the `640`
+    // sites and character-checks the two JS queries; this is the equivalent for the shell
+    // guard, and it is stronger than a count, because it reads the *shipped* condition rather
+    // than the source that produced it.
+    const distinct = [...new Set(conditions)];
+    const named = `shipped media conditions: ${distinct.join(" ; ")}`;
+    expect(distinct, named).toHaveLength(3);
+    expect(distinct.filter((c) => c.includes(PIN_TIER_EDGE) && !c.includes(PHONE_TIER_EDGE)),
+      `${named} — the pin tier's own block`).toHaveLength(1);
+    expect(distinct.filter((c) => c.includes(PHONE_TIER_EDGE) && c.includes(SHELL_GUARD_EDGE)),
+      `${named} — the shell's two arms, width OR height`).toHaveLength(1);
+    expect(distinct.filter((c) => c.includes(PHONE_TIER_EDGE) && !c.includes(SHELL_GUARD_EDGE)),
+      `${named} — the phone tier, width alone`).toHaveLength(1);
+  });
+
+test("the pane's remaining overflow in the tier is not a table", async ({ page, baseURL }, testInfo) => {
+  const vp = viewportOf(testInfo.project.name);
+  test.skip(vp.width >= HSCROLL_GATE_APPLIES_BELOW, "no pane gate above 1024");
+  test.skip(vp.width < PHONE_TIER_BELOW, "the tier, not the phone — below 640 the ratchet owns this");
+
+  // The acceptance criterion in its strongest checkable form. `hscroll-baseline.js` is a
+  // ratchet on *how much* the pane overflows and is deliberately allowed to be non-zero while
+  // `.grid2`'s 420px track floor is still #44's; this asserts the part that is this ticket's,
+  // which is that none of what is left is a table. Both are needed: the ratchet would go
+  // green on a build that swapped a table's overflow for a wider one somewhere else, and this
+  // would go green on a build that let the residual grow.
+  // ALL THIRTEEN VIEWS, the two editors included — which is what this adds over the sweep at
+  // the top of the file. That one runs on the eleven fully-responsive views and asks whether
+  // a table overflows *its own parent*; this asks the pane's question of every view in the
+  // app, so the editors' wrappers are held to it too rather than only to their own criteria.
+  const offenders = [];
+  for (const viewName of VIEWS.map((v) => v.name)) {
+    await openView(page, baseURL, viewName);
+    const pane = await page.evaluate(() => document.querySelector(".main").clientWidth);
+    for (const t of await tableFacts(page)) {
+      if (t.container === null && t.width > pane + 1) offenders.push(`${viewName} · ${t.table}`);
+    }
+  }
+  expect(offenders, "a table is handing its width straight to the pane").toEqual([]);
+  testInfo.annotations.push({ type: "pane", description: `${vp.name} · no table-shaped overflow` });
+});

--- a/web/tests/unconditional.spec.js
+++ b/web/tests/unconditional.spec.js
@@ -26,7 +26,7 @@
  * `HSCROLL_GATE_APPLIES_BELOW`.
  */
 import { expect, test } from "@playwright/test";
-import { PHONE_TIER_BELOW, VIEWPORTS } from "./viewports.js";
+import { VIEWPORTS, onPhoneShell } from "./viewports.js";
 import { openView } from "./support/app.js";
 
 const viewportOf = (projectName) => VIEWPORTS.find((v) => v.name === projectName);
@@ -54,13 +54,17 @@ function boxes(page, sel) {
 }
 
 test.describe("the refresh control keeps its natural size and its label on one line", () => {
-  // Scoped to 640 and up when the phone shell landed, because below it this control no
-  // longer exists to measure: the labelled button and the whole `.tabs-right` group it sits
-  // in are `display: none`, and Refresh is an icon in the app bar instead. The claim itself
-  // did not weaken — a labelled button that fits on one line is still unconditional
-  // *wherever the label renders*. `shell.spec.js` owns the icon's own gates below 640.
-  test.skip(({ viewport }) => viewport.width < PHONE_TIER_BELOW,
-    "below 640 the labelled control is replaced by the app bar's icon");
+  // Scoped to where the strip renders when the phone shell landed, because elsewhere this
+  // control does not exist to measure: the labelled button and the whole `.tabs-right` group
+  // it sits in are `display: none`, and Refresh is an icon in the app bar instead. The claim
+  // itself did not weaken — a labelled button that fits on one line is still unconditional
+  // *wherever the label renders*. `shell.spec.js` owns the icon's own gates.
+  //
+  // `onPhoneShell`, NOT `< 640`. The tablet tier put the shell on a height guard as well, so
+  // 844×390 is 844px wide and has no labelled Refresh either — a width test alone looks for
+  // a button that is `display: none` and reads its box as `null`.
+  test.skip(({ viewport }) => onPhoneShell(viewport),
+    "where the shell is the phone's, the labelled control is replaced by the app bar's icon");
 
   test("Portfolio › Overview", async ({ page, baseURL }) => {
     await openView(page, baseURL, "Portfolio › Overview");

--- a/web/tests/viewports.js
+++ b/web/tests/viewports.js
@@ -45,6 +45,39 @@ export const PHONE_TIER_BELOW = 640;
 export const PHONE_TIER_EDGE = "639.98px";
 
 /**
+ * The height at and below which the *navigation shell* is the phone's, whatever the width.
+ *
+ * The tablet tier's landscape answer, and the second place `500` is written — `styles.css`'s
+ * shell block is the other, and the two cross-reference in comments for the reason `640`
+ * does across four files: JS cannot read a custom property and this repo takes no build step
+ * to make one.
+ *
+ * IT IS A HEIGHT AND NOT AN ORIENTATION, and only the shell has it. The shell was chosen on
+ * a vertical budget — 48px of chrome against a bottom bar's 147px — so height is the axis it
+ * was arguing about; tables and charts were chosen on horizontal room and stay width-only,
+ * which is why `usePhone()` is untouched by the tier. At 844×390 the tablet tier's own chrome
+ * costs 27% of the screen, where the shell rejected its own alternative at 21%.
+ *
+ * Every phone landscape height is at most 430 and every iPad landscape height is at least
+ * 744, so 500 has ~314px of slack on both sides and `rotated-phone` is the only viewport in
+ * the suite that trips it.
+ */
+export const SHELL_HEIGHT_GUARD = 500;
+export const SHELL_GUARD_EDGE = "500px";
+
+/**
+ * True when a viewport gets the phone navigation shell — the drawer, the app bar and the tab
+ * picker — rather than the rail and the strip.
+ *
+ * Two arms, because the shell has two conditions. Everything else in the suite that asks
+ * "is this the phone tier" still asks about width alone, and that is the split the tier
+ * decided rather than an inconsistency: the pin, the cards, the charts and the gutter all
+ * follow width, and only the navigation follows height as well.
+ */
+export const onPhoneShell = (vp) =>
+  vp.width < PHONE_TIER_BELOW || vp.height <= SHELL_HEIGHT_GUARD;
+
+/**
  * The width below which the pinned-column pattern applies — the phone tier and the tablet
  * tier together, because the pin is worth *more* as the window narrows, not less.
  *


### PR DESCRIPTION
Closes #33.

The tier holds **exactly one rule**: the pinned identity column extends to any table that overflows between 640 and 1024, regardless of that table's phone assignment. Everything else the tier was expected to hold had already gone unconditional, stayed unchanged, or moves here onto a height guard.

## The one rule

Six wrappers arrived — both `Transactions` ledgers, `SecurityDetail`'s two histories, `Spending › Overview`'s top line items and `Dividends`' detail ledger. Each pins the column that was **already first**. No merge, no reorder, nothing that reaches desktop: `contract.jsx`'s merged identity cell exists because that table led with `Type`, 46px of `Put / Put / Call`, a column that cannot tell two rows apart at any width. A date is not that — it varies per row and these ledgers arrive ordered by it.

`Merchant` was rejected as `spending/Transactions`' pin on a measurement rather than a preference: the column is **561px** of unbounded free text out of the bank statements, and a 561px pin in a 440px window covers the screen and never lets a number through. Bounding it would be a second rule in a tier whose whole claim is that it holds one. Recorded as an open call, with the way out (a merged cell, at every width) named.

**The sixth is the one that was hiding.** `Dividends`' detail ledger already sat in an inline `{ maxHeight: 520, overflow: "auto" }` box, so it never overflowed the pane and never appeared in the ratchet — *contained* read as done, while at 640 you swiped it sideways and lost the security name along with the date. It was found by a gate, not by the inventory: `tablet.spec.js` asserts that a contained table is not the tier's rule, because the rule is the **pin**.

The inline `max-height` had to go — it beats the pattern's `60svh` outright, 520 against 234 at 844×390. The *number* stays as `--selfscroll: 520px`; a custom property is not a `max-height`, so it never enters the specificity fight and desktop is unchanged to the pixel.

## Landscape, split by axis

Each half follows the axis its own decision was argued on. The shell was chosen on a **vertical** budget — 48px of chrome against a bottom bar's 147px — so it gains `(max-height: 500px)` and 844×390 gets the drawer. Tables and charts were chosen on **horizontal** room, so they stay width-only, which is also what leaves `usePhone()` untouched by this ticket.

The 44px tap floor deliberately does **not** travel: 44px targets are on the tier's own "explicitly not done" list. So a rotated phone opens a drawer with ~38px rows. `shell.spec.js` asserts a 24px floor there rather than skipping — the geometry is gated, only comfort is open — and it is recorded as a fifth real-iPhone item on #34.

## The ratchet

Falls a **seventh** time. `ipad-portrait` and `rotated-phone` go to **zero across all thirteen views**; `rotated-phone` needed both halves of this ticket, since at 844×390 the ledgers still wanted 1196px against a 788px pane once the rail had gone.

Nothing table-shaped is left in `hscroll-baseline.js`. The five remaining rows are one cause — `.grid2`'s `minmax(420px, 1fr)` track floor — and that is #44's, which is now the last ticket standing between the file and being deleted for a `<= 0` gate.

## Tests

`tablet.spec.js` is the tier's own gate, and most of it asserts **absences**, because a cheap tier is exactly the kind of thing that quietly turns into an expensive one: no card-per-row at 640 and above, no enlarged tap targets, no resized inputs, and every media condition in the shipped sheet **enumerated and named** — a `min-width` block appearing at all is the second design the brief forbids. That enumeration is also where `500` is cross-checked, the same job `inventory.spec.js` does for `640`.

`support/tables.js` is now the one table reader both it and `editors.spec.js` use.

- **1237 Playwright pass / 0 fail** across ten viewports
- **258 pytest pass** (untouched by this change)

## Known gaps, deliberately

- **AC7 is not met at 640.** Five views still overflow by 8px — `.grid2`'s track floor, #44's, unreachable by the pin.
- **768 and 1000 have no automated coverage.** Both were measured by hand on the production build (every view read 0) and that is written into `RESPONSIVE.md` rather than implied by a green run. Whether they become viewports is an open call.
- **Two in-scope wrappers cannot be reached by the fixtures** — `SecurityDetail`'s dividend history (PLTR has none) and `Recurring`'s monitor (fixture is `[]`). Annotated on every run rather than closed with an invented row.