### PR TITLE
Full sweep and checklist reconciliation

### DIFF
--- a/RESPONSIVE.md
+++ b/RESPONSIVE.md
@@ -1,18 +1,34 @@
 # Responsive verification checklist
 
-The definition of done for the mobile-responsive work.
+The definition of done for the mobile-responsive work, reconciled against the suite that now
+carries most of it.
 
-**Part of this is now automated: `make test-web`.** A Playwright viewport suite runs the ten viewports
-below against committed fixtures and asserts the gates it can — see `web/TESTING.md`. It does not
-replace this file. Four items need a real iPhone and always will (they are named under *Viewports*
-below), the observations record values rather than pass or fail, and the open calls change decisions
-rather than failing checks. Visual-regression diffing remains out of scope by decision.
+**The regression trigger is the suite, and the command is `make test-web`.** Ten named viewports ×
+thirteen views, run against a production build through vite's preview server with every API call
+served from committed fixtures: **1,237 assertions, ~8 minutes on an unloaded machine**, green as of
+this reconciliation. `web/TESTING.md` says what each spec claims. The table-inventory grep this file used to ask a human
+to run is inside that suite now, so nothing here is a check you have to remember.
 
-So this checklist **shrinks rather than dies**, and it shrinks as behaviour lands: a gate moves out of
-this file only once the suite actually asserts it. Everything below is still checked by hand today.
+**So this file holds what is left for a human, and only that.** Every gate the suite asserts has been
+**deleted** from here rather than struck through — a checklist carrying its own history stops being a
+checklist, and the history is in git and in `.wayfinder/map-mobile-responsive.md`. What remains is
+three genuinely different kinds of thing, and folding them into one pass/fail list is how checklists
+stop being trusted:
 
