### PR TITLE
The 44px tap floor and 16px form controls, and the sweep that finds the next one

### DIFF
--- a/RESPONSIVE.md
+++ b/RESPONSIVE.md
@@ -168,7 +168,7 @@ person still looks at, and "—" means the suite has all of it.
 | Spending › Classify | editor floor · `.fillpane`/`.grow` become blocks below 640 so the page scrolls as one, `.scroll` deliberately untouched · ⇅ Reorder `display: none`, so the reorder modal is unreachable below the tier by design · `RuleModal` on `svh`, its control rows wrap, `CatSelect` capped at `max-width: 100%`, `MatchTable` `.contained` | readable · `MatchTable` renders only after a POST the GET-captured fixtures do not carry — `editors.spec.js` annotates that gap |
 | Spending › Recurring | monitor **A** · candidates **A** | the monitor never mounts — the owner tracks nothing, so `/api/spending/recurring` is `[]` and its pin is eyes-only (`pinned.spec.js` annotates it) · the **two nested scroll regions**, which is the feel check |
 | Spending › Transactions | **B** below 640 — six fields, merchant, one amount, four muted on a second line, no key/value block · **A** on `Date` from 640 to 1024, a *choice* rather than the default: `Merchant` measures **561px** of unbounded free text against a 440px window | excluded rows keep their dimming but **no fixture holds one**, so both renderings are unexercised — `cards.spec.js` asserts the two agree on 0.55 rather than observing either |
-| Sign-in | `100svh` at `auth.jsx:50` and `:125` · the box fills the screen and centres optically · **no phone rule at all** · GSI button carved out of the 44px floor | whether a **40px** button (measured) looks right beside a 44px world |
+| Sign-in | `100svh` at `auth.jsx:50` and `:125` · the box fills the screen and centres optically · **no phone rule at all** · the GSI button is **untouched by** the 44px floor rather than carved out of it — it is a `div[role="button"]` Google injects, and this screen has no form control of its own, so no selector reaches it | whether a **40px** button (measured) looks right beside a 44px world |
 
 ## Observations
 
@@ -313,7 +313,9 @@ Things the build session must be told, not left to discover.
   style beats is the same property, not the element. The trap is real for anyone trying to change
   its type size, and only that.
 - **A floor is one rule, and a population is one class.** The 44px square floor is written once, as
-  one selector list with one `:not(.editor *)` on it. `.editor` marks the two desktop-optimised
+  one selector list — and `:not(.editor *)` is on **every member of it**, including the two that
+  appear in no editor today, because a floor that is exempt-by-ancestor for some of its selectors
+  and unconditional for the rest is not exempt-by-ancestor at all. `.editor` marks the two desktop-optimised
   views' roots and does *nothing else* — it is not `.fillpane`, which is Classify's flex machinery
   and happens to sit on the same element. The two are separate on purpose: a later ticket that
   restructures Classify's scroll ownership must not silently hand it a 44px floor by deleting a

--- a/RESPONSIVE.md
+++ b/RESPONSIVE.md
@@ -5,8 +5,8 @@ carries most of it.
 
 **The regression trigger is the suite, and the command is `make test-web`.** Ten named viewports ×
 thirteen views, run against a production build through vite's preview server with every API call
-served from committed fixtures: **1,237 passed, 308 skipped, 0 failed, ~8 minutes on an unloaded
-machine**, as of this reconciliation. The skips are structural rather than disabled tests — a gate
+served from committed fixtures: **1,345 passed, 470 skipped, 0 failed, ~7.5 minutes on an unloaded
+machine**, as of #47. The skips are structural rather than disabled tests — a gate
 whose subject does not render at a viewport skips there, which is what makes "no card-per-row at 640
 and above" and "the desktop table is untouched" separate claims from their positive halves.
 `web/TESTING.md` says what each spec claims. The table-inventory grep this file used to ask a human