-The decisions behind every line here live in `.wayfinder/map-mobile-responsive.md` and its tickets. This
-file does not restate them; it checks them.
+- **Gates** — pass/fail. Every one that is left is here because headless Chromium *cannot observe
+  it*: a real notch, Safari's focus-zoom, whether a 44px target is comfortable, whether two nested
+  scroll regions feel confusing.
+- **Observations** — record a value. These **cannot fail**; nothing here changes the work.
+- **Open calls** — failing one **changes a decision** rather than reporting a bug.
+
+**One thing is none of the three, and it is written down under [Not built yet](#not-built-yet)
+instead of hiding in a gate**: two of the universal criteria — the 44px tap floor and 16px form
+controls in fully-responsive views — describe rules that were decided and never built. They are not
+manual checks, they are outstanding work, and a checklist that lists unbuilt rules as things to
+eyeball is how they stay unbuilt for another five tickets.
+
+Visual-regression diffing remains out of scope by decision, and a test asserts no screenshot
+assertion creeps in.
 
 ## Viewports
 
@@ -33,380 +49,425 @@ drift apart.
 | 9 | 1280×800 | `desktop-control` | desktop control — criterion is "identical to before" |
 | 10 | **1440×900** | `desktop-wide` | the second desktop control — the unconditional fixes claim *every* width |
 
-4/5 and 8 exist because a naive 360/390/430/768/1280 sweep never sees a tier boundary or the one range
-where the spec knowingly ships a compromise. 10 exists because one desktop width cannot tell "the tab
-strip fits" from "the tab strip fits at exactly 1280".
+4/5 and 8 exist because a naive 360/390/430/768/1280 sweep never sees a tier boundary or the one
+range where the spec knowingly ships a compromise. **The list was nine when it was written and is
+ten now**: 10 was added because one desktop width cannot tell "the tab strip fits" from "the tab
+strip fits at exactly 1280", and `.tabs { flex-wrap: wrap }` is a claim about every width above the
+fold rather than about one.
 
 **The tablet tier is covered at three of these — 640, 834 and 844×390 — and that is two short of the
-four widths its own criteria name.** 768 and 1000 are not in the list and are not being added: the
-suite is ten projects deep already and both sit inside a band whose two ends are measured. They were
-measured by hand at the tier's landing instead, on the production build against the committed
-fixtures, and every view read **0** at both. 640 is the worst case in the tier by construction — the
-narrowest pane behind the widest rail — so a width that passes at 640 and at 834 passing between them
-is an interpolation rather than an assumption. Recorded here because an untested width should be
-written down rather than implied by a green run.
+four widths its own criteria name.** 768 and 1000 are not in the list. They were measured by hand at
+the tier's landing, on the production build against the committed fixtures, and every view read
+**0** at both. 640 is the worst case in the tier by construction — the narrowest pane behind the
+widest rail — so a width that passes at 640 and at 834 passing between them is an interpolation
+rather than an assumption. Whether they should become two more projects is an [open
+call](#open-calls) rather than an oversight.
 
-**Chrome device emulation is sufficient for 1–10 except four items**, which need a real iPhone:
+**One gate the suite runs is scoped, and the scope is written here because a gate that can never
+pass trains reviewers to ignore it.** The "the main pane never scrolls horizontally" gate applies
+**strictly below 1024px** — `HSCROLL_GATE_APPLIES_BELOW` in `web/tests/viewports.js`. Above it the
+gate does not hold and is not expected to: the widest position table measures **1272px against
+1024px of content at a 1280px viewport**, and the pinned-column pattern at desktop widths is
+explicitly out of scope, so 1100, 1280 and 1440 are exempt deliberately. The same number is written
+twice on purpose — the gate stops at 1024 *because* the pattern does, and a later ticket that takes
+the pin to desktop moves one without the other.
 
-- iOS focus-zoom on form controls — emulation does not reproduce Safari's zoom at all
-- `env(safe-area-inset-*)` — desktop Chrome reports **0**; 012's prototype had to fake it
-- the nested-scroll feel on Recurring
-- touch-target comfort at 44px
+### The five things a real device has to answer
+
+Chrome device emulation is sufficient for all ten viewports **except these**, which is why they are
+the only gates left in this file:
+
+1. **iOS focus-zoom on form controls.** Emulation does not reproduce Safari's zoom at all, and the
+   bundled WebKit build is not Safari-on-iOS either.
+2. **`env(safe-area-inset-*)`.** Desktop Chrome reports **0** at every viewport in both
+   orientations; the shell prototype had to fake them.
+3. **The nested-scroll feel on Recurring.** Geometry is fine; whether it confuses is not.
+4. **Touch-target comfort at 44px**, wherever the floor landed — the drawer in portrait, the app
+   bar, the tab picker, the footnote disclosure.
+5. **Touch-target comfort at 844×390, where the floor deliberately did *not* travel.** The shell
+   follows `(max-height: 500px)` and the tap floor follows `max-width`, so a rotated phone opens a
+   drawer with **39px** rows (measured — see [Observations](#observations)). `shell.spec.js` asserts
+   a 24px floor there rather than skipping, so the geometry is gated and only the comfort question
+   is open. If it reads badly the fix is one condition on one rule, and the tier's boundary moves.
 
 ## Universal gates
 
-Applied to all 12 tab views, SecurityDetail, and sign-in. Must pass.
+Applied to all 12 tab views, SecurityDetail, and sign-in. Must pass. **This list was eight items and
+is four**, and the four that left went to the suite rather than away:
 
-1. ~~**`.main` never scrolls horizontally.** Sideways scroll is confined to a container that is visibly a
-   table.~~ **Landed for every table in the app**, which is the tablet tier's one rule finishing a job
-   five tickets started. *(Not "no horizontal page scroll" — `.main { overflow: auto }` absorbs
-   everything before it reaches the page, so that criterion can never fail.)* Eight of the thirteen
-   views hold it outright at every gated viewport, and **two whole viewports — `ipad-portrait` and
-   `rotated-phone` — are now zero across all thirteen**. `tablet.spec.js` asserts the structural half
-   directly: every table that overflows **its own container** has a wrapper, the wrapper holds the table
-   and nothing else, it fits its parent, and the identity column inside it is `sticky`. That last clause
-   is what found the sixth table — `Dividends`' detail ledger had been inside an inline 520px scroll box
-   since before this work, so it was *contained* and never appeared in the ratchet at all.
-   **What is left is not a table.** Five views — `Portfolio › Overview`, `Options`, `Net Worth` and both
-   `Spending` views — share one residual to the pixel at all seven gated viewports: `.grid2`'s
-   `minmax(420px, 1fr)` track floor against a narrower pane. It is **#44**'s, and it is the only thing
-   standing between `hscroll-baseline.js` and being deleted for a `<= 0` gate.
-2. No overlapping or clipped content.
-3. Every control reachable and tappable — **44px square** in fully-responsive views, **below 640 only**.
-   *(The 24px editor floor has landed and is asserted by `unconditional.spec.js`; it is not checked here
-   any more. Recurring's three `.link-btn`s take their width from the 44px rule rather than twice, so
-   they are still this line's business.)* **The tablet tier keeps 33px rows by decision and
-   `tablet.spec.js` asserts it** — above WCAG 2.5.8's 24px floor, below comfort; `@media (pointer:
-   coarse)` was rejected for firing on touchscreen laptops. The residual worth an eye on a real device
-   is the one this creates: at **844×390 the drawer is open on a phone with ~38px rows**, because the
-   shell travels on the height guard and the tap floor deliberately does not.
-4. ~~Navigation reachable from every screen: drawer opens, scrim tap closes it, the tab `<select>`
-   works.~~ **Landed** — `shell.spec.js` asserts the drawer, the scrim, the picker and the app bar,
-   and the suite now *drives* every phone viewport through them, so all thirteen views being
-   reachable at 390×844 is asserted thirteen times over in `baseline.spec.js` rather than once here.
-5. `input`, `select`, `textarea` render at **16px on phone** (nothing else changes size — 11px labels
-   hold everywhere, there is no type floor). *(The tab picker's own 16px has landed and is asserted;
-   every other form control on a phone is still this line's business.)*
-6. ~~Nothing is `position: fixed`.~~ **Landed** — asserted at all ten viewports across all thirteen
-   views by `baseline.spec.js`, and again by `shell.spec.js` with the drawer *open*, which is the
-   state the two candidates for fixed positioning actually exist in.
-7. Safe areas: in landscape, content **and the app bar** clear the notch; the dark background paints
-   under the home bar with no seam. *(Stays here whatever lands — it is one of the four iPhone items.
-   The suite asserts `viewport-fit=cover` and the **declarations**: `.main`'s three remaining phone
-   sides and — since the shell landed — the app bar's `max(12px, env(...))` and `.main`'s
-   `max(28px, env(...))`, both written **unconditionally**, because a rotated phone is 844px wide and
-   exits the phone block. What none of that can say is whether a real notch is actually cleared.)*
-8. The shell fills the screen with nothing unreachable below it: the bottom of a scrolled list is
-   scrollable to, and sign-in does not rubber-band. *(`100svh` has landed in the shell and on sign-in
-   — asserted as a declaration by `foundations.spec.js`, plus a source gate in `inventory.spec.js`
-   that **no `vh` unit at all** survives under `web/src` — widened from `100vh` when `RuleModal`'s
-   `6vh`/`84vh` became `svh`, which was the whole remaining population; `shell.spec.js` adds the phone column and the pane
-   scrolling to its own end. The **symptom** stays an iPhone check: emulation has no retractable
-   toolbar, so it cannot see the strip either way.)*
+| left this list | now asserted by |
+|---|---|
+| `.main` never scrolls horizontally; sideways scroll confined to a container that is visibly a table | `baseline.spec.js`'s ratchet + `tablet.spec.js`'s structural half |
+| navigation reachable from every screen — drawer, scrim, tab `<select>` | `shell.spec.js`, and every phone gate in the suite *drives* it |
+| nothing is `position: fixed` | `baseline.spec.js` at ten viewports, `shell.spec.js` with the drawer open |
+| the shell fills the screen: `100svh` everywhere, no `vh` unit under `web/src` | `foundations.spec.js` + `inventory.spec.js` |
+
+What is left:
+
+1. **No overlapping or clipped content.** The suite gates the clipping it can *name* — inside a
+   card, inside a pinned wrapper, inside the rule modal, and the drill's cards measured in the
+   pane's scroll space. Overlap in general has no gate and is an eye.
+2. **Safe areas**: in landscape, content **and the app bar** clear the notch; the dark background
+   paints under the home bar with no seam. *(The suite asserts `viewport-fit=cover` and the
+   declarations — the app bar's `max(12px, env(...))` and `.main`'s `max(28px, env(...))`, both
+   written **unconditionally**, because a rotated phone is 844px wide and exits the phone block.
+   What none of that can say is whether a real notch is cleared.)*
+3. **The bottom of a scrolled list is reachable and sign-in does not rubber-band.** `100svh` and its
+   consequences are asserted as declarations and as geometry; the **symptom** stays an iPhone check,
+   because emulation has no retractable toolbar and so cannot see the strip either way.
+4. **iOS focus-zoom does not fire on the one control that was given 16px** — the tab picker.
+   `shell.spec.js` asserts the computed 16px; whether that actually suppresses Safari's zoom is the
+   least-verified claim in the whole effort. *(Every other form control on a phone is not a check —
+   see [Not built yet](#not-built-yet).)*
 
 ## The two editors
 
-`Classify` and `NetWorth` are desktop-optimised by decision. They are checked against these four
+`Classify` and `NetWorth` are desktop-optimised by decision and are checked against their own four
 criteria **instead of** the universal list — reading comfort, row density and tap ergonomics beyond
-24px are below the floor deliberately.
+24px are below the floor deliberately. Three of the four are asserted now: containment below 1024
+with the wrapper holding the table and nothing else (`editors.spec.js`), the 24px square floor at
+all ten viewports including inside the rule modal (`unconditional.spec.js`, `editors.spec.js`), and
+`[title]` being **absent** under `.main` in both editors and inside both modals — stronger than
+gating the five that existed, because a sixth cannot arrive quietly.
 
-1. ~~Sideways scrolling confined to a container that is visibly a table; `.main` never scrolls
-   sideways.~~ **Landed** — `editors.spec.js` walks every table in both editors below 1024 and
-   asserts three things rather than one: that it *has* a scrolling ancestor short of `.main`, that
-   the ancestor holds the table **and nothing else**, and that the ancestor fits its own parent. The
-   middle one is what the criterion's word "visibly" reduces to structurally: the modal sheet's
-   `overflow: auto` absorbs `MatchTable`'s width and would satisfy the first and third while sliding
-   the heading and the buttons off the edge with the numbers. Above 1024 the wrappers do nothing, on
-   purpose — see the trap below.
-2. No overlapping or clipped controls.
-3. ~~Every control reachable, readable, tappable at 24px square.~~ **Landed** — asserted by
-   `unconditional.spec.js` at all ten viewports, and by `editors.spec.js` with the rule modal
-   **open**, which is the one surface a spec that opens nothing cannot see. *Readable* is still
-   eyes-only; the geometry is not.
-4. ~~No control that silently does nothing, and no state you can't get out of. `title=` tooltips **do
-   not exist on touch** — any explanation must be visible text.~~ **Landed** — asserted as `[title]`
-   being *absent* under `.main` in both editors and inside both modals, which is stronger than
-   checking the five that existed: a sixth cannot arrive quietly. Four of them were redundant with a
-   label beside them; the fifth, `title="pulled from statements"` on Breakdown's `auto` pill, was the
-   only one carrying something a reader could not get anywhere else — why some rows take an edit and
-   the rest show a number you cannot touch — and is a visible legend above the table now. Classify's
-   `✕` became the word **Delete**, since the constraint its tooltip carried is a 409 that already
-   lands in `msg` as visible text.
+What is left: **no overlapping or clipped controls, and *readable***. The geometry is gated; whether
+a 17-row form at a 124px label column is legible on a phone is an eye, and it is below the floor by
+choice.
 
 ## Per-view gates
 
-| view | check |
-|---|---|
-| Portfolio › Overview | tiles reflow to 2 columns; ~~**donuts gone below 640**~~ **landed** — `charts.spec.js` asserts both of this view's donuts absent below the tier, present at 640 and above, and the `.barrow` list filling the card at every width. *(`.grid2` collapsing to one column and the S2 inline rows landed earlier — both asserted.)* |
-| Portfolio › Holdings | ~~pattern **A**: Security pinned, h-scroll inside the wrapper, sticky `th` stays put as the wrapper scrolls; `tr:active` feedback and a persistent `›` in the pinned cell; footnote collapsed into `<details>`~~ **landed** — all of it asserted by `pinned.spec.js`, at seven viewports rather than at 390 alone. What is left here is eyes-only: row tap opens SecurityDetail, and whether the pin reads as an identity |
-| Portfolio › Performance | ~~pattern **A**, grouping key pinned (its `th` is `{by}` — lowercase, changes with the `<select>`)~~ **landed** — the `{by}` header is asserted by name, which is what says the *grouping key* got pinned rather than a label. Row count is bounded by the grouping dimension (max 8), so the whole table is on screen and `max-height: 60svh` never bites — asserted as the short half of the cap's one-rule claim |
-| Portfolio › Dividends | ~~crosstab pattern **A** (grows in columns, so h-scroll never expires)~~ **landed**; ~~payment ledger pattern **B** cards~~ **landed** — asserted by `cards.spec.js`, including that the 520px scroll box the table sits in does *not* come with the cards: a capped box inside a page that already scrolls is a second scroll region. ~~That table at 640 and above~~ **landed with the tablet tier, and it is the one this work nearly missed**: it was already inside an inline `{ maxHeight: 520, overflow: "auto" }` box, so it never overflowed the pane and never appeared in the ratchet — *contained* read as done. Contained is not pinned: at 640 you scrolled that box sideways and lost the security name with the date. It takes **A** on `Date`, and the inline `max-height` had to go, because an inline declaration beats any stylesheet and 520px would have overridden the pattern's `60svh` outright. The *number* stays, as `--selfscroll: 520px` — a custom property is not a `max-height`, so it loses to the pattern below 1024 and still gives this box the height it has always had above it. **Desktop is unchanged to the pixel**, which is what ruled out simply taking `.selfscroll`'s 480. Its `payments` pill now counts what is **rendered** rather than what the server holds, because under cards that pill is where the missing header's count went and the flagged-only filter moves it. The two `title=` explanations on `Declared /u` / `Implied /u` go with the `<thead>` — no loss on touch, where a tooltip never existed, and the kv keys carry the labels. ~~`LabelList` dropped below 640~~ **landed** — asserted by count against the fixture's eleven years, and the chart itself stays: dropping chrome is not dropping the chart, and the shape of the series is the one thing the crosstab above does not carry. Its `height="100%"`-inside-a-220px-wrapper is `height={220}` on the container now — never live, fixed while here |
-| Portfolio › Options | ~~contract ledger **A** — pinned Underlying; it already has an `overflow-x: auto` wrapper at `:70`, so this keeps behaviour rather than replacing it~~ **landed** — the wrapper's own 480px cap moved to `.selfscroll` so the pattern's `60svh` can win over it, which an inline `max-height` could not. **`.selfscroll` has two call sites now** — Dividends' detail ledger joined it with the tablet tier, for the same reason, and its 480px became `var(--selfscroll, 480px)` so the second site keeps its own 520 without keeping an inline declaration the pattern cannot beat. By-ticker and by-type unchanged (273/261px, they genuinely fit); ~~monthly P/L halved to 6 bars with a reserved band so negative labels clear the ticks~~ **landed** — 6 bars below the tier against 24 above it, labels raised 9px → 11px (the app's stated minimum, and this chart's labels are the only place its numbers appear anywhere), and the band **only when the window actually holds a loss** — it shrinks the scale's range from the bottom, so on a positive-only window it lifts the baseline clear of the axis and leaves every bar floating above a rule it should stand on. Both branches are exercised: the phone's six-month window is all positive in the fixture and asserts the *absence* of a band, and the 24-month window above the tier carries three losses, so the criterion itself — no value label overlapping an axis tick — is measured against real negative labels rather than asserted vacuously. Its bare `<ResponsiveContainer>`s carry explicit heights now. *(The merged `Contract` cell landed earlier — asserted.)* |
-| Portfolio › Transactions | ~~pattern **B** cards~~ **landed** — eight fields, but still one amount, so the trade is the row and the cash it moved is the hero; Qty and Price take the key/value block. Asserted at every viewport, including that the table is what renders at 640 and above. ~~And that table waits for the tablet tier~~ **landed** — it takes **A** from 640 to 1024, pinning `Date`, the column that was already first. 1220px against a 440px pane at 640, so "untouched" was Date and Acct and not one number. Residual written down rather than fixed: two trades on the same day are told apart by `Security`, 269px and one scroll-step to the right — a merged identity cell on `contract.jsx`'s precedent was rejected because a date, unlike `Put / Put / Call`, varies per row and the ledger arrives ordered by it |
-| Portfolio › SecurityDetail | ~~txn history **B**~~ **landed**; ~~dividend history **B**~~ **landed but never rendered** — PLTR is the row the suite drills into because it has 73 option trades, and it has no dividends at all, so `cards.spec.js` annotates that gap on every run rather than closing it with an invented row; ~~options history **A**, pinning the merged two-line `Contract` cell~~ **landed**. Three tables, two patterns below 640 — and **B, A, A above it**, since the tablet tier gives both histories the pin as well: `Date` is the identity on this page outright rather than second-best, because every row is the same security. The dividend history's wrapper is the one thing in the tier no fixture can reach, and `pinned.spec.js` annotates it. `← Holdings` is a ≥44px target and is the **only** way back — there is no router. *(The pane no longer scrolls sideways here at any gated viewport: cards below 640, the pin from 640 to 1024.)* |
-| Net Worth | editor floor; ~~line chart has a **DOM key, not `<Legend>`**~~ **landed** — and it was the only chart in the app with no legend of any kind at any width, so `name="Net Worth"` / `name="Excl. Housing"` reached the tooltip and nowhere else. Two anonymous coloured lines, on desktop as much as on touch. Asserted by the key's text *and* by its chips matching the lines' own strokes — a key with an independent palette goes wrong silently. ~~Breakdown and History wrapped in `overflow-x: auto`~~ **landed** — as `.contained`, **below 1024 rather than unconditionally**, because an `overflow-x: auto` wrapper is the sticky scrollport for the `th` inside it and a scrollport sized to its content never scrolls: unconditional, it would kill a header that sticks to `.main` today at every width, and "unchanged at 1024 and above" has to include what a wrapper kills silently. Below the tier the header stops sticking and that is accepted — row density is below this floor by decision. It is the whole of Net Worth's phone overflow: 349 → 74 at 360, and the view lands **exactly** on the `.grid2` residual `Portfolio › Overview`, `Options` and `By Category` already share, to the pixel, at all seven gated viewports. ~~The row grid is unchanged~~ **asserted** rather than merely left alone — one rule, no media query, its 120px and 70px tracks measured, because the instinct is to shrink the column that at this gutter is 124px and not the ~200px it looks like; ~~`100svh`~~ *(the shell's, landed and asserted)* |
-| Spending › Overview | ~~donut gone below 640, list is the chart~~ **landed and asserted**; the stacked bar chart's `<Legend>` is a `.chartkey` now, which is **the only chart change the suite cannot see** — `/api/spending/trends` was captured as a 500 from the live database, so `trend.series.length > 0` is false and that chart never mounts. `inventory.spec.js` gates it from the source instead, and `charts.spec.js` annotates the gap on every run; ~~Top Line Items pattern **B** (471px — A's pin would be the 232px Line item, 70% of the viewport)~~ **landed**, and it is the row that proves the map's claim about the leftover overflow: this view fell 114 → 74 / 84 → 44 / 44 → 4 and landed **exactly** on the three other `.grid2` views. Both halves of the `.grid2` end up as ranked lists. **The table above 640 takes A, pinning `Category`** — the 390px rejection does not transfer, because the column that is already first is 82px rather than the 232px `Line item`, and `Line item` sits beside it inside the window at every width in the tier. It shed the last 40px this view carried alone at 640 |
-| Spending › By Category | ~~donut gone below 640~~ **landed and asserted**; ~~Categories pattern **A** with the name column pinned — it keeps its own `▸`/`▾` and does **not** get the persistent `›`~~ **landed** — `pinned.spec.js` carries this view like the other six and `drill.spec.js` asserts the carve-out by name, plus the `.rowtap` feedback it takes *instead* of the chevron; ~~drilled transactions render as **B** cards **below the table**, headed by subcategory + count + aggregate~~ **landed**, and they leave the `.grid2` entirely rather than merely the table — inside that card they would be 386px wide in a 362px pane, clipped by the 420px track floor #44 owns rather than by the nesting this ticket fixes. **The only grouped B table in the spec, so `CardGroup` in `cards.jsx` has exactly one call site** — it landed here because until now there was nothing grouped to head. What is left is eyes-only: whether three levels of drill read as one structure once the third leaves the grid |
-| Spending › Classify | editor floor; ~~`.fillpane` neutralised so the page scrolls as one~~ **landed** — `.fillpane` and `.grow` become blocks below 640 and `.scroll` is **deliberately untouched**: it keeps the `overflow: auto` that still confines the table sideways, and with no flex parent left to cap it, it sizes to its own content, so the scrollport that remains never scrolls. `overflow-x: auto; overflow-y: visible` is not available — the first forces the second. This deletes the app's deepest nesting; what survives is the rules list's inline `maxHeight: 232`, which CSS cannot reach and which is accepted (see the trap). ~~**⇅ Reorder hidden on phone**~~ **landed** — `display: none`, not `disabled`, because a control that is present and does nothing is what criterion 4 forbids; the reorder modal is therefore unreachable below the tier **by design**. ~~`RuleModal` uses `svh`~~ **landed**, and `inventory.spec.js`'s `100vh` gate widened to the *unit* on the way past — `6vh`/`84vh` were the whole remaining population. Its two control rows wrap and `CatSelect` takes `max-width: 100%`, without which a 19-option select plus its button pushed the 358px sheet into a sideways scroll and took Cancel with it; `MatchTable` is `.contained` for the same reason. *(The `textarea`'s styling has landed — asserted.)* |
-| Spending › Recurring | ~~monitor **A** *(open call)* and candidates **A**~~ **landed** — both pinned; the open call is untouched by that, since it asks whether this view wants a different information design rather than whether the reflow works. **Only the candidates table is asserted**: the owner tracks nothing, so `/api/spending/recurring` is `[]` in the committed fixtures and the monitor never mounts. `pinned.spec.js` annotates that gap on every run rather than closing it with an invented row — so the monitor's pin is an eyes-only check here. Three `.link-btn`s at 44px square; **two nested scroll regions** — the feel check |
-| Spending › Transactions | ~~pattern **B** cards~~ **landed** — the six-field shape the whole pattern was measured on: merchant, one amount, and four muted fields on a second line, with no key/value block at all. Its excluded rows keep their dimming, but **no fixture holds one** — every captured transaction is counted spend and `include_excluded=true` was never captured, so both renderings are equally unexercised and `cards.spec.js` asserts the two agree on 0.55 rather than observing either. ~~The table at 640 and above waits for the tablet tier~~ **landed** — **A**, pinning `Date`, and that pin is a *choice* rather than the default: `Merchant` is what the card leads with and its column measures **561px**, unbounded free text out of the statements, which in a 440px window is a pinned column that covers the screen and never lets a number through. Bounding it would be a second rule in a tier that holds exactly one |
-| Sign-in | ~~`100vh` → `100svh` at `auth.jsx:50` and `:125`~~ **landed** — asserted, along with the box filling the screen, optical centring and the absence of any phone rule. GSI button **carved out** of the 44px floor; no `env()` padding anywhere. What is left here is eyes-only: whether the carved-out button looks right beside a 44px world |
+Every row carries its final pattern assignment. **A** is the pinned identity column (restyled markup,
+below 1024); **B** is one card per row (different markup, below 640, and its tier lives in
+`usePhone()` rather than in the stylesheet). Nothing here is unassigned; the third column is what a
+person still looks at, and "—" means the suite has all of it.
+
+| view | final assignment | what a human still checks |
+|---|---|---|
+| Portfolio › Overview | tiles reflow to 2 columns · both donuts dropped below 640, the `.barrow` list *is* the chart · `.grid2` one column · S2 inline rows | — |
+| Portfolio › Holdings | **A**, pinning `Security` · sticky `th` · `tr:active` feedback and a persistent `›` in the pinned cell · footnote collapsed into `<details>` | whether the pin reads as an *identity* rather than as a first column |
+| Portfolio › Performance | **A**, pinning the grouping key — its `th` is `{by}`, lowercase, and changes with the `<select>` | — |
+| Portfolio › Dividends | crosstab **A** (grows in columns, so h-scroll never expires) · payment ledger **B** below 640, **A** on `Date` from 640 to 1024 · `LabelList` dropped below 640 · `--selfscroll: 520px` keeps desktop's box height without an inline `max-height` | — |
+| Portfolio › Options | contract ledger **A**, pinning `Underlying` · by-ticker and by-type unchanged (273/261px — they genuinely fit) · monthly P/L 6 bars below the tier against 24 above it, with the reserved band only when the window holds a loss | — |
+| Portfolio › Transactions | **B** below 640 · **A** on `Date` from 640 to 1024 | — *(telling two same-day trades apart is an [open call](#open-calls), not a check)* |
+| Portfolio › SecurityDetail | txn history **B** · dividend history **B** · options history **A**, pinning the merged two-line `Contract` cell — and **B, A, A** above 640, since the tier gives both histories the pin on `Date` · `← Holdings` is a ≥44px target and the only way back | the dividend history renders for no fixture (PLTR has none) — its wrapper is the one thing in the tier no fixture reaches, and `pinned.spec.js` annotates that on every run |
+| Net Worth | editor floor · line chart carries a DOM `.chartkey`, not `<Legend>` · Breakdown and History `.contained` **below 1024**, not unconditionally · row grid unchanged | readable — the editors' remaining criterion |
+| Spending › Overview | donut dropped below 640, the list is the chart · stacked bar chart's `<Legend>` is a `.chartkey` · Top Line Items **B** below 640, **A** on `Category` from 640 to 1024 | the stacked bar chart itself: `/api/spending/trends` was captured as a **500**, so it never mounts under test. `inventory.spec.js` gates it from source and `charts.spec.js` annotates the gap. Closes when **#35** does |
+| Spending › By Category | donut dropped below 640 · Categories **A** with the name column pinned, keeping its own `▸`/`▾` and the `.rowtap` flash *instead of* the persistent `›` · drilled transactions **B**, **outside the `.grid2` entirely** rather than merely outside the table | whether three levels of drill read as one structure once the third leaves the grid |
+| Spending › Classify | editor floor · `.fillpane`/`.grow` become blocks below 640 so the page scrolls as one, `.scroll` deliberately untouched · ⇅ Reorder `display: none`, so the reorder modal is unreachable below the tier by design · `RuleModal` on `svh`, its control rows wrap, `CatSelect` capped at `max-width: 100%`, `MatchTable` `.contained` | readable · `MatchTable` renders only after a POST the GET-captured fixtures do not carry — `editors.spec.js` annotates that gap |
+| Spending › Recurring | monitor **A** · candidates **A** | the monitor never mounts — the owner tracks nothing, so `/api/spending/recurring` is `[]` and its pin is eyes-only (`pinned.spec.js` annotates it) · the **two nested scroll regions**, which is the feel check |
+| Spending › Transactions | **B** below 640 — six fields, merchant, one amount, four muted on a second line, no key/value block · **A** on `Date` from 640 to 1024, a *choice* rather than the default: `Merchant` measures **561px** of unbounded free text against a 440px window | excluded rows keep their dimming but **no fixture holds one**, so both renderings are unexercised — `cards.spec.js` asserts the two agree on 0.55 rather than observing either |
+| Sign-in | `100svh` at `auth.jsx:50` and `:125` · the box fills the screen and centres optically · **no phone rule at all** · GSI button carved out of the 44px floor | whether a **40px** button (measured) looks right beside a 44px world |
 
 ## Observations
 
-Record the value. These **cannot fail** — nothing here changes the work.
+Record the value. These **cannot fail** — nothing here changes the work. Measured during this
+reconciliation unless marked otherwise.
 
-- Rendered GSI button height at `size: "large"`. If ≥44px the carve-out is moot; if 40px it is
-  load-bearing and stays written down.
-- No seam under `viewport-fit=cover`, both orientations.
-- **Whether iPadOS Safari focus-zooms form controls.** The spec assumes it does not, and keeps 16px
-  inputs phone-only on that basis. This is the least-verified claim in the whole map.
-- Rows actually achieved vs the spec's 12–13 portrait / 4 landscape on Holdings.
-- **The drawer's row height at 844×390**, which is the residual the tablet tier's height guard creates
-  and the one place two of that tier's decisions pull against each other. The shell travels to a
-  rotated phone on `(max-height: 500px)`; the 44px floor stays behind `max-width`, because 44px targets
-  are on the tier's "explicitly not done" list. The result is a phone, in the hand, with ~38px
-  navigation rows — above WCAG 2.5.8's 24px floor and below the comfort target the same effort set for
-  the same control in portrait. `shell.spec.js` asserts a 24px floor there rather than skipping, so the
-  geometry is gated; what is not gated is whether it is *comfortable*, which is the fourth iPhone item
-  in a new place. If it reads badly, the fix is one condition on one rule and the tier's boundary moves.
+- **Rendered GSI button height at `size: "large"` — 40px.** Measured at 177.39 × 40px: the
+  `role="button"` element GIS injects, with its inner pill at 38px. Chromium at 390×844 against the
+  dev server on `localhost:5173`, which `DEPLOY.md` lists as an authorized JavaScript origin, with
+  the network open and the session endpoint answered 401 — the suite's own seam aborts every
+  cross-origin request, so it can never see this button. **40 is under 44, so the carve-out is
+  load-bearing and stays written down.** Caveat kept honest: this is Chromium's render of Google's
+  button, not iOS Safari's.
+- **Seam under `viewport-fit=cover`, both orientations — NOT RECORDED.** Needs a real iPhone.
+  Chromium reports every inset as 0 in both orientations, which the suite confirms rather than
+  works around.
+- **Whether iPadOS Safari focus-zooms form controls — NOT RECORDED.** Needs a real iPad. The spec
+  assumes it does not, and keeps 16px inputs phone-only on that basis. This remains the
+  least-verified claim in the whole map.
+- **Holdings rows achieved — 12 portrait, 4 landscape. Both predictions met.**
+  At **390×844**: 12 rows fully on screen (11 data + 1 group row), 13 counting the one cut by the
+  fold — against a predicted 12–13. At **844×390**: 4 fully on screen (3 data + 1 group), 5 counting
+  the partial — against a predicted 4. A data row is **52.5px**, a group row **36px**.
+  Two things worth knowing about *how* it was met. The prediction was taken at a 44px cell pitch that
+  [was never built](#not-built-yet); the count lands in range anyway because the pinned `Security`
+  cell is two lines, which makes a data row 52.5px on its own. And at 844×390 the footnote
+  disclosure is **open**, because `Holdings.jsx` reads its query by *width*, once, at mount — 844 is
+  not the phone tier — so the landscape count is with the footnote expanded, which is the harder
+  case rather than the easier one.
+- **The drawer's row height at 844×390 — 39px** (`Settings`, the dim one, 37.5px), against **44px**
+  for the same rows at 390×844. Predicted ~38px. This is the residual the tablet tier's height guard
+  creates and the one place two of that tier's decisions pull against each other: the shell travels
+  to a rotated phone on `(max-height: 500px)`, and the 44px floor stays behind `max-width` because
+  44px targets are on the tier's "explicitly not done" list. Above WCAG 2.5.8's 24px floor, below
+  the comfort target the same effort set for the same control in portrait. The comfort half is
+  iPhone item 5.
+
+## Real-device log
+
+The five items above need a device this repo cannot drive. Record the run here rather than leaving
+it implied — an unrecorded device check is indistinguishable from one that never happened.
+
+| # | item | device / OS | date | result |
+|---|---|---|---|---|
+| 1 | iOS focus-zoom on the tab picker at 390×844 | — | — | **not yet run** |
+| 2 | notch and home-bar seam under `viewport-fit=cover`, both orientations | — | — | **not yet run** |
+| 3 | Recurring's two nested scroll regions — does it confuse | — | — | **not yet run** |
+| 4 | 44px comfort where the floor landed: drawer, app bar, picker, footnote summary | — | — | **not yet run** |
+| 5 | 39px drawer rows at 844×390 — comfortable, or does the floor need the height arm | — | — | **not yet run** |
+| 6 | *(observation)* does iPadOS Safari focus-zoom form controls — an iPad, not an iPhone | — | — | **not yet run** |
+
+All five are an iPhone. **A sixth run wants an iPad**, and it is an
+[observation](#observations) rather than a gate: whether iPadOS Safari focus-zooms form controls,
+which is what the spec assumed when it kept 16px inputs phone-only.
 
 ## Open calls
 
 Failing these **changes a decision**, rather than reporting a bug.
 
-- `Recurring.jsx:94` monitor assigned **A** — the map suspects Recurring wants a different information
-  design entirely, not a reflow.
+- `Recurring.jsx:94` monitor assigned **A** — the map suspects Recurring wants a different
+  information design entirely, not a reflow.
 - Recurring's two nested scroll regions — geometry is fine; whether it *feels* confusing is not
   measurable from here.
 - `SecurityDetail.jsx:49` txn history stays **B**, but it measures the same ~4 cards per screen that
-  overturned B for the options table beside it (8 cols, 914px, up to 71 rows, four numbers per row). If it
-  reads as cramped, it wants **A** and SecurityDetail becomes B, A, A. **Now buildable rather than
+  overturned B for the options table beside it (8 cols, 914px, up to 71 rows, four numbers per row).
+  If it reads as cramped, it wants **A** and SecurityDetail becomes B, A, A. **Buildable rather than
   hypothetical** — the cards are on screen, so this is a look rather than a thought experiment.
-- **Whether a phone list of 1001 cards is usable.** `spending/Transactions` fetches `limit=1000` and the
-  card is ~2× an A row's height, so the pattern's own list is the app's longest render. The map routed the
-  row-cap question to observation during verification and it is still open; nothing about it is decidable
-  at a desk, and the table it replaced was equally uncapped. **The By Category drill is now the second
-  instance and is on screen too** — same `limit=1000`, and "Dining Out" alone is 285 transactions in one
-  year in the live DB, against the 16 the committed fixture drills into. The fixture cannot show you the
-  bad case; a real phone on the live database can.
-
-- **Whether a date is enough of an identity on the two multi-security ledgers.** The tablet tier pins
-  the column that was already first, which on `Portfolio › Transactions` and `Spending › Transactions`
-  is `Date`. That is a real identity — it varies per row and both ledgers arrive ordered by it, which
-  is exactly what `contract.jsx`'s merged cell existed to supply for a column of `Put / Put / Call`.
-  What it does not do is separate two rows on the same day: on those you are reading the pin, seeing
-  one date twice, and relying on `Security` or `Merchant` being one scroll-step to the right.
-  **The alternative was rejected on a measurement, not on principle** — `Merchant` is 561px of
-  unbounded free text against a 440px window at 640, so pinning it covers the screen and never lets a
-  number through, and bounding it would be a second rule in a tier whose whole claim is that it holds
-  one. If reading a same-day run is genuinely confusing on a tablet, the answer is a merged identity
-  cell on `contract.jsx`'s precedent — which changes those tables at *every* width, and is therefore a
-  decision rather than a fix.
+- **Whether a phone list of 1001 cards is usable.** `spending/Transactions` fetches `limit=1000` and
+  the card is ~2× an A row's height, so the pattern's own list is the app's longest render. Nothing
+  about it is decidable at a desk, and the table it replaced was equally uncapped. **The By Category
+  drill is the second instance** — same `limit=1000`, and "Dining Out" alone is 285 transactions in
+  one year in the live DB against the 16 the committed fixture drills into. The fixture cannot show
+  you the bad case; a real phone on the live database can.
+- **Whether a date is enough of an identity on the two multi-security ledgers.** The tablet tier
+  pins the column that was already first, which on `Portfolio › Transactions` and `Spending ›
+  Transactions` is `Date`. That is a real identity — it varies per row and both ledgers arrive
+  ordered by it. What it does not do is separate two rows on the same day: on those you are reading
+  the pin, seeing one date twice, and relying on `Security` or `Merchant` being one scroll-step to
+  the right. **The alternative was rejected on a measurement, not on principle** — `Merchant` is
+  561px of unbounded free text against a 440px window at 640, so pinning it covers the screen and
+  never lets a number through, and bounding it would be a second rule in a tier whose whole claim is
+  that it holds one. If reading a same-day run is genuinely confusing on a tablet, the answer is a
+  merged identity cell on `contract.jsx`'s precedent — which changes those tables at *every* width,
+  and is therefore a decision rather than a fix.
 - **Whether 768 and 1000 deserve to be viewports.** The tier's own criteria name four widths and the
   suite gates three of them (640, 834, and 844×390 for the height guard). Both missing widths sit
   strictly inside a band whose ends are measured, and both read **0** on every view when measured by
-  hand at the tier's landing — but that measurement is a moment in time and the suite is what makes a
-  fact durable. Adding them is two more projects on a suite that is already ten deep and ~10 minutes
-  per full run, which is the cost side. Decide it once, here, rather than each time someone notices.
+  hand at the tier's landing — but that measurement is a moment in time and the suite is what makes
+  a fact durable. Adding them is two more projects on a suite that is already ten deep and ~8
+  minutes per full run, which is the cost side. Decide it once, here, rather than each time someone
+  notices.
 
-*(`Options.jsx:71` left this list: resolved to **A**, on the measurement that a 9-field card is 4 rows per
-screen against A's 12 — the same reasoning that rejected B for Holdings at 3.)*
+*(`Options.jsx:71` left this list: resolved to **A**, on the measurement that a 9-field card is 4
+rows per screen against A's 12 — the same reasoning that rejected B for Holdings at 3.)*
+
+## Not built yet
+
+Neither gates nor observations: **rules that were decided and never built**. They are here rather
+than in the gate list because eyeballing an unbuilt rule is not a check, and because a residual with
+no owner is precisely how four tables went unassigned through the whole map.
+
+- **The 44px tap floor never reached the content controls, and 16px form controls never landed at
+  all.** `--tap: 44px` is declared and used by `.navitem`, `.logout-btn`, `.bar-btn`, `.tabsel` and
+  `.tablenote > summary` — the navigation shell and the footnote disclosure, no more. The rest of
+  what was decided is absent from `styles.css`: `input, select, textarea { font-size: 16px }`,
+  `th, td { padding: 11px 8px }` (the 44px row pitch), and the square floor on `.link-btn`,
+  `.refresh-btn`, `select`, `SecurityDetail`'s back link and `Transactions`' "show excluded" label.
+  **Measured at 390×844 against the committed fixtures**, counting only fully-responsive views —
+  the two editors are exempt at 24px and clear it:
+
+  | view | controls under 44px square | form controls not at 16px |
+  |---|---|---|
+  | Portfolio › Holdings | grouping `<select>` 104×31 · checkbox 13×13 | 2 (12px) |
+  | Portfolio › Performance | grouping `<select>` 168×33 | 1 (14px) |
+  | Portfolio › Dividends | checkbox 13×13 | 1 (11.2px) |
+  | Portfolio › Transactions | account `<select>` 158×33 · text input 100×35 | 2 (14px) |
+  | Spending › By Category | 4 | 1 |
+  | Spending › Recurring | 38 — the three `.link-btn`s per row, at ~21px tall | 5 |
+  | Spending › Transactions | 3 | 3 |
+
+  `Portfolio › Overview`, `Options`, `SecurityDetail` and `Spending › Overview` carry no control
+  that fails, and sign-in's only one is the carved-out GSI button. **The 16px half is what the
+  entire iOS-focus-zoom decision rests on**, so today that decision protects one control — the tab
+  picker — and nothing else. `tablet.spec.js` already asserts the *inverse* above 640 ("tap targets
+  are not enlarged and inputs are not resized"), so the tier boundary is gated from one side only.
+  The stylesheet comment at `styles.css:414` reads as though the phone rule exists; it does not.
+- **`.grid2`'s `minmax(420px, 1fr)` track floor is the last horizontal overflow below 640, and it is
+  **#44**'s.** Five views — `Portfolio › Overview`, `Options`, `Net Worth` and both `Spending`
+  views — share it *to the pixel* at all seven gated viewports: 74 / 44 / 4 / 0 / 8 / 0 / 0. One
+  cause, no table involved, and nothing else at all in the ratchet. The usual remedy is
+  `minmax(min(420px, 100%), 1fr)`. Until it lands, `hscroll-baseline.js` cannot become a `<= 0` gate.
 
 ## Traps
 
 Things the build session must be told, not left to discover.
 
-- `spending/Transactions.jsx:40` carries an inline `fontSize: 13` — **CSS cannot reach it**; the rule silently
-  no-ops until that style moves to a class.
-- `Classify.jsx:126` carries an inline `maxHeight: 232` — same problem, accepted as-is, and it is now **the one nested scroll region left in the app below 640**: the `.fillpane` machinery around it is neutralised there, so the rules list is the only thing on that screen that scrolls inside the page.
-- `ByCategory.jsx:186` carries an inline `paddingLeft: 26` — same family. It is what makes that table's
-  pinned column 212px rather than ~186px.
-- **A pinned column is only useful if its column is an identity.** `SecurityDetail`'s options table used to
-  lead with `Type` (`Put`/`Put`/`Call`); the merged `Contract` cell that replaced it has landed, so that
-  one is now pinnable. The rule still applies to every *other* A table — check the pin actually tells you
-  which row you are on.
-- **A nested `<table>` inherits its parent's width**, so it sets the parent's min-content. This is why the
-  By Category drilldown leaves the table on phone rather than becoming cards in place. **Leaving the
-  table is not enough** — landed, and measured: cards placed in the categories card are still 386px in a
-  362px pane, because `.grid2`'s 420px track floor (the trap below) reaches them there. They leave the
-  whole grid.
+- `spending/Transactions.jsx:40` carries an inline `fontSize: 13` — **CSS cannot reach it**; a rule
+  targeting it silently no-ops until that style moves to a class.
+- `Classify.jsx:126` carries an inline `maxHeight: 232` — same problem, accepted as-is, and it is
+  **the one nested scroll region left in the app below 640**: the `.fillpane` machinery around it is
+  neutralised there, so the rules list is the only thing on that screen that scrolls inside the page.
+- `ByCategory.jsx:186` carries an inline `paddingLeft: 26` — same family. It is what makes that
+  table's pinned column 212px rather than ~186px.
+- **A pinned column is only useful if its column is an identity.** `SecurityDetail`'s options table
+  used to lead with `Type` (`Put`/`Put`/`Call`); the merged `Contract` cell that replaced it has
+  landed, so that one is now pinnable. The rule still applies to every *other* A table — check the
+  pin actually tells you which row you are on.
+- **A nested `<table>` inherits its parent's width**, so it sets the parent's min-content. This is
+  why the By Category drilldown leaves the table on phone rather than becoming cards in place.
+  **Leaving the table is not enough** — cards placed in the categories card are still 386px in a
+  362px pane, because `.grid2`'s 420px track floor reaches them there. They leave the whole grid.
 - **A card that overflows the pane reports nothing to `scrollWidth`** — it fits its own contents
   perfectly; what is off screen is the box it sits in. And measuring its right edge in *viewport*
-  coordinates does not catch it either, because clicking a row has already scrolled `.main` sideways and
-  dragged the card back into view. `drill.spec.js` adds `scrollLeft` back and compares in the pane's
-  scroll space; built against the rejected layout, that is the difference between a 27px failure and a
-  green run.
-- `.grid2`'s `minmax(420px, 1fr)` is **~100px optimistic against real data** — `spending/Overview.jsx:36`'s card needs
-  **519px** with the live DB's longest subcategory name. `auto-fit` still behaves; the column just spills
-  inside itself between 1024 and ~1256.
-- **The 420px track floor is the ONLY entry left in the horizontal ratchet below 640, and it is
-  #44's.** Below that width the floor exceeds the 362px pane outright, so `Portfolio ›
-  Overview`, `Options`, `By Category` **and now `Net Worth`** all carry the *same* residual —
-  74 / 44 / 4 / 0 / 8 / 0 / 0 by viewport, one cause, no table involved. `Net Worth` joined the moment
-  the editors' floor took its two tables off the pane, which is the strongest evidence the file can
-  offer that the remaining phone overflow is one defect rather than four. **`Spending › Overview` is
-  the fifth and is now on that number at all seven** — the 40px it used to carry alone at 640 was the
-  Top Line Items table, and the tablet tier's pin took it. So the ratchet is five views, one cause,
-  and nothing else at all. The pinned column
-  cannot reach it and neither can card-per-row or the editors' floor. The usual remedy is
-  `minmax(min(420px, 100%), 1fr)`. **Written down here because a residual with no owner is precisely
-  how the four unassigned tables happened.**
+  coordinates does not catch it either, because clicking a row has already scrolled `.main`
+  sideways and dragged the card back into view. `drill.spec.js` adds `scrollLeft` back and compares
+  in the pane's scroll space; built against the rejected layout, that is the difference between a
+  27px failure and a green run.
+- `.grid2`'s `minmax(420px, 1fr)` is **~100px optimistic against real data** —
+  `spending/Overview.jsx:36`'s card needs **519px** with the live DB's longest subcategory name.
+  `auto-fit` still behaves; the column just spills inside itself between 1024 and ~1256.
 - **`640` is a literal in four places, and the charts did not make it five**: `styles.css`'s
   `max-width: 639.98px`, `tests/viewports.js`'s `PHONE_TIER_BELOW` / `PHONE_TIER_EDGE`,
-  `Holdings.jsx`'s `startsCollapsed` — the app's first `matchMedia` read, which arrived with the
-  pinned column rather than with the charts as the map expected — and `cards.jsx`'s `usePhone`, which
-  arrived with card-per-row. The charts were forecast as the fifth and are not: `charts.jsx` and
-  `Options.jsx` call `usePhone()`. No single source of truth without a build step. Every site
-  cross-references the others in a comment, and `inventory.spec.js` now holds **two** gates on it: it
-  counts the sites, so a fifth file writing the number fails rather than being noticed by a reader,
-  and it checks the two JS queries **character for character** against the tier edge. Counting is not
-  agreeing — `(max-width: 640px)` in `cards.jsx` keeps the count at four, keeps every comment true to
-  the word, and moves the whole card-per-row tier into the 1px dead zone the `.98` exists to prevent.
+  `Holdings.jsx`'s `startsCollapsed` — the app's first `matchMedia` read — and `cards.jsx`'s
+  `usePhone`. `charts.jsx` and `Options.jsx` call `usePhone()` rather than reading the query
+  themselves. No single source of truth without a build step. Every site cross-references the others
+  in a comment, and `inventory.spec.js` holds **two** gates on it: it counts the sites, so a fifth
+  file writing the number fails rather than being noticed by a reader, and it checks the two JS
+  queries **character for character** against the tier edge. Counting is not agreeing —
+  `(max-width: 640px)` keeps the count at four while moving the whole card-per-row tier into the 1px
+  dead zone the `.98` exists to prevent.
 - **`500` is the tier's own second number, written twice**: `styles.css`'s shell block and
-  `tests/viewports.js`'s `SHELL_GUARD_EDGE` / `SHELL_HEIGHT_GUARD`. It is gated differently from the
-  other two and deliberately so — `tablet.spec.js` **enumerates every media condition in the shipped
-  sheet** and names each by the number that identifies it, which is stronger than a count of source
-  sites: it reads what the build actually emitted, so `500` appearing on the wrong block, or a fourth
-  block appearing at all, fails there. It also fails if the shell's two arms stop being one condition.
+  `tests/viewports.js`'s `SHELL_GUARD_EDGE` / `SHELL_HEIGHT_GUARD`. It is gated differently and
+  deliberately so — `tablet.spec.js` **enumerates every media condition in the shipped sheet** and
+  names each by the number that identifies it, which is stronger than a count of source sites: it
+  reads what the build actually emitted, so `500` appearing on the wrong block, or a fourth block
+  appearing at all, fails there. It also fails if the shell's two arms stop being one condition.
 - **The two `matchMedia` readers differ on purpose, and the difference is not an inconsistency.**
-  `Holdings.jsx` reads the query **once, at mount**, because it only seeds a disclosure's initial state
-  and the user then owns it — a footnote that reopens itself on rotate is worse than a stale one.
-  `cards.jsx`'s `usePhone` **subscribes**, because it *is* the layout: a rotated phone is 844px wide,
-  has left the tier, and must get its table back without a reload. `cards.spec.js` drives that rotation
-  rather than trusting it.
-- **Pattern B's tier is written in JavaScript and nowhere else.** Pattern A restyles markup that renders
-  at every width, so its 1024 has to be a media query — and `pinned.spec.js` gates *which* tier, because
-  `639.98` and `1023.98` are one character apart to read. B is different markup, so none of `.cards`,
-  `.rowcard` or the `.rc-*` rules is inside a media block at all: above 640 the hook does not render
-  them. Wrapping them "for safety" would be 640 written twice. Asserted.
+  `Holdings.jsx` reads the query **once, at mount**, because it only seeds a disclosure's initial
+  state and the user then owns it — a footnote that reopens itself on rotate is worse than a stale
+  one. `cards.jsx`'s `usePhone` **subscribes**, because it *is* the layout: a rotated phone is 844px
+  wide, has left the tier, and must get its table back without a reload. `cards.spec.js` drives that
+  rotation rather than trusting it.
+- **Pattern B's tier is written in JavaScript and nowhere else.** Pattern A restyles markup that
+  renders at every width, so its 1024 has to be a media query — and `pinned.spec.js` gates *which*
+  tier, because `639.98` and `1023.98` are one character apart to read. B is different markup, so
+  none of `.cards`, `.rowcard` or the `.rc-*` rules is inside a media block at all: above 640 the
+  hook does not render them. Wrapping them "for safety" would be 640 written twice. Asserted.
 - **A comment mentioning `<table` breaks the table-inventory count.** The gate is a plain
   `grep -ro "<table" web/src`, so prose is indistinguishable from markup to it — a CSS comment
   explaining what the cards replace pushed the count to 23 and failed `inventory.spec.js`. Say "the
-  real table" in prose. Deliberate: the grep is the same one a human runs, and teaching it to parse
-  is how it stops being cheap enough to run.
-- **`1024` is now a literal in two FILES** for the same reason: `styles.css`'s `max-width: 1023.98px`
-  — written **twice** there since the editors' `.contained` landed, in its own block rather than the
+  real table" in prose. Deliberate: the grep is the same one a human would run, and teaching it to
+  parse is how it stops being cheap enough to run.
+- **`1024` is a literal in two FILES** for the same reason: `styles.css`'s `max-width: 1023.98px` —
+  written **twice** there since the editors' `.contained` landed, in its own block rather than the
   pin's, because they are two claims about one width and a ticket that takes the pin to desktop must
-  move one without the other — and `tests/viewports.js`'s `PIN_TIER_BELOW` / `PIN_TIER_EDGE`. It is the same number as
-  `HSCROLL_GATE_APPLIES_BELOW` and deliberately not the same constant — the gate is exempt above 1024
-  *because* the pattern stops there, so a ticket that takes the pin to desktop moves one and not both.
+  move one without the other — and `tests/viewports.js`'s `PIN_TIER_BELOW` / `PIN_TIER_EDGE`.
 - **`border-collapse: separate` does not paint a border declared on a `<tr>` at all.** It is the
-  trap behind the trap: switching a table to `separate` to keep the sticky borders silently deletes any
-  row-level rule in it. `Dividends`' 2px total rule was one, and is `.totalrow` on the cells now.
-- **A pinned first cell must not be a `colSpan` banner.** `Holdings`' group rows are excluded from the
-  pin by `:not(.grouprow)` — pinning a seven-column banner parks a subtotal over the numbers the
-  sideways scroll exists to reach. The label slides away instead; its background is what keeps the row
-  identifiable once it has. Any new grouped pattern-A table needs the same class.
+  trap behind the trap: switching a table to `separate` to keep the sticky borders silently deletes
+  any row-level rule in it. `Dividends`' 2px total rule was one, and is `.totalrow` on the cells now.
+- **A pinned first cell must not be a `colSpan` banner.** `Holdings`' group rows are excluded from
+  the pin by `:not(.grouprow)` — pinning a seven-column banner parks a subtotal over the numbers the
+  sideways scroll exists to reach. The label slides away instead; its background is what keeps the
+  row identifiable once it has. Any new grouped pattern-A table needs the same class.
 - **An inline `max-height` beats the pattern's `60svh`.** `Options`' trades wrapper shipped its cap
-  inline; it is `.selfscroll` now precisely so the cascade can reach it. Nothing else may put a height
-  on a `.pinned` wrapper inline. **`Dividends`' detail ledger is the second instance and shows the way
-  out when the two boxes disagree on the number**: `.selfscroll` reads `var(--selfscroll, 480px)` and
-  that site sets `--selfscroll: 520px` inline. A custom property is not a `max-height` declaration, so
-  it never enters the specificity fight — the pattern still wins below 1024, and desktop keeps the
-  height it always had. Reach for that, not for a second class and not for a shared literal that
-  quietly moves one of the two.
+  inline; it is `.selfscroll` now precisely so the cascade can reach it. Nothing else may put a
+  height on a `.pinned` wrapper inline. **`Dividends`' detail ledger is the second instance and
+  shows the way out when the two boxes disagree on the number**: `.selfscroll` reads
+  `var(--selfscroll, 480px)` and that site sets `--selfscroll: 520px` inline. A custom property is
+  not a `max-height` declaration, so it never enters the specificity fight — the pattern still wins
+  below 1024, and desktop keeps the height it always had. Reach for that, not for a second class and
+  not for a shared literal that quietly moves one of the two.
 - **`overflow-x: auto` forces `overflow-y` from `visible` to `auto`.** So a `.pinned` wrapper is the
-  sticky scrollport for its own header *whether or not anyone gave it a height* — and a scrollport that
-  sizes to content never scrolls, so the header rides the page away instead of sticking. Measured at
-  −500px of drift on a 500px page scroll. **This is why `60svh` sits with the pattern at 1024 rather
-  than in the phone block**, where it was first written: scoped to the phone it would leave the header
-  broken from 640 to 1024, and in landscape too, since a rotated phone is 844px wide and exits that
-  block. The map already had this mechanism recorded once — `Dividends.jsx:30`'s "dead sticky header on
-  desktop today" is the same sentence about a table short enough for it not to matter. **The editors'
-  `.contained` is the third reading of the same mechanism, and it decided a tier.** Written
-  unconditionally it would have killed Breakdown's and History's sticky headers — which stick to
-  `.main` today — at *every* width, and that is a change to a view whose criterion is "unchanged at
-  1024 and above". So containment is written below 1024, the header stops sticking only where row
-  density is already below the floor, and desktop is untouched. A wrapper's cost is never only the
-  overflow it absorbs.
+  sticky scrollport for its own header *whether or not anyone gave it a height* — and a scrollport
+  that sizes to content never scrolls, so the header rides the page away instead of sticking.
+  Measured at −500px of drift on a 500px page scroll. **This is why `60svh` sits with the pattern at
+  1024 rather than in the phone block**, where it was first written: scoped to the phone it would
+  leave the header broken from 640 to 1024, and in landscape too, since a rotated phone is 844px
+  wide and exits that block. **The editors' `.contained` is the third reading of the same mechanism,
+  and it decided a tier.** Written unconditionally it would have killed Breakdown's and History's
+  sticky headers — which stick to `.main` today — at *every* width, and that is a change to a view
+  whose criterion is "unchanged at 1024 and above". So containment is written below 1024, the header
+  stops sticking only where row density is already below the floor, and desktop is untouched. A
+  wrapper's cost is never only the overflow it absorbs.
 - **The neutralisation of a nested scroll is a rule about the PARENT, not the scroller.** Below 640
-  `Classify`'s `.fillpane` and `.grow` become blocks; `.scroll` keeps `overflow: auto` untouched, and
-  that is what still confines its table sideways. Reaching for `overflow-x: auto; overflow-y: visible`
-  instead is not available — the trap above forces the second from the first — and dropping `overflow`
-  altogether hands the table's width straight to `.main`. `.grow`'s `overflow: hidden` must go with
-  the flex, though: it exists to stop a flex child overflowing a box the algorithm sized, and on a
-  block that sizes to its own content it becomes a clip with nothing to scroll it back.
+  `Classify`'s `.fillpane` and `.grow` become blocks; `.scroll` keeps `overflow: auto` untouched,
+  and that is what still confines its table sideways. Reaching for `overflow-x: auto; overflow-y:
+  visible` instead is not available — the trap above forces the second from the first — and dropping
+  `overflow` altogether hands the table's width straight to `.main`. `.grow`'s `overflow: hidden`
+  must go with the flex, though: it exists to stop a flex child overflowing a box the algorithm
+  sized, and on a block that sizes to its own content it becomes a clip with nothing to scroll it
+  back.
 - **A `<select>` does not shrink below its longest option, and a flex item does not shrink below
   min-content.** `CatSelect` holds 19 categories, the longest of which is 30 characters; inside the
   rule modal's 358px sheet at 390px that one control plus its button was what made the *sheet* a
   horizontal scroller, taking Cancel off the edge with it. `max-width: 100%` on the control and
   `flex-wrap: wrap` on the row, both. Neither alone is enough.
-- In `.main`, the padding **longhands must follow the shorthand** — the shorthand resets all four sides.
-- ~~**`.main`'s phone `padding-top` guards `env(safe-area-inset-top)` and must stop once the app bar
-  lands.**~~ **Discharged** by the shell: the pane's top is a bare `14px` now and the app bar carries
-  `max(0px, env(safe-area-inset-top))` instead. `shell.spec.js` asserts both halves, so putting the
-  guard back fails rather than silently double-padding.
-- **The app bar's inset guards are unconditional, and must stay that way.** They read like phone rules
-  and belong in the phone block by instinct — but a rotated phone is 844px wide and *exits* that block,
-  and landscape is the only orientation where the notch is at the side. Same for `.main`'s
-  `max(28px, env(...))`. The *value* follows the width; the *guard* does not. The **drawer's**
-  guard is the exception and stays inside the block, because `position: absolute` and the transform
-  are in that rule too — and the whole rule **has now travelled** onto the shell's
-  `(max-height: 500px)` arm, guard included, which is what puts it on the one screen it was written
-  for. **`.side` as a *rail* still has no guard at all**, and that residual is smaller than it looks:
-  the only landscape screens that keep the rail are tablets, which have no side notch.
-- **The shell follows *height*; everything else follows *width*.** This is the tablet tier's landscape
-  answer and the easiest thing in the stylesheet to get wrong, because the two blocks now sit next to
-  each other and their conditions differ by one clause. The split is not taste — each half follows the
-  axis its own decision was argued on. The shell was chosen on a vertical budget (48px against a bottom
-  bar's 147px), so it takes `(max-height: 500px)`; the pin, the cards, the charts, the gutter and the
-  44px floor were all chosen on horizontal room and stay width-only, which is also why `usePhone()` is
-  untouched by the tier and why `640` is still a literal in exactly four files. Two consequences to
-  keep straight: at **844×390 the navigation is a phone's and the content is not**, and the height arm
-  fires on a desktop window under 500px tall, which is accepted — that window has the same vertical
-  problem a rotated phone does. Adding a rule to the shell block that belongs to the phone hands it to
-  that window too; `tablet.spec.js` asserts the tap floor did not make that move.
-- **A table can be *contained* and still not pinned, and the ratchet cannot tell.** `Dividends`' detail
-  ledger sat in an inline `{ maxHeight: 520, overflow: "auto" }` box, so it never overflowed `.main`
-  and read as done through five tickets — while at 640 you scrolled it sideways and lost the identity
-  column exactly as the untouched tables did. Two lessons, both now gates: the pane-overflow number is
-  evidence about the *pane*, not about a table, and a scroll box that predates the pattern has to be a
-  **class** before the pattern can reach it, because an inline `max-height` beats any stylesheet.
-- **The app bar is `box-sizing: content-box`** against the app-wide `border-box`, so the top inset adds
-  to its 48px instead of eating it. 48px is the number the whole drawer-versus-bottom-bar trade was
-  decided on; under `border-box` a 47px inset would crush the bar to a line.
-- **`.tabs` is not only the navigation strip.** `ByCategory.jsx:132` borrows the class for its own view
-  header — an `<h3>` and a year `<select>` — with the border overridden inline. That is why the phone
-  rule that hides the strip is `.main > .tabs`; a bare `.tabs` deletes that heading and the year picker
-  with it, and the view still renders, so nothing fails loudly.
-- Sticky + pinned cells require `border-collapse: separate; border-spacing: 0`; under `collapse` they
-  lose their borders. *(Landed, and `pinned.spec.js` asserts both the border model and the resulting
-  1px rules on the header and the pinned column — the model alone would pass while the borders were
-  gone for some other reason.)*
-- `display: none` starves `ResponsiveContainer` to 0×0 — drop chart *chrome* via `matchMedia`, never the
-  container. **Landed as "do not render it at all"**, which is the stronger form of the same rule: a
+- In `.main`, the padding **longhands must follow the shorthand** — the shorthand resets all four
+  sides.
+- **The app bar's inset guards are unconditional, and must stay that way.** They read like phone
+  rules and belong in the phone block by instinct — but a rotated phone is 844px wide and *exits*
+  that block, and landscape is the only orientation where the notch is at the side. Same for
+  `.main`'s `max(28px, env(...))`. The *value* follows the width; the *guard* does not. The
+  **drawer's** guard is the exception and stays inside the block, because `position: absolute` and
+  the transform are in that rule too — and the whole rule has now travelled onto the shell's
+  `(max-height: 500px)` arm, guard included. **`.side` as a *rail* still has no guard at all**, and
+  that residual is smaller than it looks: the only landscape screens that keep the rail are tablets,
+  which have no side notch.
+- **The shell follows *height*; everything else follows *width*.** This is the tablet tier's
+  landscape answer and the easiest thing in the stylesheet to get wrong, because the two blocks sit
+  next to each other and their conditions differ by one clause. The split is not taste — each half
+  follows the axis its own decision was argued on. The shell was chosen on a vertical budget (48px
+  against a bottom bar's 147px), so it takes `(max-height: 500px)`; the pin, the cards, the charts,
+  the gutter and the 44px floor were all chosen on horizontal room and stay width-only. Two
+  consequences to keep straight: at **844×390 the navigation is a phone's and the content is not**,
+  and the height arm fires on a desktop window under 500px tall, which is accepted — that window has
+  the same vertical problem a rotated phone does. Adding a rule to the shell block that belongs to
+  the phone hands it to that window too; `tablet.spec.js` asserts the tap floor did not make that
+  move.
+- **A table can be *contained* and still not pinned, and the ratchet cannot tell.** `Dividends`'
+  detail ledger sat in an inline `{ maxHeight: 520, overflow: "auto" }` box, so it never overflowed
+  `.main` and read as done through five tickets — while at 640 you scrolled it sideways and lost the
+  identity column exactly as the untouched tables did. Two lessons, both now gates: the pane-overflow
+  number is evidence about the *pane*, not about a table, and a scroll box that predates the pattern
+  has to be a **class** before the pattern can reach it.
+- **The app bar is `box-sizing: content-box`** against the app-wide `border-box`, so the top inset
+  adds to its 48px instead of eating it. 48px is the number the whole drawer-versus-bottom-bar trade
+  was decided on; under `border-box` a 47px inset would crush the bar to a line.
+- **`.tabs` is not only the navigation strip.** `ByCategory.jsx:132` borrows the class for its own
+  view header — an `<h3>` and a year `<select>` — with the border overridden inline. That is why the
+  phone rule that hides the strip is `.main > .tabs`; a bare `.tabs` deletes that heading and the
+  year picker with it, and the view still renders, so nothing fails loudly.
+- Sticky + pinned cells require `border-collapse: separate; border-spacing: 0`; under `collapse`
+  they lose their borders. `pinned.spec.js` asserts both the border model and the resulting 1px
+  rules on the header and the pinned column — the model alone would pass while the borders were gone
+  for some other reason.
+- `display: none` starves `ResponsiveContainer` to 0×0 — drop chart *chrome* via `matchMedia`, never
+  the container. Landed as "do not render it at all", which is the stronger form of the same rule: a
   hidden chart and a collapsed chart are the same DOM, so nothing downstream could tell them apart.
-  `charts.spec.js` sweeps every `.recharts-responsive-container` in six views at ten viewports and
-  fails on a zero in either dimension.
 - **A percentage chart height is a trap that renders correctly.** `height="100%"` resolves against a
-  parent that has a height, so `Dividends` (inside a 220px wrapper) and `Options` (a bare container,
-  which defaults to `height="100%"`, inside a 240px one) both drew fine and would have collapsed to
-  0×0 the day someone made either wrapper flex-derived — with no error anywhere. Both carry explicit
-  pixel heights on the container now. **Never put a percentage height on a `ResponsiveContainer`.**
+  parent that has a height, so `Dividends` (inside a 220px wrapper) and `Options` (a bare container
+  inside a 240px one) both drew fine and would have collapsed to 0×0 the day someone made either
+  wrapper flex-derived — with no error anywhere. Both carry explicit pixel heights now. **Never put
+  a percentage height on a `ResponsiveContainer`.**
 - **A recharts bar with a negative value has a NEGATIVE `height`**, and that inverts `position`:
-  `LabelList position="top"` prints the label *below* the bar (`Label.js:161` — `verticalSign`). With
-  the lowest bar reaching the bottom of the plot, `−18.7k` lands on top of `25-04`. The fix is
-  `<YAxis padding={{ bottom }}>`, which shrinks the scale's *range* rather than its domain and so
-  reserves a strip no bar can enter. Not phone-only — a negative bar reaches the bottom at every width.
-  **Apply it only when the data actually holds a negative**: shrinking the range lifts the baseline
-  too, so on a positive-only series it detaches every bar from the axis line for a label that does
-  not exist. That is the trap inside the fix, and it looks like a rendering bug rather than a
-  reserved band.
+  `LabelList position="top"` prints the label *below* the bar (`Label.js:161` — `verticalSign`). The
+  fix is `<YAxis padding={{ bottom }}>`, which shrinks the scale's *range* rather than its domain
+  and so reserves a strip no bar can enter. Not phone-only — a negative bar reaches the bottom at
+  every width. **Apply it only when the data actually holds a negative**: shrinking the range lifts
+  the baseline too, so on a positive-only series it detaches every bar from the axis line for a
+  label that does not exist.
 - **Recharts renders a `LabelList` only after the bar animation ends**, so a label count taken on
   arrival is 0 — and a gate expecting 0 passes for the wrong reason. `charts.spec.js`'s `barsSettled`
   waits for two identical samples of every bar's path; there is no marker in the DOM for this.
-- **`<Legend>` is a chart child, so its space comes out of the plot** — ~75px of a 300px chart. Every
-  key in the app is `.chartkey` DOM under the container. `inventory.spec.js` forbids `<Legend` in
-  source *and* names the two files that must carry a `<ChartKey>`, because "no legend" is also
+- **`<Legend>` is a chart child, so its space comes out of the plot** — ~75px of a 300px chart.
+  Every key in the app is `.chartkey` DOM under the container. `inventory.spec.js` forbids `<Legend`
+  in source *and* names the two files that must carry a `<ChartKey>`, because "no legend" is also
   satisfied by having no key at all — which is the state `NetWorth` actually shipped in.
 
 ## Re-running
 
-- **Any change under `web/src`** → `make test-web`, then the manual gates at 390×844 for touched views.
-- **Changes to `styles.css` or the shell** → `make test-web`, then the full manual sweep.
-- **The table inventory must be 22** — `grep -ro "<table" web/src | wc -l`. If it is not, a table has been
-  added or removed and the per-view table above is stale. Four tables went unassigned through the whole map
-  because two views never entered the inventory and two tables render only behind a conditional; this one
-  line is what catches the next one. `web/tests/inventory.spec.js` now asserts it, so `make test-web` fails
-  rather than leaving it to whoever remembers to run the grep.
+**The trigger is the suite. The command is `make test-web`.** It builds the frontend and runs all
+ten viewport projects plus the file-reading `inventory` project; a full run is ~8 minutes.
+
+```
+make test-web                                          # everything
+cd web && npx playwright test --project=design-width    # one viewport
+cd web && npx playwright test --ui                      # pick through it interactively
+```
+
+- **Any change under `web/src`** → `make test-web`.
+- **Changes to `styles.css` or the shell** → `make test-web`, and then the five real-device items
+  above if the change touches the tap floors, the safe-area guards or the nested scrolls.
+- **The table inventory, the `640` literal count, the `vh` sweep and the viewport list are all
+  inside the suite now.** There is no grep left for a human to remember.

--- a/RESPONSIVE.md
+++ b/RESPONSIVE.md
@@ -5,8 +5,11 @@ carries most of it.
 
 **The regression trigger is the suite, and the command is `make test-web`.** Ten named viewports ×
 thirteen views, run against a production build through vite's preview server with every API call
-served from committed fixtures: **1,237 assertions, ~8 minutes on an unloaded machine**, green as of
-this reconciliation. `web/TESTING.md` says what each spec claims. The table-inventory grep this file used to ask a human
+served from committed fixtures: **1,237 passed, 308 skipped, 0 failed, ~8 minutes on an unloaded
+machine**, as of this reconciliation. The skips are structural rather than disabled tests — a gate
+whose subject does not render at a viewport skips there, which is what makes "no card-per-row at 640
+and above" and "the desktop table is untouched" separate claims from their positive halves.
+`web/TESTING.md` says what each spec claims. The table-inventory grep this file used to ask a human
 to run is inside that suite now, so nothing here is a check you have to remember.
 
 **So this file holds what is left for a human, and only that.** Every gate the suite asserts has been
@@ -259,7 +262,11 @@ than in the gate list because eyeballing an unbuilt rule is not a check, and bec
 no owner is precisely how four tables went unassigned through the whole map.
 
 - **The 44px tap floor never reached the content controls, and 16px form controls never landed at
-  all.** `--tap: 44px` is declared and used by `.navitem`, `.logout-btn`, `.bar-btn`, `.tabsel` and
+  all.** **Decided in `.wayfinder/tickets/015-touch-targets-type-scale.md`, which is closed, and
+  never given a build issue** — every ticket that could have carried it was scoped to a pattern or a
+  view, and the rules are neither. **It has no issue number yet, and that is the first thing to fix
+  about it**: the entry below is the evidence a ticket needs, not the ticket.
+  `--tap: 44px` is declared and used by `.navitem`, `.logout-btn`, `.bar-btn`, `.tabsel` and
   `.tablenote > summary` — the navigation shell and the footnote disclosure, no more. The rest of
   what was decided is absent from `styles.css`: `input, select, textarea { font-size: 16px }`,
   `th, td { padding: 11px 8px }` (the 44px row pitch), and the square floor on `.link-btn`,

--- a/RESPONSIVE.md
+++ b/RESPONSIVE.md
@@ -262,10 +262,10 @@ than in the gate list because eyeballing an unbuilt rule is not a check, and bec
 no owner is precisely how four tables went unassigned through the whole map.
 
 - **The 44px tap floor never reached the content controls, and 16px form controls never landed at
-  all.** **Decided in `.wayfinder/tickets/015-touch-targets-type-scale.md`, which is closed, and
-  never given a build issue** — every ticket that could have carried it was scoped to a pattern or a
-  view, and the rules are neither. **It has no issue number yet, and that is the first thing to fix
-  about it**: the entry below is the evidence a ticket needs, not the ticket.
+  all.** Decided in `.wayfinder/tickets/015-touch-targets-type-scale.md`, which is closed, and never
+  given a build issue until the sweep went looking — every ticket after it was scoped to a *pattern*
+  or a *view*, and these are two rules about every fully-responsive screen, so each one reasonably
+  assumed the foundations ticket had them. **It is #47's now.**
   `--tap: 44px` is declared and used by `.navitem`, `.logout-btn`, `.bar-btn`, `.tabsel` and
   `.tablenote > summary` — the navigation shell and the footnote disclosure, no more. The rest of
   what was decided is absent from `styles.css`: `input, select, textarea { font-size: 16px }`,

--- a/web/CLAUDE.md
+++ b/web/CLAUDE.md
@@ -1,19 +1,11 @@
 # Frontend
 
 **The definition of done for anything you change under `web/src` is
-[`../RESPONSIVE.md`](../RESPONSIVE.md).** Read it before changing layout, not after.
+[`../RESPONSIVE.md`](../RESPONSIVE.md).** Read it before changing layout, not after. It holds only
+what the suite cannot assert, so a check written there is genuinely yours to run.
 
-**The regression trigger is the suite, and the command is `make test-web`** (from the repo root).
-It builds the frontend and runs ten named viewports × thirteen views against the production build,
-with every API call served from committed fixtures. A full run is ~8 minutes; one viewport is
-`cd web && npx playwright test --project=design-width`. First run on a machine also needs
-`cd web && npx playwright install chromium`.
+**The regression trigger is the suite: `make test-web`**, from the repo root, on any change under
+`web/src`. [`TESTING.md`](TESTING.md) beside this file says what it runs, what each spec claims, and
+what none of them can.
 
-`RESPONSIVE.md` holds only what the suite cannot assert: five gates that need a real iPhone and one
-observation that needs an iPad, the rest of the observations with their measured values, the open
-calls, and one section of rules that were decided and never built. Every
-gate the suite covers has been deleted from it rather than struck through — so if a check is written
-there, it is genuinely yours to run.
-
-`TESTING.md` in this directory says what each spec claims and, more usefully, what it cannot.
-`RESPONSIVE.md`'s **Traps** section is the list of things that look like tidying and are not.
+Nothing else about the suite is repeated here on purpose — this file points, it does not restate.

--- a/web/CLAUDE.md
+++ b/web/CLAUDE.md
@@ -1,0 +1,19 @@
+# Frontend
+
+**The definition of done for anything you change under `web/src` is
+[`../RESPONSIVE.md`](../RESPONSIVE.md).** Read it before changing layout, not after.
+
+**The regression trigger is the suite, and the command is `make test-web`** (from the repo root).
+It builds the frontend and runs ten named viewports × thirteen views against the production build,
+with every API call served from committed fixtures. A full run is ~8 minutes; one viewport is
+`cd web && npx playwright test --project=design-width`. First run on a machine also needs
+`cd web && npx playwright install chromium`.
+
+`RESPONSIVE.md` holds only what the suite cannot assert: five gates that need a real iPhone and one
+observation that needs an iPad, the rest of the observations with their measured values, the open
+calls, and one section of rules that were decided and never built. Every
+gate the suite covers has been deleted from it rather than struck through — so if a check is written
+there, it is genuinely yours to run.
+
+`TESTING.md` in this directory says what each spec claims and, more usefully, what it cannot.
+`RESPONSIVE.md`'s **Traps** section is the list of things that look like tidying and are not.

--- a/web/TESTING.md
+++ b/web/TESTING.md
@@ -1,8 +1,10 @@
 # Frontend verification — start here
 
 **The definition of done for anything you change under `web/src` is [`../RESPONSIVE.md`](../RESPONSIVE.md).**
-It is the checklist: ten viewports, the universal gates, the per-view gates, the traps, and
-the handful of items that need a real iPhone. Read it before changing layout, not after.
+It is the checklist — and since the sweep reconciled it against this suite, it holds **only what
+this suite cannot assert**: five items that need a real iPhone or iPad, the observations with their
+measured values, the open calls, and one section of rules that were decided and never built. Every
+gate that moved in here was deleted from there. Read it before changing layout, not after.
 
 **The command is `make test-web`** (from the repo root). It builds the frontend and runs the
 Playwright viewport suite against the production build through vite's preview server.
@@ -19,8 +21,9 @@ First run on a machine also needs the browser: `cd web && npx playwright install
 
 `tests/baseline.spec.js` — ten named viewports × thirteen views. Its header docstring is the
 authority on what it asserts and, more importantly, **what it can never assert**. Read that
-before treating a green run as "verified on a phone"; it is not. Four things need a real
-iPhone and are named there.
+before treating a green run as "verified on a phone"; it is not. Five things need a real
+device and are named there — the fifth arrived with the tablet tier, which put the navigation
+shell on a height guard the 44px tap floor deliberately did not follow.
 
 **Where the shell is the phone's, "open a view" means different clicks**, and
 `tests/support/app.js` makes them: the hamburger, then the section in the drawer, then the tab in

--- a/web/TESTING.md
+++ b/web/TESTING.md
@@ -2,9 +2,10 @@
 
 **The definition of done for anything you change under `web/src` is [`../RESPONSIVE.md`](../RESPONSIVE.md).**
 It is the checklist — and since the sweep reconciled it against this suite, it holds **only what
-this suite cannot assert**: five items that need a real iPhone or iPad, the observations with their
-measured values, the open calls, and one section of rules that were decided and never built. Every
-gate that moved in here was deleted from there. Read it before changing layout, not after.
+this suite cannot assert**: five gates that need a real iPhone and one observation that needs an
+iPad, the rest of the observations with their measured values, the open calls, and one section of
+rules that were decided and never built. Every gate that moved in here was deleted from there. Read
+it before changing layout, not after.
 
 **The command is `make test-web`** (from the repo root). It builds the frontend and runs the
 Playwright viewport suite against the production build through vite's preview server.
@@ -21,9 +22,9 @@ First run on a machine also needs the browser: `cd web && npx playwright install
 
 `tests/baseline.spec.js` — ten named viewports × thirteen views. Its header docstring is the
 authority on what it asserts and, more importantly, **what it can never assert**. Read that
-before treating a green run as "verified on a phone"; it is not. Five things need a real
-device and are named there — the fifth arrived with the tablet tier, which put the navigation
-shell on a height guard the 44px tap floor deliberately did not follow.
+before treating a green run as "verified on a phone"; it is not. Five gates need a real iPhone and
+one observation needs an iPad, all six named there — the fifth gate arrived with the tablet tier,
+which put the navigation shell on a height guard the 44px tap floor deliberately did not follow.
 
 **Where the shell is the phone's, "open a view" means different clicks**, and
 `tests/support/app.js` makes them: the hamburger, then the section in the drawer, then the tab in

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -421,8 +421,16 @@ tr.subrow > td { background: var(--panel2); }
    The *vertical* half is app-wide, because it costs nothing horizontally. The *horizontal*
    half is scoped to the two editors — `.fillpane` is Classify, `.nw-del` is Net Worth —
    because widening a `✕` inside a table cell widens the table, and Recurring's three
-   `.link-btn`s are in a fully-responsive view whose floor is 44px square, not 24px. They
-   get their width from that rule, in the phone tier, rather than twice. */
+   `.link-btn`s are in a fully-responsive view whose floor is 44px square, not 24px — so
+   their width was left to that rule rather than written twice.
+
+   THAT RULE DOES NOT EXIST YET, and this comment used to imply it did. The 44px floor
+   reached the navigation shell and the footnote disclosure only; `.link-btn`,
+   `.refresh-btn`, `select`, the SecurityDetail back link and the "show excluded" label
+   never got it, and `input, select, textarea { font-size: 16px }` never landed at all.
+   Measured at 390x844: Recurring alone carries 38 controls under 44px square. Recorded
+   with the rest of the evidence under "Not built yet" in `RESPONSIVE.md`. Until it lands,
+   Recurring's three buttons are 24px tall and 24px is the whole of their floor. */
 button { min-height: 24px; }
 .fillpane button, .nw-del { min-width: 24px; }
 /* S2 inline: one line per entry, the proportional fill *behind* the text rather than beside

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -429,8 +429,9 @@ tr.subrow > td { background: var(--panel2); }
    `.refresh-btn`, `select`, the SecurityDetail back link and the "show excluded" label
    never got it, and `input, select, textarea { font-size: 16px }` never landed at all.
    Measured at 390x844: Recurring alone carries 38 controls under 44px square. Recorded
-   with the rest of the evidence under "Not built yet" in `RESPONSIVE.md`. Until it lands,
-   Recurring's three buttons are 24px tall and 24px is the whole of their floor. */
+   with the rest of the evidence under "Not built yet" in `RESPONSIVE.md`, and owned by
+   issue #47. Until it lands, Recurring's three buttons are 24px tall and 24px is the whole
+   of their floor. */
 button { min-height: 24px; }
 .fillpane button, .nw-del { min-width: 24px; }
 /* S2 inline: one line per entry, the proportional fill *behind* the text rather than beside

--- a/web/tests/baseline.spec.js
+++ b/web/tests/baseline.spec.js
@@ -8,12 +8,20 @@
  * derived once from the live database. This is the same substitution shape the backend
  * suite uses at the persistence boundary, one layer down.
  *
- * WHAT THIS SUITE ASSERTS TODAY. Only what already holds. This file is the baseline the
- * mobile-responsive work is measured against, so it must run green against the code as
- * it stands, before any layout change lands — otherwise "desktop is unchanged" is an
- * assertion nobody can check. The suite grows as behaviour lands; the per-view gates in
- * `RESPONSIVE.md` (pinned columns, card patterns, the drawer, 44px targets, 16px form
- * controls) are deliberately not here yet, because none of them are true yet.
+ * WHAT THIS FILE ASSERTS. The gates that are true of *every* view at *every* viewport, and
+ * nothing else: that the view rendered from fixtures at all, that nothing computes to
+ * `position: fixed`, and the horizontal-overflow ratchet. It began as the baseline the
+ * mobile-responsive work was measured against — green against the code as it stood, before
+ * any layout change landed, so that "desktop is unchanged" was an assertion somebody could
+ * check — and every pattern that landed since took its gates to its own spec rather than
+ * here: the pin to `pinned.spec.js`, the cards to `cards.spec.js`, the drawer to
+ * `shell.spec.js`, the tier to `tablet.spec.js`.
+ *
+ * TWO OF `RESPONSIVE.md`'S UNIVERSAL CRITERIA HAVE NO SPEC AT ALL, and that is not an
+ * omission here: the 44px tap floor on content controls and 16px form controls were decided
+ * and never built, so there is nothing to assert. They are recorded under that file's
+ * "Not built yet" with the measured evidence. Do not add a gate for them before the rules
+ * exist — a suite that fails for behaviour nobody has written is a suite people switch off.
  *
  * WHAT THIS SUITE CANNOT CHECK, EVER. A green run is not "verified on a phone":
  *
@@ -26,14 +34,18 @@
  *     paints under the home indicator with no seam.
  *   - Touch-target comfort and nested-scroll feel. 44px is measurable; whether a target
  *     is comfortable, and whether two nested scroll regions feel confusing rather than
- *     merely being geometrically fine, are subjective by construction.
+ *     merely being geometrically fine, are subjective by construction. There are two
+ *     places for this rather than one since the tablet tier: the drawer at 390x844, where
+ *     the floor applies and measures 44px, and the drawer at 844x390, where it
+ *     deliberately does not and measures 39px.
  *   - Every open call. An open call changes a decision rather than failing a check —
  *     whether the recurring-spend monitor wants a redesign rather than a reflow, whether
  *     any phone list needs a row cap, whether SecurityDetail's transaction history reads
  *     as cramped. None of those are assertions.
  *
- * The manual checklist therefore shrinks rather than dies: it keeps those four items,
- * the observations, and the open calls.
+ * The manual checklist therefore shrinks rather than dies: it keeps those items, the
+ * observations, and the open calls — and nothing else. The sweep reconciled it against
+ * this suite, so a gate written there is one a person genuinely has to run.
  *
  * ONE GATE IS SCOPED, AND IT IS A RATCHET RATHER THAN A LINE. The horizontal-scroll gate
  * applies only below 1024px — `HSCROLL_GATE_APPLIES_BELOW` says why the wider two are


### PR DESCRIPTION
Closes nothing yet — see **What is still open** at the foot. Refs #34.

## What this does

Ran the full sweep, then made `RESPONSIVE.md` tell the truth about what is left for a human.

**The suite is green at every viewport**: 1,237 passed, 308 skipped, 0 failed, ~8 minutes, ten viewport projects plus `inventory`. Run three times; the one intermediate failure was four timeouts at `phone-tier-last-pixel` under load, which passed on their own and on the next clean run.

**Every gate the suite asserts is deleted from the checklist rather than struck through.** A file carrying its own history stops being a checklist, and the history is in git. Universal gates go 8 → 4, with the four departures tabulated against the spec that took each one. The per-view table becomes an assignment register — every row carries its final pattern, and a third column says what a person still looks at, which for eight of the fourteen is "—". The two editors keep one criterion of four.

**The horizontal-scroll gate's scope is written down with its reason**: below 1024 only, because the widest position table is 1272px against 1024px of content at 1280 and the pin stops there. Unscoped it could never pass, which is how a gate trains reviewers to ignore it.

**`make test-web` is named as the trigger**, and the table-inventory grep the file used to ask a human to run is inside the suite. There is no grep left to remember.

**`web/CLAUDE.md` lands**, three tickets after 019 specified it. It points; it does not restate.

## The observations, measured

| observation | value |
|---|---|
| GSI button at `size: "large"` | **177.39 × 40px** — 40 < 44, so the carve-out is **load-bearing**, not moot |
| Holdings rows on one screen | **12 portrait** (11 data + 1 group), **4 landscape** — both predictions met |
| Drawer row height | **39px at 844×390** against **44px at 390×844** |
| safe-area seam · iPadOS focus-zoom | **not recorded** — hardware |

The GSI button had to be measured off-suite: the suite's seam aborts every cross-origin request by design, so Google's script never loads under test. Measured against the dev server on `localhost:5173`, which `DEPLOY.md` lists as an authorized origin, with the session endpoint answered 401.

Holdings met its prediction **by a route the prediction did not name**: 52.5px rows, because the pinned `Security` cell is two lines — not the 44px cell pitch the forecast was taken at, which is the next section. And at 844×390 the footnote is *expanded*, because `Holdings.jsx` reads its query by width once at mount, so the landscape count is the harder case rather than the easier one.

## What the sweep found

**Two of the universal criteria describe rules that were decided and never built.** `--tap: 44px` reached the navigation shell and the footnote disclosure; the rest of ticket 015's table is absent from `styles.css` — `input, select, textarea { font-size: 16px }`, `th, td { padding: 11px 8px }`, and the square floor on `.link-btn`, `.refresh-btn`, `select`, the back link and the "show excluded" label. Measured at 390×844: Recurring alone carries 38 controls under 44px square, and 199 selects and 27 inputs across the app render at 14px. **So the iOS focus-zoom decision — which `RESPONSIVE.md` calls the least-verified claim in the whole map — protects exactly one control today, the tab picker.**

They are recorded under a new **Not built yet** section rather than left as manual gates, because eyeballing an unbuilt rule is not a check, and filed as **#47**. The comment at `styles.css:414` that implied the phone rule existed now says it does not.

## What is still open

- **#34 cannot close on this PR.** Its last acceptance criterion is a real-iPhone check for the items that need one, and there is no device in this environment. `RESPONSIVE.md` gains a **Real-device log** — six rows, all "not yet run" — so an unrecorded check cannot pass for a done one.
- **#47** — the two unbuilt rules above.
- **#44** — `.grid2`'s 420px track floor, still the last horizontal overflow below 640: five views, one cause, 74 / 44 / 4 / 0 / 8 / 0 / 0.
- **#35** — `/api/spending/trends` is a captured 500, so Spending › Overview's stacked bar chart never mounts under test and is source-gated only.
- Six **open calls**, unchanged and still decisions rather than bugs — including whether 768 and 1000 become viewports, which the sweep deliberately did not decide for you.

## Review

`/code-review` against `main` found three real issues, all fixed in the second commit: the new residual had no owner in the section whose own rule is that a residual must have one; `web/CLAUDE.md` restated `TESTING.md` rather than pointing at it; and the device-item count read five in two files and six in a third.