@@ -25,10 +25,11 @@ stop being trusted:
 - **Open calls** — failing one **changes a decision** rather than reporting a bug.
 
 **One thing is none of the three, and it is written down under [Not built yet](#not-built-yet)
-instead of hiding in a gate**: two of the universal criteria — the 44px tap floor and 16px form
-controls in fully-responsive views — describe rules that were decided and never built. They are not
-manual checks, they are outstanding work, and a checklist that lists unbuilt rules as things to
-eyeball is how they stay unbuilt for another five tickets.
+instead of hiding in a gate**: a rule that was decided and never built. It is not a manual check, it
+is outstanding work, and a checklist that lists unbuilt rules as things to eyeball is how they stay
+unbuilt for another five tickets. **That section held two entries and holds one** — the 44px tap
+floor and 16px form controls landed as #47, which is what took universal gate 4 from one control to
+every control; `.grid2`'s track floor is what is left, and it is #44's.
 
 Visual-regression diffing remains out of scope by decision, and a test asserts no screenshot
 assertion creeps in.
@@ -85,8 +86,14 @@ the only gates left in this file:
 2. **`env(safe-area-inset-*)`.** Desktop Chrome reports **0** at every viewport in both
    orientations; the shell prototype had to fake them.
 3. **The nested-scroll feel on Recurring.** Geometry is fine; whether it confuses is not.
-4. **Touch-target comfort at 44px**, wherever the floor landed — the drawer in portrait, the app
-   bar, the tab picker, the footnote disclosure.
+4. **Touch-target comfort at 44px**, wherever the floor landed — which since #47 is **every control
+   in the eleven fully-responsive views**, not only the navigation. The drawer in portrait, the app
+   bar, the tab picker and the footnote disclosure had it before; the tables' own controls, the
+   filter `<select>`s, the checkbox labels, `Recurring`'s `+ Track` / `✕` pairs and the 44px row
+   pitch under every `tr.rowlink` and `tr.rowtap` have it now. `tap.spec.js` gates the geometry at
+   four phone viewports; **whether it is comfortable is still an eye**, and the two places to look
+   first are the ones where 44px cost something visible: `Recurring`'s action column (100.72 →
+   118.8px) and `Holdings`, which lost two rows a screen.
 5. **Touch-target comfort at 844×390, where the floor deliberately did *not* travel.** The shell
    follows `(max-height: 500px)` and the tap floor follows `max-width`, so a rotated phone opens a
    drawer with **39px** rows (measured — see [Observations](#observations)). `shell.spec.js` asserts
@@ -118,10 +125,12 @@ What is left:
 3. **The bottom of a scrolled list is reachable and sign-in does not rubber-band.** `100svh` and its
    consequences are asserted as declarations and as geometry; the **symptom** stays an iPhone check,
    because emulation has no retractable toolbar and so cannot see the strip either way.
-4. **iOS focus-zoom does not fire on the one control that was given 16px** — the tab picker.
-   `shell.spec.js` asserts the computed 16px; whether that actually suppresses Safari's zoom is the
-   least-verified claim in the whole effort. *(Every other form control on a phone is not a check —
-   see [Not built yet](#not-built-yet).)*
+4. **iOS focus-zoom does not fire on any form control.** `tap.spec.js` sweeps every rendered
+   `input`, `select` and `textarea` in all thirteen views at every phone viewport and asserts the
+   computed 16px; `shell.spec.js` holds the tab picker's separately, since that one is in the app
+   bar rather than under `.main`. Whether 16px actually suppresses Safari's zoom is still the
+   least-verified claim in the whole effort — but it is no longer also the narrowest. *(Until #47
+   the rule protected exactly one control, and this gate said so.)*
 
 ## The two editors
 
@@ -152,7 +161,7 @@ person still looks at, and "—" means the suite has all of it.
 | Portfolio › Dividends | crosstab **A** (grows in columns, so h-scroll never expires) · payment ledger **B** below 640, **A** on `Date` from 640 to 1024 · `LabelList` dropped below 640 · `--selfscroll: 520px` keeps desktop's box height without an inline `max-height` | — |
 | Portfolio › Options | contract ledger **A**, pinning `Underlying` · by-ticker and by-type unchanged (273/261px — they genuinely fit) · monthly P/L 6 bars below the tier against 24 above it, with the reserved band only when the window holds a loss | — |
 | Portfolio › Transactions | **B** below 640 · **A** on `Date` from 640 to 1024 | — *(telling two same-day trades apart is an [open call](#open-calls), not a check)* |
-| Portfolio › SecurityDetail | txn history **B** · dividend history **B** · options history **A**, pinning the merged two-line `Contract` cell — and **B, A, A** above 640, since the tier gives both histories the pin on `Date` · `← Holdings` is a ≥44px target and the only way back | the dividend history renders for no fixture (PLTR has none) — its wrapper is the one thing in the tier no fixture reaches, and `pinned.spec.js` annotates that on every run |
+| Portfolio › SecurityDetail | txn history **B** · dividend history **B** · options history **A**, pinning the merged two-line `Contract` cell — and **B, A, A** above 640, since the tier gives both histories the pin on `Date` · `← Holdings` is `a.backlink`, a ≥44px target below the tier and the only way back — it was 17px until #47, see [Observations](#observations) | the dividend history renders for no fixture (PLTR has none) — its wrapper is the one thing in the tier no fixture reaches, and `pinned.spec.js` annotates that on every run |
 | Net Worth | editor floor · line chart carries a DOM `.chartkey`, not `<Legend>` · Breakdown and History `.contained` **below 1024**, not unconditionally · row grid unchanged | readable — the editors' remaining criterion |
 | Spending › Overview | donut dropped below 640, the list is the chart · stacked bar chart's `<Legend>` is a `.chartkey` · Top Line Items **B** below 640, **A** on `Category` from 640 to 1024 | the stacked bar chart itself: `/api/spending/trends` was captured as a **500**, so it never mounts under test. `inventory.spec.js` gates it from source and `charts.spec.js` annotates the gap. Closes when **#35** does |
 | Spending › By Category | donut dropped below 640 · Categories **A** with the name column pinned, keeping its own `▸`/`▾` and the `.rowtap` flash *instead of* the persistent `›` · drilled transactions **B**, **outside the `.grid2` entirely** rather than merely outside the table | whether three levels of drill read as one structure once the third leaves the grid |
@@ -179,23 +188,41 @@ reconciliation unless marked otherwise.
 - **Whether iPadOS Safari focus-zooms form controls — NOT RECORDED.** Needs a real iPad. The spec
   assumes it does not, and keeps 16px inputs phone-only on that basis. This remains the
   least-verified claim in the whole map.
-- **Holdings rows achieved — 12 portrait, 4 landscape. Both predictions met.**
-  At **390×844**: 12 rows fully on screen (11 data + 1 group row), 13 counting the one cut by the
-  fold — against a predicted 12–13. At **844×390**: 4 fully on screen (3 data + 1 group), 5 counting
-  the partial — against a predicted 4. A data row is **52.5px**, a group row **36px**.
-  Two things worth knowing about *how* it was met. The prediction was taken at a 44px cell pitch that
-  [was never built](#not-built-yet); the count lands in range anyway because the pinned `Security`
-  cell is two lines, which makes a data row 52.5px on its own. And at 844×390 the footnote
-  disclosure is **open**, because `Holdings.jsx` reads its query by *width*, once, at mount — 844 is
-  not the phone tier — so the landscape count is with the footnote expanded, which is the harder
-  case rather than the easier one.
+- **Holdings rows achieved — 10 portrait, 4 landscape. Re-measured after #47, and the portrait
+  prediction is now MISSED by two.**
+  At **390×844**: **10** rows fully on screen (9 data + 1 group row), 11 counting the one cut by the
+  fold — against a predicted 12–13. At **844×390**: **4** fully on screen (3 data + 1 group), 5
+  counting the partial — against a predicted 4, unchanged. A data row is **60.5px** portrait and
+  **52.5px** landscape; a group row **44px** and **36px**.
+  **The two numbers differ because the tap floor is width-scoped**, which is the tier's own split
+  showing up in a row count: 844 is not the phone tier, so a rotated phone gets the old 7px cell
+  padding and the old row heights. Landscape did not change at all.
+  Portrait did, and the prediction was wrong in both directions at once. 015 forecast a 44px pitch
+  and 12 rows; the pitch it actually produces here is **60.5px**, because the pinned `Security` cell
+  is two lines and 11px of padding is paid on both of them. The count was *met* before #47 for the
+  same reason — the two-line cell made a row 52.5px without any pitch rule at all — so the earlier
+  reading of "prediction met" was a coincidence of the wrong cause. **Two rows is the price of the
+  floor on this screen**, and 015 stated the bill as 15 → 12 on a one-line cell.
+  At 844×390 the footnote disclosure is **open**, because `Holdings.jsx` reads its query by *width*,
+  once, at mount — so the landscape count is with the footnote expanded, the harder case.
+- **`SecurityDetail`'s `← Holdings` — 76.45 × 44px below the tier, 76.45 × 17px above it.** Recorded
+  because the per-view table asserted it was "a ≥44px target" and **it was not**: a bare `<a>` with
+  an `onClick` and no `href` is inline and had no box at all, so it measured 17px tall until #47 gave
+  it `a.backlink` and the inline-flex. It is the one claim in this file the sweep found to be simply
+  false rather than unbuilt. Above 640 it is still 17px, by the same decision that leaves a rotated
+  phone with 39px drawer rows.
+- **`Recurring`'s action column — 100.72px → 118.8px** below the tier, against 015's forecast of
+  ~45px → ~88px. Right direction, wrong magnitude in both readings: the cell already carried more
+  than the bare buttons, so the floor cost **18px** rather than the 43px predicted. Paid in scroll
+  distance inside a pinned table, which is what the forecast said it would be.
 - **The drawer's row height at 844×390 — 39px** (`Settings`, the dim one, 37.5px), against **44px**
   for the same rows at 390×844. Predicted ~38px. This is the residual the tablet tier's height guard
   creates and the one place two of that tier's decisions pull against each other: the shell travels
   to a rotated phone on `(max-height: 500px)`, and the 44px floor stays behind `max-width` because
   44px targets are on the tier's "explicitly not done" list. Above WCAG 2.5.8's 24px floor, below
   the comfort target the same effort set for the same control in portrait. The comfort half is
-  iPhone item 5.
+  iPhone item 5. **Re-measured after #47 and still 39px**, which was the point of measuring it: that
+  ticket gave a rotated phone every new rule for its *content* and none for its navigation.
 
 ## Real-device log
 
@@ -207,7 +234,7 @@ it implied — an unrecorded device check is indistinguishable from one that nev
 | 1 | iOS focus-zoom on the tab picker at 390×844 | — | — | **not yet run** |
 | 2 | notch and home-bar seam under `viewport-fit=cover`, both orientations | — | — | **not yet run** |
 | 3 | Recurring's two nested scroll regions — does it confuse | — | — | **not yet run** |
-| 4 | 44px comfort where the floor landed: drawer, app bar, picker, footnote summary | — | — | **not yet run** |
+| 4 | 44px comfort where the floor landed — since #47, every control in the eleven fully-responsive views | — | — | **not yet run** |
 | 5 | 39px drawer rows at 844×390 — comfortable, or does the floor need the height arm | — | — | **not yet run** |
 | 6 | *(observation)* does iPadOS Safari focus-zoom form controls — an iPad, not an iPhone | — | — | **not yet run** |
 
@@ -261,35 +288,14 @@ Neither gates nor observations: **rules that were decided and never built**. The
 than in the gate list because eyeballing an unbuilt rule is not a check, and because a residual with
 no owner is precisely how four tables went unassigned through the whole map.
 
-- **The 44px tap floor never reached the content controls, and 16px form controls never landed at
-  all.** Decided in `.wayfinder/tickets/015-touch-targets-type-scale.md`, which is closed, and never
-  given a build issue until the sweep went looking — every ticket after it was scoped to a *pattern*
-  or a *view*, and these are two rules about every fully-responsive screen, so each one reasonably
-  assumed the foundations ticket had them. **It is #47's now.**
-  `--tap: 44px` is declared and used by `.navitem`, `.logout-btn`, `.bar-btn`, `.tabsel` and
-  `.tablenote > summary` — the navigation shell and the footnote disclosure, no more. The rest of
-  what was decided is absent from `styles.css`: `input, select, textarea { font-size: 16px }`,
-  `th, td { padding: 11px 8px }` (the 44px row pitch), and the square floor on `.link-btn`,
-  `.refresh-btn`, `select`, `SecurityDetail`'s back link and `Transactions`' "show excluded" label.
-  **Measured at 390×844 against the committed fixtures**, counting only fully-responsive views —
-  the two editors are exempt at 24px and clear it:
+**This section held two entries and holds one.** The 44px tap floor and 16px form controls — decided
+in `.wayfinder/tickets/015-touch-targets-type-scale.md`, absent from `styles.css` for five tickets,
+found by measuring rather than by reading — **landed as #47** and are gated by `tap.spec.js`, which
+is a sweep of everything the page renders rather than a list of selectors, because a named-selector
+gate is exactly what could not notice them. What each view carried before it landed is in that
+issue; the numbers are not repeated here, since a checklist that keeps its own history stops being
+a checklist.
 
-  | view | controls under 44px square | form controls not at 16px |
-  |---|---|---|
-  | Portfolio › Holdings | grouping `<select>` 104×31 · checkbox 13×13 | 2 (12px) |
-  | Portfolio › Performance | grouping `<select>` 168×33 | 1 (14px) |
-  | Portfolio › Dividends | checkbox 13×13 | 1 (11.2px) |
-  | Portfolio › Transactions | account `<select>` 158×33 · text input 100×35 | 2 (14px) |
-  | Spending › By Category | 4 | 1 |
-  | Spending › Recurring | 38 — the three `.link-btn`s per row, at ~21px tall | 5 |
-  | Spending › Transactions | 3 | 3 |
-
-  `Portfolio › Overview`, `Options`, `SecurityDetail` and `Spending › Overview` carry no control
-  that fails, and sign-in's only one is the carved-out GSI button. **The 16px half is what the
-  entire iOS-focus-zoom decision rests on**, so today that decision protects one control — the tab
-  picker — and nothing else. `tablet.spec.js` already asserts the *inverse* above 640 ("tap targets
-  are not enlarged and inputs are not resized"), so the tier boundary is gated from one side only.
-  The stylesheet comment at `styles.css:414` reads as though the phone rule exists; it does not.
 - **`.grid2`'s `minmax(420px, 1fr)` track floor is the last horizontal overflow below 640, and it is
   **#44**'s.** Five views — `Portfolio › Overview`, `Options`, `Net Worth` and both `Spending`
   views — share it *to the pixel* at all seven gated viewports: 74 / 44 / 4 / 0 / 8 / 0 / 0. One
@@ -301,7 +307,25 @@ no owner is precisely how four tables went unassigned through the whole map.
 Things the build session must be told, not left to discover.
 
 - `spending/Transactions.jsx:40` carries an inline `fontSize: 13` — **CSS cannot reach it**; a rule
-  targeting it silently no-ops until that style moves to a class.
+  targeting it silently no-ops until that style moves to a class. **Narrower than it reads, and #47
+  is the proof**: only the *declared* property is out of reach. That label now carries `.taplabel`
+  and takes its `min-height` and its `display` from the stylesheet perfectly well; what an inline
+  style beats is the same property, not the element. The trap is real for anyone trying to change
+  its type size, and only that.
+- **A floor is one rule, and a population is one class.** The 44px square floor is written once, as
+  one selector list with one `:not(.editor *)` on it. `.editor` marks the two desktop-optimised
+  views' roots and does *nothing else* — it is not `.fillpane`, which is Classify's flex machinery
+  and happens to sit on the same element. The two are separate on purpose: a later ticket that
+  restructures Classify's scroll ownership must not silently hand it a 44px floor by deleting a
+  layout class. And the exemption is **asserted as a band** in `tap.spec.js` — at least 24px, and
+  something genuinely under 44 — so dropping the `:not()` fails there rather than being noticed the
+  next time somebody opens the rules table on a phone.
+- **A checkbox's tap target is its `<label>`, not its box.** All three checkboxes in the app are
+  wrapped in one and carry `.taplabel`; the floor is on the label and the box stays 13×13, because a
+  44px checkbox is a different thing from a 44px target. `tap.spec.js` resolves a checkbox to its
+  labelling ancestor before measuring, so a *new* checkbox with no label fails there — which is
+  correct, since nothing would be enlarging its target. A `<label>` is inline and has no box to
+  size, so the rule carries `display: inline-flex` with it; the same is true of `a.backlink`.
 - `Classify.jsx:126` carries an inline `maxHeight: 232` — same problem, accepted as-is, and it is
   **the one nested scroll region left in the app below 640**: the `.fillpane` machinery around it is
   neutralised there, so the rules list is the only thing on that screen that scrolls inside the page.
@@ -465,7 +489,7 @@ Things the build session must be told, not left to discover.
 ## Re-running
 
 **The trigger is the suite. The command is `make test-web`.** It builds the frontend and runs all
-ten viewport projects plus the file-reading `inventory` project; a full run is ~8 minutes.
+ten viewport projects plus the file-reading `inventory` project; a full run is ~7.5 minutes.
 
 ```
 make test-web                                          # everything

--- a/web/TESTING.md
+++ b/web/TESTING.md
@@ -86,7 +86,10 @@ at 24px by decision and the exemption is **asserted as a band** rather than skip
 if their floor disappears and if the phone one leaks in; a checkbox is measured on the `<label>` that
 wraps it, because clicking a label toggles the box and a 44px checkbox is not what a square floor
 means; and sign-in's Google button is unreachable here at all — the seam aborts Google's script — and
-was measured off-suite at 40px, which is why the carve-out is load-bearing. It is width-scoped, so
+has **no carve-out in the stylesheet because it needs none**: it is a `div[role="button"]` Google
+injects, and sign-in carries no form control of its own, so no selector in the floor reaches that
+screen. It was measured off-suite at 40px, which is why the number is written down rather than
+shrugged at. It is width-scoped, so
 844×390 gets the drawer and **no tap floor**, which is the same boundary `tablet.spec.js` asserts
 from above.
 

--- a/web/TESTING.md
+++ b/web/TESTING.md
@@ -3,9 +3,9 @@
 **The definition of done for anything you change under `web/src` is [`../RESPONSIVE.md`](../RESPONSIVE.md).**
 It is the checklist — and since the sweep reconciled it against this suite, it holds **only what
 this suite cannot assert**: five gates that need a real iPhone and one observation that needs an
-iPad, the rest of the observations with their measured values, the open calls, and one section of
-rules that were decided and never built. Every gate that moved in here was deleted from there. Read
-it before changing layout, not after.
+iPad, the rest of the observations with their measured values, the open calls, and one rule that was
+decided and never built. Every gate that moved in here was deleted from there. Read it before
+changing layout, not after.
 
 **The command is `make test-web`** (from the repo root). It builds the frontend and runs the
 Playwright viewport suite against the production build through vite's preview server.
@@ -74,6 +74,21 @@ wrapper holds the table and nothing else, it fits its parent, and — the part a
 does not give you — the identity column inside it is `sticky`. That last gate is what found the
 sixth table: `Dividends`' detail ledger had been inside an inline 520px scroll box since long
 before this work, so it never appeared in the pane ratchet and read as done.
+
+`tests/tap.spec.js` — the phone tier's two rules about every fully-responsive *screen*: 16px form
+controls and a 44px square tap floor, below 639.98px. **The only spec in the suite that is a sweep
+rather than a list**, and the reason is the bug it exists for: both rules were decided in ticket 015,
+built for the navigation shell alone, and went unnoticed for five tickets because every gate here
+asserts a selector somebody named — and a named-selector gate cannot see a control nobody named.
+This one asks the page what it renders and measures all of it, so a control added next year fails
+without anyone remembering it. Three carve-outs, each with its own reason: the two editors are exempt
+at 24px by decision and the exemption is **asserted as a band** rather than skipped, so it fails both
+if their floor disappears and if the phone one leaks in; a checkbox is measured on the `<label>` that
+wraps it, because clicking a label toggles the box and a 44px checkbox is not what a square floor
+means; and sign-in's Google button is unreachable here at all — the seam aborts Google's script — and
+was measured off-suite at 40px, which is why the carve-out is load-bearing. It is width-scoped, so
+844×390 gets the drawer and **no tap floor**, which is the same boundary `tablet.spec.js` asserts
+from above.
 
 `tests/pinned.spec.js` — pattern A: fourteen tables across ten views that pin an identity column and
 scroll the rest sideways below **1024px**, not 640. Eight of them are tables you read *down* a

--- a/web/playwright.config.js
+++ b/web/playwright.config.js
@@ -39,7 +39,7 @@ export default defineConfig({
     { name: "inventory", testMatch: /inventory\.spec\.js/ },
     ...VIEWPORTS.map((v) => ({
       name: v.name,
-      testMatch: /(baseline|unconditional|foundations|shell|pinned|cards|drill|charts|editors|tablet)\.spec\.js/,
+      testMatch: /(baseline|unconditional|foundations|shell|pinned|cards|drill|charts|editors|tablet|tap)\.spec\.js/,
       use: {
         ...devices["Desktop Chrome"],
         viewport: { width: v.width, height: v.height },

--- a/web/src/modules/networth/NetWorth.jsx
+++ b/web/src/modules/networth/NetWorth.jsx
@@ -37,8 +37,12 @@ export default function NetWorth() {
 
   const refreshSnaps = async () => setSnaps(await get("/api/networth/snapshots"));
 
+  /* `editor`, and it is the only thing this class does: it marks one of the two
+     desktop-optimised views so the phone tier's 44px square floor can exempt them by
+     ancestor rather than by listing their selectors. Their floor is WCAG 2.5.8's 24px at
+     every width — see `styles.css`'s square-floor block and `.wayfinder/tickets/017`. */
   return (
-    <div>
+    <div className="editor">
       <SummaryCards m={detail} />
       <div className="grid2" style={{ marginTop: 22 }}>
         <Trend snaps={snaps} />

--- a/web/src/modules/portfolio/Dividends.jsx
+++ b/web/src/modules/portfolio/Dividends.jsx
@@ -106,7 +106,8 @@ export default function Dividends() {
           {det && <span className="pill" style={{ marginLeft: 6 }}>{sgd(shownSgd)}</span>}
           {det && det.flagged > 0 &&
             <span className="pill" style={{ marginLeft: 6, color: "var(--neg)" }}>{det.flagged} need manual input</span>}
-          <label style={{ marginLeft: 12, fontWeight: 400, fontSize: ".8em" }}>
+          {/* `taplabel` — the label is the target, not the 13x13 box. See Holdings. */}
+          <label className="taplabel" style={{ marginLeft: 12, fontWeight: 400, fontSize: ".8em" }}>
             <input type="checkbox" checked={onlyFlagged} onChange={(e) => setOnlyFlagged(e.target.checked)} />
             &nbsp;flagged only
           </label>

--- a/web/src/modules/portfolio/Holdings.jsx
+++ b/web/src/modules/portfolio/Holdings.jsx
@@ -151,7 +151,10 @@ export default function Holdings() {
             {Object.entries(GROUPS).map(([k, v]) => <option key={k} value={k}>{v}</option>)}
           </select>
         </label>
-        <label className="mut" style={{ fontSize: 12, display: "flex", alignItems: "center", gap: 6 }}>
+        {/* `taplabel`: the label is the tap target, not the 13x13 box inside it — clicking it
+            toggles the checkbox, so a 44px checkbox would be the wrong reading of a square
+            floor. The same class is on the other two checkbox labels in the app. */}
+        <label className="mut taplabel" style={{ fontSize: 12, display: "flex", alignItems: "center", gap: 6 }}>
           <input type="checkbox" checked={showClosed} onChange={(e) => setShowClosed(e.target.checked)} />
           Show closed positions
         </label>

--- a/web/src/modules/portfolio/SecurityDetail.jsx
+++ b/web/src/modules/portfolio/SecurityDetail.jsx
@@ -13,7 +13,7 @@ export default function SecurityDetail({ ticker, bucket, onBack }) {
   }, [ticker, bucket]);
 
   if (!d) return <div className="loading">Loading {ticker}…</div>;
-  if (d.error || !d.summary) return <div className="loading">No data for {ticker}. <a onClick={onBack} style={{ cursor: "pointer", color: "var(--acc)" }}>← back</a></div>;
+  if (d.error || !d.summary) return <div className="loading">No data for {ticker}. <a className="backlink" onClick={onBack} style={{ cursor: "pointer", color: "var(--acc)" }}>← back</a></div>;
   const s = d.summary;
   // SGD, like every other tile — a native sum would be wrong anyway for a security paid in
   // more than one currency (e.g. an EUR REIT with SGD-settled lots).
@@ -24,7 +24,12 @@ export default function SecurityDetail({ ticker, bucket, onBack }) {
   return (
     <div>
       <div style={{ marginBottom: 14 }}>
-        <a onClick={onBack} style={{ cursor: "pointer", color: "var(--acc)", fontWeight: 600 }}>← Holdings</a>
+        {/* `backlink`, because this is the only way out of this view and a bare `<a>` with an
+            `onClick` and no `href` is inline — it has no box for a tap floor to size. It
+            measured 76.45x17 before the class landed; the phone rule gives it the inline-flex
+            and the 44px square. */}
+        <a className="backlink" onClick={onBack}
+           style={{ cursor: "pointer", color: "var(--acc)", fontWeight: 600 }}>← Holdings</a>
       </div>
       <div className="hd-row" style={{ display: "flex", alignItems: "baseline", gap: 10, marginBottom: 4 }}>
         <h2 style={{ margin: 0 }}>{s.name}</h2>

--- a/web/src/modules/spending/Classify.jsx
+++ b/web/src/modules/spending/Classify.jsx
@@ -104,8 +104,13 @@ export default function Classify() {
   const classified = q.total_spend - q.unclassified;
   const progress = q.total_spend ? Math.round((classified / q.total_spend) * 100) : 0;
 
+  /* `editor` alongside `fillpane`, and the two are not the same job: `fillpane` is the flex
+     machinery this view's scroll ownership is built on, `editor` marks it as one of the two
+     desktop-optimised views the phone tier's 44px square floor exempts by ancestor. Both
+     modals render inside this element, so the exemption reaches them too — which is the
+     point, since `RuleModal` is where the sheet is narrowest. */
   return (
-    <div className="fillpane">
+    <div className="fillpane editor">
       <div className="tiles">
         <Tile lbl="Spends" val={q.total_spend} />
         <Tile lbl="Unclassified" val={q.unclassified} cls={q.unclassified ? "neg" : ""} />

--- a/web/src/modules/spending/Transactions.jsx
+++ b/web/src/modules/spending/Transactions.jsx
@@ -37,7 +37,11 @@ export default function SpendTransactions() {
         <select value={source} onChange={(e) => setSource(e.target.value)} style={{ marginLeft: 8 }}>
           {Object.entries(SOURCES).map(([v, l]) => <option key={v} value={v}>{l}</option>)}
         </select>
-        <label style={{ marginLeft: 12, fontSize: 13, fontWeight: 400 }}>
+        {/* `taplabel` — 015 named this exact label when it wrote the rule: the label is the
+            target and `<label>` is inline, so it needs the flex to have a box at all. The
+            inline `fontSize: 13` stays out of reach of CSS and is left alone; nothing here
+            is a claim about its type size. */}
+        <label className="taplabel" style={{ marginLeft: 12, fontSize: 13, fontWeight: 400 }}>
           <input type="checkbox" checked={excluded} onChange={(e) => setExcluded(e.target.checked)} /> show excluded
         </label>
       </h3>

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -424,14 +424,15 @@ tr.subrow > td { background: var(--panel2); }
    `.link-btn`s are in a fully-responsive view whose floor is 44px square, not 24px — so
    their width was left to that rule rather than written twice.
 
-   THAT RULE DOES NOT EXIST YET, and this comment used to imply it did. The 44px floor
-   reached the navigation shell and the footnote disclosure only; `.link-btn`,
-   `.refresh-btn`, `select`, the SecurityDetail back link and the "show excluded" label
-   never got it, and `input, select, textarea { font-size: 16px }` never landed at all.
-   Measured at 390x844: Recurring alone carries 38 controls under 44px square. Recorded
-   with the rest of the evidence under "Not built yet" in `RESPONSIVE.md`, and owned by
-   issue #47. Until it lands, Recurring's three buttons are 24px tall and 24px is the whole
-   of their floor. */
+   THAT RULE EXISTS NOW — the square-floor block at the bottom of this file, #47. For five
+   tickets it did not, and this comment implied it did: the 44px floor had reached the
+   navigation shell and the footnote disclosure only, so Recurring's three buttons were 24px
+   tall and 24px was the whole of their floor. Below 640 their width is that rule's now, and
+   this one is what still holds them above it, on the desktop the editors are optimised for.
+
+   THE TWO RULES STAY SEPARATE, and the split is the reason: this one is unconditional and
+   `.fillpane`-scoped, that one is `max-width: 639.98px` and `:not(.editor *)`. Folding them
+   together would either take 44px to desktop or take the editors' 24px away below 640. */
 button { min-height: 24px; }
 .fillpane button, .nw-del { min-width: 24px; }
 /* S2 inline: one line per entry, the proportional fill *behind* the text rather than beside
@@ -631,6 +632,82 @@ input, select, textarea { background: var(--panel2); border: 1px solid var(--lin
      would hand it to any short desktop window too, which is the tier's own "desktop is
      unchanged" line. */
   .logout-btn { min-height: var(--tap); min-width: var(--tap); }
+
+  /* ── the two rules about every fully-responsive screen ──
+     015 decided both and neither was built for five tickets, because every ticket after it
+     was scoped to a *pattern* or a *view* and these are neither — so each one reasonably
+     assumed the foundations ticket had them. #34's sweep found the gap by measuring instead
+     of reading; they are #47's, and they are here now. `tests/tap.spec.js` is the gate, and
+     it is a sweep rather than a selector list for the same reason the gap existed: a
+     named-selector gate cannot notice a control nobody thought to name.
+
+     EXPLICIT 16px, NOT INHERITED. `input, select, textarea` take `font: inherit` from their
+     base rule and the body stays 14px by decision — raising it would invalidate every row-count and
+     column-width measurement in the spec — so this has to name the size rather than pick it
+     up. It is the whole of the defence against iOS Safari's focus-zoom, which re-scales the
+     layout when a control under 16px takes focus, and it applies to the two editors too:
+     their exemption is about tap *targets*, and NetWorth's 17-row form is the densest set of
+     inputs in the app rather than an accepted casualty. Accepted consequence, 015's: form
+     controls render visibly larger than the text around them, which is what iOS users see
+     across most of the web anyway. */
+  input, select, textarea { font-size: 16px; }
+
+  /* THE 44px ROW PITCH: 11 + 21 (14px x 1.5) + 11 + 1px border. Horizontal 10 -> 8 is not a
+     rounding — it returns ~40px of scroll distance on a ten-column table, so this makes the
+     widest tables *narrower* while making their rows tappable.
+
+     No carve-out for full-bleed rows, and that is a decision rather than an oversight: 015
+     refused one because exempting them means every table needs a class declaring whether it
+     is tappable and every table added later needs a judgement call. So this rule is also
+     what fixes `tr.rowtap` and `tr.rowlink` — a `min-height` on a `<tr>` is ignored by table
+     layout, and the cells are the only thing that can grow a row.
+
+     44px IS THE FLOOR, NOT THE PITCH, and the difference is measurable: a `.pinned` table
+     whose identity cell wraps to two lines pays the 11px on both of them, so Holdings' data
+     rows are 60.5px rather than 44 and the screen holds ten instead of the forecast twelve.
+     Recorded under Observations in `RESPONSIVE.md` rather than tuned away — a pitch that
+     shrinks when a cell wraps would not be a floor.
+
+     Global, editors included: it is what gives Classify's tables 44px rows for free, and
+     their floor was only ever about horizontal room inside a cell. */
+  th, td { padding: 11px 8px; }
+
+  /* THE SQUARE FLOOR. Square rather than height-only because the shape exists for bare glyph
+     buttons sitting adjacent, and `Recurring.jsx` is the view it was written for: `+ Track`
+     at 55x24 and `✕ dismiss` at 21.9x24 in the same cell. Cost, measured after the fact: that
+     action column goes 100.72px -> 118.8px, paid in scroll distance rather than in clipping.
+     015 forecast ~45px -> ~88px and was right about the direction only — the cell already
+     carried more than the two buttons, so the floor cost 18px rather than 43.
+
+     `:not(.editor *)` IS THE TWO-POPULATION SPLIT, WRITTEN ONCE. `.link-btn` is one class in
+     views with different obligations — seven instances in `Classify`, three in `Recurring` —
+     and 44px square inside Classify's rules table is not a padding tweak but the editor
+     redesign the map ruled out (three of them sit side by side in one cell). `.editor` marks
+     the two roots and nothing else; the unconditional 24px floor above stays written as
+     `.fillpane button, .nw-del` rather than being folded in here, because that one is a
+     claim about every width and widening its selector would change desktop.
+
+     CHECKBOXES ARE EXCLUDED AND TARGETED THROUGH THEIR LABEL. A 44px checkbox is not what a
+     square floor means; clicking a label toggles the box it wraps, so `.taplabel` is the
+     target and the box is a glyph inside it. 015 wrote exactly this for Transactions' "show
+     excluded"; Holdings' and Dividends' checkboxes have the same shape and take the same
+     class. The label needs the flex to have a box at all — `<label>` is inline, and so is
+     `SecurityDetail`'s back link, which is a bare `<a>` with an `onClick` and no `href`.
+
+     NOT ON THE SHELL'S ARM. This block is `max-width` only; the drawer travels to 844x390 on
+     `(max-height: 500px)` and this floor deliberately does not follow, which is what leaves a
+     rotated phone with 39px drawer rows. Extending it on height would hand it to any desktop
+     window under 500px tall — the tier's own "desktop is unchanged" line. */
+  button:not(.editor *),
+  select:not(.editor *),
+  textarea:not(.editor *),
+  input:not([type="checkbox"]):not(.editor *),
+  a.backlink,
+  .taplabel {
+    min-height: var(--tap);
+    min-width: var(--tap);
+  }
+  a.backlink, .taplabel { display: inline-flex; align-items: center; }
 
   /* THE NAVIGATION SHELL IS NOT HERE ANY MORE — see the `(max-height: 500px)` block above.
      It moved out whole rather than being duplicated: the shell was chosen on a *vertical*

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -679,7 +679,11 @@ input, select, textarea { background: var(--panel2); border: 1px solid var(--lin
      015 forecast ~45px -> ~88px and was right about the direction only — the cell already
      carried more than the two buttons, so the floor cost 18px rather than 43.
 
-     `:not(.editor *)` IS THE TWO-POPULATION SPLIT, WRITTEN ONCE. `.link-btn` is one class in
+     `:not(.editor *)` IS THE TWO-POPULATION SPLIT, AND IT IS ON EVERY MEMBER OF THE LIST —
+     including `a.backlink` and `.taplabel`, neither of which appears in an editor today. A
+     floor that is exempt-by-ancestor for four selectors and unconditional for two is not
+     exempt-by-ancestor; the next `.taplabel` to land inside NetWorth would take the phone
+     floor with nobody deciding it should. `.link-btn` is one class in
      views with different obligations — seven instances in `Classify`, three in `Recurring` —
      and 44px square inside Classify's rules table is not a padding tweak but the editor
      redesign the map ruled out (three of them sit side by side in one cell). `.editor` marks
@@ -702,8 +706,8 @@ input, select, textarea { background: var(--panel2); border: 1px solid var(--lin
   select:not(.editor *),
   textarea:not(.editor *),
   input:not([type="checkbox"]):not(.editor *),
-  a.backlink,
-  .taplabel {
+  a.backlink:not(.editor *),
+  .taplabel:not(.editor *) {
     min-height: var(--tap);
     min-width: var(--tap);
   }

--- a/web/tests/tap.spec.js
+++ b/web/tests/tap.spec.js
@@ -40,9 +40,13 @@
  *
  * 3. **Sign-in's Google button.** Not reachable here at all — sign-in is not one of the
  *    thirteen views, and `mockApi`'s seam aborts Google's script by design, so the button
- *    never exists in this suite. It is carved out of the floor in the stylesheet too, and #34
- *    measured it off-suite at 177.39 × 40px: under 44, so the carve-out is load-bearing rather
- *    than moot. `RESPONSIVE.md`'s Observations holds the number.
+ *    never exists in this suite. **There is no carve-out for it in the stylesheet, and it does
+ *    not need one**: GIS injects a `div[role="button"]`, and `auth.jsx` carries no `<button>`,
+ *    `<input>` or `<select>` of its own, so nothing in the floor's selector list reaches that
+ *    screen. It is unaffected rather than exempted, and the distinction is worth writing down
+ *    because a future sign-in control *would* take the floor without anyone deciding it should.
+ *    #34 measured the button off-suite at 177.39 × 40px — under 44, which is why the number is
+ *    recorded rather than shrugged at. `RESPONSIVE.md`'s Observations holds it.
  *
  * WHAT THIS CANNOT CHECK. Whether 44px is *comfortable* — that is item 4 on the real-device
  * list and it stays there. Geometry is all this file claims.
@@ -71,12 +75,19 @@ const EDITORS = new Set(["Net Worth", "Spending › Classify"]);
 /**
  * Everything that answers a tap, as a selector list.
  *
- * The interactive elements plus the two row classes that *are* controls — `tr.rowlink` opens
- * SecurityDetail and `tr.rowtap` drills a category, and neither is a `<button>`, so a sweep
- * of form controls alone would walk straight past the largest tap targets in the app. 015
- * refused a carve-out for full-bleed rows on purpose: exempting them means every table needs
- * a class declaring whether it is tappable, so the row pitch is what fixes these rather than
- * a rule of their own.
+ * The interactive elements plus the three row classes that *are* controls — `tr.rowlink` opens
+ * SecurityDetail, `tr.rowtap` drills a category, `tr.grouprow` collapses a Holdings group —
+ * and none of them is a `<button>`, so a sweep of form controls alone would walk straight past
+ * the largest tap targets in the app. 015 refused a carve-out for full-bleed rows on purpose:
+ * exempting them means every table needs a class declaring whether it is tappable, so the row
+ * pitch is what fixes these rather than a rule of their own.
+ *
+ * A TAPPABLE ROW IS THE ONE THING THIS SWEEP STILL HAS TO BE TOLD ABOUT, and that is a
+ * property of React rather than a shortcut: an `onClick` prop leaves no `onclick` attribute in
+ * the DOM, so there is nothing to query for. `tr.grouprow` was found by reading `Holdings.jsx`
+ * after the first version of this file shipped without it — it passes at 44px today, so the
+ * cost of the omission was an ungated pass rather than a missed failure, which is exactly the
+ * shape of the bug this whole file exists for. A new tappable row class needs adding here.
  *
  * `input` is here whole and split later — a checkbox is a control, it is just not measured
  * where it is drawn. `summary` is the footnote disclosure. `a` catches SecurityDetail's back
@@ -92,6 +103,7 @@ const CONTROL = [
   "a",
   "tr.rowlink",
   "tr.rowtap",
+  "tr.grouprow",
 ].map((s) => `.main ${s}`).join(", ");
 
 /**
@@ -249,7 +261,9 @@ test.describe("the two editors keep the 24px floor and do not get the phone one"
       const exempt = buttons.filter((c) => c.h < TAP);
       expect(
         exempt.length,
-        `${name} has no button under ${TAP}px — the phone floor has leaked into an editor`
+        `every button in ${name} is now ${TAP}px or taller. Either the phone floor has leaked ` +
+          `into an editor — check the \`:not(.editor *)\` clauses — or these buttons grew for ` +
+          `some other reason and this band needs a different subject to measure`
       ).toBeGreaterThan(0);
     });
   }

--- a/web/tests/tap.spec.js
+++ b/web/tests/tap.spec.js
@@ -1,0 +1,256 @@
+/**
+ * The phone tier's two rules about every fully-responsive screen: 16px form controls and a
+ * 44px square tap floor.
+ *
+ * Decided in `.wayfinder/tickets/015-touch-targets-type-scale.md` and, until this file
+ * landed, built only for the navigation shell — `--tap` reached `.navitem`, `.logout-btn`,
+ * `.bar-btn`, `.tabsel` and `.tablenote > summary` and stopped. The sweep that found the gap
+ * (#34) found it by *measuring* rather than by reading, which is the whole argument for this
+ * file existing: every other spec in this suite asserts a named selector, and a named-selector
+ * gate cannot notice a control nobody thought to name. Recurring alone carried 38 of them.
+ *
+ * SO THIS ONE IS A SWEEP, NOT A LIST. It asks the page what it renders and measures all of
+ * it. A control added to any fully-responsive view next year fails here without anyone
+ * remembering to add it — which is the only form of this gate worth having, since the failure
+ * mode being defended against is precisely "nobody owned it".
+ *
+ * WIDTH, NOT `onPhoneShell`. Both rules sit in the `max-width: 639.98px` block and nowhere
+ * else, so 844×390 — a rotated phone, which gets the drawer from the tier's height guard —
+ * gets NO tap floor and is exempt here. That is the split `RESPONSIVE.md` states as "the shell
+ * follows *height*; everything else follows *width*", and it is why the drawer a rotated phone
+ * opens holds 39px rows. `tablet.spec.js` asserts the same boundary from the other side ("not
+ * enlarged, not resized above the tier"), so between them the tier edge is gated from both.
+ *
+ * THREE CARVE-OUTS, EACH FOR ITS OWN REASON:
+ *
+ * 1. **The two editors.** `Classify` and `NetWorth` are desktop-optimised by decision and
+ *    their floor is 24px unconditional, not 44px on a phone — 015 priced the alternative and
+ *    called it the editor redesign the map ruled out (`Classify` puts three `.link-btn`s side
+ *    by side inside one table cell). `unconditional.spec.js` and `editors.spec.js` hold their
+ *    24px. This file asserts the exemption is *real* rather than merely skipping them, because
+ *    an exemption nothing measures is indistinguishable from a rule that quietly stopped being
+ *    scoped.
+ *
+ * 2. **Checkboxes are measured through their `<label>`.** A 44px checkbox is not what a square
+ *    floor means — 015 wrote the rule for the "show excluded" label as `min-height: var(--tap)`
+ *    on the *label*, because clicking a label toggles the box it wraps, so the label is the
+ *    target and the box is a glyph inside it. All three of the app's checkboxes are wrapped
+ *    this way. A bare checkbox with no labelling ancestor would be measured on its own and
+ *    fail, which is correct: nothing would be enlarging its target.
+ *
+ * 3. **Sign-in's Google button.** Not reachable here at all — sign-in is not one of the
+ *    thirteen views, and `mockApi`'s seam aborts Google's script by design, so the button
+ *    never exists in this suite. It is carved out of the floor in the stylesheet too, and #34
+ *    measured it off-suite at 177.39 × 40px: under 44, so the carve-out is load-bearing rather
+ *    than moot. `RESPONSIVE.md`'s Observations holds the number.
+ *
+ * WHAT THIS CANNOT CHECK. Whether 44px is *comfortable* — that is item 4 on the real-device
+ * list and it stays there. Geometry is all this file claims.
+ */
+import { expect, test } from "@playwright/test";
+import { PHONE_TIER_BELOW } from "./viewports.js";
+import { VIEWS, openView } from "./support/app.js";
+
+/** The floor, as `styles.css` writes it. Read as a number here; `--tap` is the CSS side. */
+const TAP = 44;
+
+/** WCAG 2.5.8's floor — what the two editors clear instead, at every width. */
+const WCAG_FLOOR = 24;
+
+/** The phone form-control size, and the whole of the iOS focus-zoom defence. */
+const NO_ZOOM_PX = 16;
+
+/**
+ * The two desktop-optimised editors, by the name `VIEWS` reaches them under.
+ *
+ * A set rather than a predicate on the view name, so adding a third editor is a deliberate
+ * edit here rather than a regex that quietly starts matching.
+ */
+const EDITORS = new Set(["Net Worth", "Spending › Classify"]);
+
+/**
+ * Everything that answers a tap, as a selector list.
+ *
+ * The interactive elements plus the two row classes that *are* controls — `tr.rowlink` opens
+ * SecurityDetail and `tr.rowtap` drills a category, and neither is a `<button>`, so a sweep
+ * of form controls alone would walk straight past the largest tap targets in the app. 015
+ * refused a carve-out for full-bleed rows on purpose: exempting them means every table needs
+ * a class declaring whether it is tappable, so the row pitch is what fixes these rather than
+ * a rule of their own.
+ *
+ * `input` is here whole and split later — a checkbox is a control, it is just not measured
+ * where it is drawn. `summary` is the footnote disclosure. `a` catches SecurityDetail's back
+ * link, which is a bare `<a>` with an `onClick` and no `href` and so has no box of its own
+ * until something gives it one.
+ */
+const CONTROL = [
+  "button",
+  "select",
+  "textarea",
+  "input",
+  "summary",
+  "a",
+  "tr.rowlink",
+  "tr.rowtap",
+].map((s) => `.main ${s}`).join(", ");
+
+/**
+ * Every rendered control under `.main`, as boxes, with the checkbox → label resolution
+ * already applied.
+ *
+ * `getClientRects()` rather than the selector is what filters `display: none`, for the reason
+ * `unconditional.spec.js` gives: a control the tier *removed* is not a control failing the
+ * floor, but one merely crushed to zero still is. Classify's ⇅ Reorder is the first kind.
+ */
+function controls(page) {
+  return page.$$eval(CONTROL, (els) => {
+    const seen = new Set();
+    const out = [];
+    for (const el of els) {
+      // A checkbox is targeted through the label that wraps it — see the header. `closest`
+      // rather than `labels`, because a wrapping label is the shape all three sites use and
+      // it is the one that makes the whole strip tappable.
+      const isCheckbox = el.tagName === "INPUT" && el.type === "checkbox";
+      const target = isCheckbox ? (el.closest("label") ?? el) : el;
+      if (seen.has(target)) continue;
+      seen.add(target);
+      if (target.getClientRects().length === 0) continue;
+      const r = target.getBoundingClientRect();
+      out.push({
+        w: Math.round(r.width * 100) / 100,
+        h: Math.round(r.height * 100) / 100,
+        tag: target.tagName.toLowerCase(),
+        cls: target.className && typeof target.className === "string" ? target.className : "",
+        text: (target.textContent ?? "").trim().replace(/\s+/g, " ").slice(0, 40),
+        viaLabel: isCheckbox && target !== el,
+      });
+    }
+    return out;
+  });
+}
+
+/** Every rendered form control's computed `font-size`, in px. */
+function formControlSizes(page) {
+  return page.$$eval(".main input, .main select, .main textarea", (els) =>
+    els
+      .filter((el) => el.getClientRects().length > 0)
+      .map((el) => ({
+        px: parseFloat(getComputedStyle(el).fontSize),
+        tag: el.tagName.toLowerCase(),
+        type: el.type ?? "",
+        cls: typeof el.className === "string" ? el.className : "",
+      }))
+  );
+}
+
+const describeBox = (c) =>
+  `${c.tag}${c.cls ? "." + c.cls.split(/\s+/).join(".") : ""} ${c.w}×${c.h}` +
+  `${c.viaLabel ? " (checkbox, measured on its label)" : ""}` +
+  `${c.text ? ` — “${c.text}”` : ""}`;
+
+/* ── the 16px rule ───────────────────────────────────────────────────────────────────────
+   Every view, editors included. This one is not about tap size at all: it is the only thing
+   standing between an iOS user and Safari's focus-zoom, which re-scales the whole layout the
+   moment a control under 16px takes focus. It applies to the editors precisely because their
+   exemption is about *targets* — NetWorth's 17-row form is the densest set of inputs in the
+   app and zooming into it is the worst version of the problem, not an accepted one.
+
+   `RESPONSIVE.md` calls the underlying assumption — that 16px suppresses the zoom — the
+   least-verified claim in the whole map. It is still unverified; what changed is that it now
+   covers every control rather than the tab picker alone. Real-device item 1. */
+test.describe("form controls render at 16px below the phone tier", () => {
+  test.skip(({ viewport }) => viewport.width >= PHONE_TIER_BELOW,
+    "the 16px rule is inside `max-width: 639.98px` — above the tier, `tablet.spec.js` asserts the inverse");
+
+  for (const view of VIEWS) {
+    test(view.name, async ({ page, baseURL }) => {
+      await openView(page, baseURL, view.name);
+      // No lower bound on the count here, unlike the floor sweep below: four of the thirteen
+      // views carry no form control at all, and an empty list is a true pass for them.
+      const found = await formControlSizes(page);
+      const wrong = found
+        .filter((f) => f.px < NO_ZOOM_PX)
+        .map((f) => `${f.tag}${f.type ? `[${f.type}]` : ""} at ${f.px}px`);
+      expect(wrong, `form controls under ${NO_ZOOM_PX}px in ${view.name}`).toEqual([]);
+    });
+  }
+});
+
+/* ── the 44px square floor ───────────────────────────────────────────────────────────────
+   The eleven fully-responsive views. Square rather than height-only because the shape exists
+   for bare glyph buttons sitting adjacent, and `Recurring.jsx` is the view it was written
+   for: `+ Track` and `✕ dismiss` are in the same cell, 55px and 21.9px wide against a 24px
+   height before this landed. A floor that one selector writes differently stops being one. */
+test.describe("every control clears 44px square below the phone tier", () => {
+  test.skip(({ viewport }) => viewport.width >= PHONE_TIER_BELOW,
+    "the tap floor is inside `max-width: 639.98px` — a rotated phone is 844px wide and exempt by decision");
+
+  for (const view of VIEWS.filter((v) => !EDITORS.has(v.name))) {
+    test(view.name, async ({ page, baseURL }) => {
+      await openView(page, baseURL, view.name);
+      // No lower bound on the count, and that is a real property rather than a softening:
+      // `Portfolio › Overview`, `Options` and `Spending › Overview` render no control at all
+      // below the tier — the tab strip is in the app bar and the charts lose their chrome —
+      // so an empty sweep is a true pass for them. The guard against a selector that matches
+      // nothing everywhere is the dedicated test below, on the view with the most controls.
+      const found = await controls(page);
+      const under = found.filter((c) => c.w < TAP || c.h < TAP).map(describeBox);
+      expect(under, `controls under ${TAP}px square in ${view.name}`).toEqual([]);
+    });
+  }
+});
+
+/* ── the sweep is actually sweeping ──────────────────────────────────────────────────────
+   A sweep that matches nothing passes every view silently, and three of the thirteen views
+   legitimately render no control below the tier — so "found nothing" cannot be a per-view
+   failure. This is the guard instead: `Recurring` is the view #47 was written for and the one
+   that carried 38 failing controls, so if the selector list ever stops resolving, it stops
+   here rather than everywhere quietly. */
+test.describe("the sweep resolves controls at all", () => {
+  test.skip(({ viewport }) => viewport.width >= PHONE_TIER_BELOW, "phone tier only");
+
+  test("Spending › Recurring renders the control-dense view the floor was written for", async ({
+    page,
+    baseURL,
+  }) => {
+    await openView(page, baseURL, "Spending › Recurring");
+    const found = await controls(page);
+    expect(found.length, "Recurring's controls, as the sweep sees them").toBeGreaterThan(20);
+  });
+});
+
+/* ── the exemption, asserted rather than assumed ─────────────────────────────────────────
+   The two editors keep the 24px floor below the tier as well as above it. Skipping them would
+   leave the scoping unmeasured, and the scoping is the fragile half: the floor is written as
+   one rule with one `:not(.editor *)` on it, and dropping that one clause is a silent change
+   to the two views whose criterion is "does not break", not "is comfortable".
+
+   Asserted as a *band* — at least 24, and something genuinely under 44 — so it fails in both
+   directions: if the editors lose their floor entirely, and if the phone floor leaks into
+   them. `.link-btn` is the population 015's inventory correction split in two, so it is the
+   right thing to measure: seven instances here, three in Recurring, same class, different
+   obligations. */
+test.describe("the two editors keep the 24px floor and do not get the phone one", () => {
+  test.skip(({ viewport }) => viewport.width >= PHONE_TIER_BELOW,
+    "the exemption is only visible where the phone floor applies");
+
+  for (const name of ["Spending › Classify", "Net Worth"]) {
+    test(name, async ({ page, baseURL }) => {
+      await openView(page, baseURL, name);
+      const found = await controls(page);
+      const buttons = found.filter((c) => c.tag === "button");
+      expect(buttons.length, `${name} rendered no button to measure`).toBeGreaterThan(0);
+
+      const belowWcag = buttons
+        .filter((c) => c.w < WCAG_FLOOR || c.h < WCAG_FLOOR)
+        .map(describeBox);
+      expect(belowWcag, `${name} buttons under WCAG 2.5.8's ${WCAG_FLOOR}px`).toEqual([]);
+
+      const exempt = buttons.filter((c) => c.h < TAP);
+      expect(
+        exempt.length,
+        `${name} has no button under ${TAP}px — the phone floor has leaked into an editor`
+      ).toBeGreaterThan(0);
+    });
+  }
+});


### PR DESCRIPTION
Closes #47.

015 decided a 44px square tap floor and 16px form controls for every fully-responsive screen. One line of it landed — `--tap`, on the navigation shell and the footnote disclosure — and the rest went missing for five tickets, because every ticket after it was scoped to a *pattern* or a *view* and these are neither. #34's sweep found the gap by measuring instead of reading.

## What is here

Three rules, all inside the `max-width: 639.98px` block and nowhere else:

- `input, select, textarea { font-size: 16px }` — global, editors included, because their exemption is about tap *targets* and NetWorth's 17-row form is the densest set of inputs in the app rather than an accepted casualty.
- `th, td { padding: 11px 8px }` — the row pitch. Global for the same reason 015 refused a carve-out for full-bleed rows: exempting them means every table needs a class declaring whether it is tappable. It is also what fixes `tr.rowlink` / `tr.rowtap` / `tr.grouprow`, since a `min-height` on a `<tr>` is ignored by table layout.
- The square floor, with `:not(.editor *)` on **every** member of the selector list.

`.editor` marks the two desktop-optimised views' roots and does nothing else — deliberately beside `.fillpane` rather than reusing it, so a later ticket that restructures Classify's scroll ownership cannot hand it a 44px floor by deleting a layout class.

`web/tests/tap.spec.js` is the gate, and it is **a sweep rather than a selector list** for the same reason the gap existed: a named-selector gate cannot notice a control nobody thought to name. Three carve-outs, each asserted rather than assumed — the editors' exemption is checked as a *band* (≥24, something genuinely <44) so it fails in both directions; a checkbox is measured on the `<label>` that wraps it; sign-in's Google button is unreachable here at all.

## Two measurements that contradicted the map

- **Holdings holds 10 rows portrait, not the predicted 12–13.** The pinned `Security` cell is two lines and 11px of padding is paid on both, so the pitch is 60.5px rather than 44. The count was *met* before this landed for the same reason — the two-line cell made a row 52.5px with no pitch rule at all — so the earlier "prediction met" was a coincidence of the wrong cause. Landscape is unchanged at 4, because the floor is width-scoped and 844 is not the phone tier. Recorded under Observations; **the decision this reopens is tracked separately, not here.**
- **`← Holdings` measured 76.45 × 17px, not the "≥44px target" the checklist asserted.** A bare `<a>` with an `onClick` and no `href` is inline and had no box at all. It is the one claim in `RESPONSIVE.md` the sweep found simply *false* rather than unbuilt.

## Verification

- `make test-web` green at every viewport: **1,345 passed, 470 skipped, 0 failed**. (+108 passed / +162 skipped against `main` — the new spec at four phone viewports, skipped at six.)
- Every `hscroll-baseline.js` number re-measured at all seven gated viewports: **none rose and none fell.** The residual there is a `.grid2` track floor with no table in it, which is #44's.
- `tablet.spec.js`'s "not enlarged, not resized above the tier" and `unconditional.spec.js` / `editors.spec.js`'s 24px floor pass unchanged.
- The drawer at 844×390 re-measured at 39px — confirming the floor did **not** travel to the shell's height arm.

## Second commit

`/code-review` found three issues, all fixed in `34c4506` — the largest being that this branch's own comments claimed a GSI carve-out in the stylesheet that does not exist, which is exactly the mistake the branch was written to fix. Also: `tr.grouprow` was missing from the sweep (it passes at 44px, so the cost was an *ungated pass*), and `:not(.editor *)` was on four of six selectors.
