### PR TITLE
The 420px track floor: the last unowned overflow below 640

### DIFF
--- a/RESPONSIVE.md
+++ b/RESPONSIVE.md
@@ -27,9 +27,11 @@ stop being trusted:
 **One thing is none of the three, and it is written down under [Not built yet](#not-built-yet)
 instead of hiding in a gate**: a rule that was decided and never built. It is not a manual check, it
 is outstanding work, and a checklist that lists unbuilt rules as things to eyeball is how they stay
-unbuilt for another five tickets. **That section held two entries and holds one** — the 44px tap
+unbuilt for another five tickets. **That section held two entries and holds none** — the 44px tap
 floor and 16px form controls landed as #47, which is what took universal gate 4 from one control to
-every control; `.grid2`'s track floor is what is left, and it is #44's.
+every control, and `.grid2`'s track floor landed as #44, which took `hscroll-baseline.js` to zero.
+An empty section is the point of the section; the moment a rule is decided and not built, it goes
+back.
 
 Visual-regression diffing remains out of scope by decision, and a test asserts no screenshot
 assertion creeps in.
@@ -288,19 +290,23 @@ Neither gates nor observations: **rules that were decided and never built**. The
 than in the gate list because eyeballing an unbuilt rule is not a check, and because a residual with
 no owner is precisely how four tables went unassigned through the whole map.
 
-**This section held two entries and holds one.** The 44px tap floor and 16px form controls — decided
-in `.wayfinder/tickets/015-touch-targets-type-scale.md`, absent from `styles.css` for five tickets,
-found by measuring rather than by reading — **landed as #47** and are gated by `tap.spec.js`, which
-is a sweep of everything the page renders rather than a list of selectors, because a named-selector
-gate is exactly what could not notice them. What each view carried before it landed is in that
-issue; the numbers are not repeated here, since a checklist that keeps its own history stops being
-a checklist.
+**This section held two entries and holds none.** Both landed by measuring rather than by reading,
+which is the only thing an unbuilt-rule list is really for.
 
-- **`.grid2`'s `minmax(420px, 1fr)` track floor is the last horizontal overflow below 640, and it is
-  **#44**'s.** Five views — `Portfolio › Overview`, `Options`, `Net Worth` and both `Spending`
-  views — share it *to the pixel* at all seven gated viewports: 74 / 44 / 4 / 0 / 8 / 0 / 0. One
-  cause, no table involved, and nothing else at all in the ratchet. The usual remedy is
-  `minmax(min(420px, 100%), 1fr)`. Until it lands, `hscroll-baseline.js` cannot become a `<= 0` gate.
+The 44px tap floor and 16px form controls — decided in
+`.wayfinder/tickets/015-touch-targets-type-scale.md`, absent from `styles.css` for five tickets —
+**landed as #47** and are gated by `tap.spec.js`, which is a sweep of everything the page renders
+rather than a list of selectors, because a named-selector gate is exactly what could not notice
+them. What each view carried before it landed is in that issue; the numbers are not repeated here,
+since a checklist that keeps its own history stops being a checklist.
+
+`.grid2`'s `minmax(420px, 1fr)` track floor — the last horizontal overflow below 640, shared to the
+pixel by five views — **landed as #44** as `minmax(min(420px, 100%), 1fr)`, and `hscroll-baseline.js`
+is now zero at every gated viewport and every view. Its header says what deleting it costs and why
+that is a separate ticket. What the five identical rows turned out to be hiding is in Traps below.
+
+*(The section is empty and is meant to stay readable that way. Add an entry the moment a rule is
+decided and not built.)*
 
 ## Traps
 
@@ -339,17 +345,36 @@ Things the build session must be told, not left to discover.
   pin actually tells you which row you are on.
 - **A nested `<table>` inherits its parent's width**, so it sets the parent's min-content. This is
   why the By Category drilldown leaves the table on phone rather than becoming cards in place.
-  **Leaving the table is not enough** — cards placed in the categories card are still 386px in a
-  362px pane, because `.grid2`'s 420px track floor reaches them there. They leave the whole grid.
+  **Leaving the table is not enough** — cards placed in the categories card were still 386px in a
+  362px pane when `.grid2`'s track floor was a hard 420px and reached them there. They leave the
+  whole grid. #44 has since collapsed that floor, so the *arithmetic* no longer forces it; the
+  decision stands anyway, because a drilldown that renders in place inside a category card is a
+  card inside a card inside a grid track, and the layout was rejected on that as well as on width.
+- **Rows that agree to the pixel are evidence of a shared cause and are not proof of a single one.**
+  `Portfolio › Overview`, `Options`, `Net Worth` and both `Spending` views read 74 / 44 / 4 / 0 / 8 /
+  0 / 0 across all seven gated viewports for four tickets, and #44 was filed on that agreement. Four
+  of them went to zero together when the track floor collapsed; `Net Worth` went to **38 / 8** and
+  stopped, because it carried a second cause the shared number had been sitting on top of —
+  `.nw-formhead`'s Date and Note are 176 and 177 wide against the 298px card a collapsed track hands
+  them, so that row's own min-content is 367 and the pane took the difference. `flex-wrap: wrap`
+  fixed it. **The way to tell one cause from two is to fix the cause and see which rows fail to
+  move**, which only works if you fix before you rewrite the baseline — measure the survivors, and
+  do not zero a row you have not watched go to zero.
 - **A card that overflows the pane reports nothing to `scrollWidth`** — it fits its own contents
   perfectly; what is off screen is the box it sits in. And measuring its right edge in *viewport*
   coordinates does not catch it either, because clicking a row has already scrolled `.main`
   sideways and dragged the card back into view. `drill.spec.js` adds `scrollLeft` back and compares
   in the pane's scroll space; built against the rejected layout, that is the difference between a
   27px failure and a green run.
-- `.grid2`'s `minmax(420px, 1fr)` is **~100px optimistic against real data** —
+- `.grid2`'s 420px is **~100px optimistic against real data**, and **#44 did not change that** —
   `spending/Overview.jsx:36`'s card needs **519px** with the live DB's longest subcategory name.
-  `auto-fit` still behaves; the column just spills inside itself between 1024 and ~1256.
+  `auto-fit` still behaves; the column just spills inside itself between 1024 and ~1256. The floor
+  is `min(420px, 100%)` now, which is a claim about the *pane* and reads as if it fixed this: it
+  does not, because 100% is never the binding term above the collapse. Content spilling inside a
+  track and a track spilling out of a pane are two problems, and only the second one has landed.
+  #44 was filed expecting this to be worth 40px at 640 on `Spending › Overview` and asked for it to
+  be measured rather than assumed — measured, it is **zero**, and has been since the tablet tier;
+  `hscroll-baseline.js`'s entry 7 is where it went. Nothing below 1024 carries it.
 - **`640` is a literal in four places, and the charts did not make it five**: `styles.css`'s
   `max-width: 639.98px`, `tests/viewports.js`'s `PHONE_TIER_BELOW` / `PHONE_TIER_EDGE`,
   `Holdings.jsx`'s `startsCollapsed` — the app's first `matchMedia` read — and `cards.jsx`'s

--- a/RESPONSIVE.md
+++ b/RESPONSIVE.md
@@ -345,10 +345,14 @@ Things the build session must be told, not left to discover.
   pin actually tells you which row you are on.
 - **A nested `<table>` inherits its parent's width**, so it sets the parent's min-content. This is
   why the By Category drilldown leaves the table on phone rather than becoming cards in place.
-  **Leaving the table is not enough** — cards placed in the categories card were still 386px in a
+  **Leaving the table is not enough** — cards placed in the categories card were still ~386px in a
   362px pane when `.grid2`'s track floor was a hard 420px and reached them there. They leave the
-  whole grid. #44 has since collapsed that floor, so the *arithmetic* no longer forces it; the
-  decision stands anyway, because a drilldown that renders in place inside a category card is a
+  whole grid. **The tilde is deliberate and is its own small lesson**: this was written as 386 here
+  and 388 in `ByCategory.jsx`, and by the time anyone noticed, the layout the number described had
+  been rejected and could not be re-measured. A measurement of a *rejected* alternative is worth
+  keeping and is worth keeping in exactly one place; `ByCategory.jsx` now points here instead of
+  restating it. #44 has since collapsed that floor, so the arithmetic no longer forces the decision
+  either; it stands anyway, because a drilldown that renders in place inside a category card is a
   card inside a card inside a grid track, and the layout was rejected on that as well as on width.
 - **Rows that agree to the pixel are evidence of a shared cause and are not proof of a single one.**
   `Portfolio › Overview`, `Options`, `Net Worth` and both `Spending` views read 74 / 44 / 4 / 0 / 8 /

--- a/web/TESTING.md
+++ b/web/TESTING.md
@@ -188,13 +188,15 @@ tickets. Three prototypes live in `web/prototypes/`.
 
 ## Two things to know before you touch the suite
 
-**`tests/hscroll-baseline.js` is a list of defects, not a specification.** The suite ratchets
-against the measured numbers so it can run green now and still catch a regression. Lower them as
-the work lands; never raise one to make a test pass. **It is nearly done**: seven lowerings in,
-two of the seven gated viewports are zero across all thirteen views and every number left is the
-same one cause — `.grid2`'s `minmax(420px, 1fr)` track floor against a narrower pane, which is
-#44's. Nothing table-shaped is left in it, and `tablet.spec.js` asserts that half separately,
-because the ratchet would go green on a build that swapped one table's overflow for another's.
+**`tests/hscroll-baseline.js` was a list of defects, not a specification.** The suite ratchets
+against the measured numbers so it could run green on day one and still catch a regression. Lower
+them as the work lands; never raise one to make a test pass. **It is done**: eight lowerings in,
+`.grid2`'s track floor became `minmax(min(420px, 100%), 1fr)` under #44 and **every number in the
+file is zero** — all thirteen views, all seven gated viewports. It is now a table of zeroes
+standing in for `<= 0`, and its own header says what deleting it costs and why that is its own
+ticket. Until then a raise is a plain regression, not a defect getting worse. `tablet.spec.js`
+still asserts the table-shaped half separately, because the ratchet would go green on a build that
+swapped one table's overflow for another's.
 
 **No screenshots, ever.** Geometry and structure only. Visual-regression diffing is out of
 scope by decision, and a test asserts that no `toHaveScreenshot` creeps in.

--- a/web/TESTING.md
+++ b/web/TESTING.md
@@ -3,9 +3,10 @@
 **The definition of done for anything you change under `web/src` is [`../RESPONSIVE.md`](../RESPONSIVE.md).**
 It is the checklist — and since the sweep reconciled it against this suite, it holds **only what
 this suite cannot assert**: five gates that need a real iPhone and one observation that needs an
-iPad, the rest of the observations with their measured values, the open calls, and one rule that was
-decided and never built. Every gate that moved in here was deleted from there. Read it before
-changing layout, not after.
+iPad, the rest of the observations with their measured values, and the open calls. Its "Not built
+yet" section — rules decided and never built — is **empty** since #44, and an entry belongs there
+the moment that stops being true. Every gate that moved in here was deleted from there. Read it
+before changing layout, not after.
 
 **The command is `make test-web`** (from the repo root). It builds the frontend and runs the
 Playwright viewport suite against the production build through vite's preview server.

--- a/web/src/modules/spending/ByCategory.jsx
+++ b/web/src/modules/spending/ByCategory.jsx
@@ -24,10 +24,12 @@ import { CardGroup, Cards, RowCard, usePhone } from "../../cards.jsx";
 // its count and its aggregate.
 //
 // BELOW THE `.grid2` RATHER THAN INSIDE THE CARD, which is a second width problem and not the
-// same one. `.grid2`'s track floor is `minmax(420px, 1fr)` and does not fit the 362px pane —
-// the residual four views share and no ticket owns (`RESPONSIVE.md`'s Traps). Cards placed
-// inside that card would be 388px wide in a 362px pane and clipped again, by a cause this
-// view cannot reach. Outside the grid they take the pane's own width.
+// same one. When this was written `.grid2`'s track floor was a hard `minmax(420px, 1fr)` that
+// did not fit the 362px pane — the residual four views shared and no ticket owned — so cards
+// placed inside that card would have been 388px in a 362px pane and clipped again, by a cause
+// this view could not reach. #44 collapsed that floor to `min(420px, 100%)`, so the clipping
+// is gone; this stays outside the grid regardless, because a drilldown nested a card deep
+// inside a track is the layout that was rejected, not merely the width it happened to have.
 export default function SpendByCategory() {
   const [years, setYears] = useState(null);   // null=loading, []=no data
   const [yearsErr, setYearsErr] = useState(false);

--- a/web/src/modules/spending/ByCategory.jsx
+++ b/web/src/modules/spending/ByCategory.jsx
@@ -26,10 +26,13 @@ import { CardGroup, Cards, RowCard, usePhone } from "../../cards.jsx";
 // BELOW THE `.grid2` RATHER THAN INSIDE THE CARD, which is a second width problem and not the
 // same one. When this was written `.grid2`'s track floor was a hard `minmax(420px, 1fr)` that
 // did not fit the 362px pane — the residual four views shared and no ticket owned — so cards
-// placed inside that card would have been 388px in a 362px pane and clipped again, by a cause
-// this view could not reach. #44 collapsed that floor to `min(420px, 100%)`, so the clipping
-// is gone; this stays outside the grid regardless, because a drilldown nested a card deep
-// inside a track is the layout that was rejected, not merely the width it happened to have.
+// placed inside that card overflowed the pane and were clipped again, by a cause this view
+// could not reach. `RESPONSIVE.md`'s Traps owns that measurement; it is not restated here,
+// because two sites carrying it disagreed by 2px for three tickets and neither was checkable
+// once the layout it described had been rejected. #44 collapsed the floor to
+// `min(420px, 100%)`, so the clipping is gone; this stays outside the grid regardless,
+// because a drilldown nested a card deep inside a track is the layout that was rejected, not
+// merely the width it happened to have.
 export default function SpendByCategory() {
   const [years, setYears] = useState(null);   // null=loading, []=no data
   const [yearsErr, setYearsErr] = useState(false);

--- a/web/src/modules/spending/Overview.jsx
+++ b/web/src/modules/spending/Overview.jsx
@@ -61,10 +61,13 @@ export default function SpendOverview() {
             </Cards>
           ) : (
           /* Pattern A above the card tier, and the smallest overflow in the ticket: 443px
-             natural against a 388px card at 640 — 40px, the last table-shaped number left in
-             the ratchet at that viewport once the two ledgers were pinned. It reaches zero
-             everywhere else in the tier, which is what a `max-content` table in an `auto-fit`
-             track looks like: 478px in a 478px card at 768 and wider.
+             natural against a 388px card at 640 — 40px, which was the last table-shaped
+             number in the ratchet at that viewport once the two ledgers were pinned, and is
+             now zero along with everything else in that file. It reached zero everywhere else
+             in the tier without help, which is what a `max-content` table in an `auto-fit`
+             track looks like: 478px in a 478px card at 768 and wider. #44 was filed expecting
+             this 40px to survive the `.grid2` fix and asked for it to be measured rather than
+             assumed; the pin had already taken it a ticket earlier.
 
              `Category` IS THE PIN, AND THE 390px REJECTION DOES NOT TRANSFER. Pattern A was
              turned down for this table on a phone because pinning `Line item` — unbounded

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -128,8 +128,17 @@ body { margin: 0; background: var(--bg); color: var(--txt);
    sites have exactly two children, so a third column is impossible however wide the monitor.
    420 is min-content over representative data — it sets where the grid collapses, not a
    promise that nothing spills inside a column (`spending/Overview`'s card needs 519 against
-   the live DB's longest subcategory name). */
-.grid2 { display: grid; grid-template-columns: repeat(auto-fit, minmax(420px, 1fr)); gap: 18px; }
+   the live DB's longest subcategory name).
+   `min(420px, 100%)` RATHER THAN `420px`, AND THE PERCENTAGE IS THE WHOLE OF IT. A bare
+   `420px` is a hard floor `auto-fit` cannot collapse below, so on a 362px phone pane the
+   single track was still 420 wide and the pane scrolled sideways by the difference — the
+   last horizontal overflow below 640, carried identically by all five call sites. The
+   percentage resolves against the grid container, so the floor reads "420px, or the whole
+   pane, whichever is smaller" and gives way only where there is no room. It moves the
+   floor, NOT the collapse point: two tracks still need 420 + 18 + 420 = 858px of grid box,
+   which is what `unconditional.spec.js` asserts at ten viewports, and above that width the
+   `min()` resolves to 420px and desktop is unchanged to the pixel. */
+.grid2 { display: grid; grid-template-columns: repeat(auto-fit, minmax(min(420px, 100%), 1fr)); gap: 18px; }
 .card { background: var(--panel); border: 1px solid var(--line); border-radius: 10px; padding: 16px; }
 .card h3 { margin: 0 0 12px; font-size: 14px; color: var(--mut); text-transform: uppercase; letter-spacing: .04em; }
 /* A card heading with controls on its right. The one call site is Classify's rules card,
@@ -462,7 +471,15 @@ input, select, textarea { background: var(--panel2); border: 1px solid var(--lin
 .loading { color: var(--mut); padding: 40px; }
 
 /* net worth */
-.nw-formhead { display: flex; gap: 14px; margin-bottom: 12px; }
+/* `flex-wrap: wrap` IS NOT COSMETIC AND IT IS NOT THE `.grid2` FLOOR. Date and Note are two
+   flex items of 176px and 177px against 298px of card once the track collapses, so the row's
+   own min-content is 367 and the pane took the difference — 38px at 360 and 8px at 390, which
+   is what was left of `Net Worth` after `min(420px, 100%)` landed and the only thing in the
+   whole ratchet that #44 did not predict. Wrap rather than shrink: each label fits the card on
+   a line of its own, where shrinking both would leave a ~159px date field for a ten-character
+   date and its picker glyph. Unconditional, and desktop is unchanged for the ordinary flex
+   reason — 367px has room above the collapse, so nothing wraps there. */
+.nw-formhead { display: flex; flex-wrap: wrap; gap: 14px; margin-bottom: 12px; }
 .nw-formhead label { display: flex; flex-direction: column; gap: 4px; font-size: 12px; color: var(--mut); }
 .nw-group { margin-bottom: 12px; }
 .nw-grouptitle { font-size: 11px; text-transform: uppercase; letter-spacing: .04em; color: var(--mut); margin: 8px 0 4px; }

--- a/web/tests/baseline.spec.js
+++ b/web/tests/baseline.spec.js
@@ -47,11 +47,13 @@
  * observations, and the open calls — and nothing else. The sweep reconciled it against
  * this suite, so a gate written there is one a person genuinely has to run.
  *
- * ONE GATE IS SCOPED, AND IT IS A RATCHET RATHER THAN A LINE. The horizontal-scroll gate
- * applies only below 1024px — `HSCROLL_GATE_APPLIES_BELOW` says why the wider two are
- * exempt. Below it the gate does not hold today either, because that is the defect the
- * whole effort exists to fix, so the overflow is measured and held against the recorded
- * numbers in `HSCROLL_BASELINE` — see that file for what those numbers are and are not.
+ * ONE GATE IS SCOPED, AND IT IS STILL A RATCHET RATHER THAN A LINE. The horizontal-scroll
+ * gate applies only below 1024px — `HSCROLL_GATE_APPLIES_BELOW` says why the wider two are
+ * exempt. Below it the gate now **does** hold: `HSCROLL_BASELINE` was a table of measured
+ * defects the ratchet lowered over eight slices, and since #44 every number in it is zero,
+ * so the lookup is `<= 0` written the long way. It stays a lookup for one more ticket —
+ * that file's header says what removing it costs and names this line as one of the edits.
+ * Until then, read it for what those numbers are and are not.
  *
  * NO SCREENSHOTS. Geometry and structure only, nowhere in this suite. `inventory.spec.js`
  * asserts that.

--- a/web/tests/hscroll-baseline.js
+++ b/web/tests/hscroll-baseline.js
@@ -1,29 +1,42 @@
 /**
  * How far the main pane overflows itself horizontally today, per viewport and per view.
  *
- * THIS FILE IS A LIST OF DEFECTS, NOT A SPECIFICATION. Every non-zero number is the
- * mobile-responsive problem stated in pixels: at 390px, Holdings puts 1201px of table
- * past the edge of the pane, which is why you see the Security column and not one number.
+ * **NOTHING IS LEFT. EVERY NUMBER IN THIS FILE IS ZERO** — all thirteen views at all seven
+ * gated viewports — which is the first time that has been true since the harness was
+ * written, and it is what the file existed to reach rather than a fact about it.
  *
- * The suite gates against these numbers rather than against zero because this harness had
- * to run green against today's code, before any layout change landed — a baseline that
- * fails on arrival measures nothing and gets switched off within a week. So the gate is a
- * ratchet: it fails when a number goes UP, which is the regression it can actually catch
- * today, and every later slice of the responsive work lowers numbers toward zero. When
- * they are all zero, delete this file and assert `<= 0` directly, which is the gate the
- * spec actually describes.
+ * THIS FILE WAS A LIST OF DEFECTS, NOT A SPECIFICATION, and its own instruction for this
+ * moment is the one below: it is now a table of zeroes standing in for `<= 0`, and the gate
+ * the spec actually describes is `expect(overflow).toBeLessThanOrEqual(0)` with no table at
+ * all. **DELETING IT IS THE NEXT TICKET'S, AND IT IS THREE EDITS**: `baseline.spec.js`'s
+ * lookup, `inventory.spec.js`'s key-parity test — which exists to catch a stale entry and
+ * has nothing left to guard once the entries are gone — and this file. It was deliberately
+ * not folded into #44, whose subject is a CSS track floor: a layout change and a harness
+ * change land better apart, and a green ratchet is worth one ticket's wait.
  *
- * Do not raise a number to make a test pass. A raised number is the defect getting worse.
+ * The suite gated against these numbers rather than against zero because this harness had
+ * to run green against the code as it stood, before any layout change landed — a baseline
+ * that fails on arrival measures nothing and gets switched off within a week. So the gate is
+ * a ratchet: it fails when a number goes UP, which was the regression it could actually
+ * catch on day one, and every later slice of the responsive work lowered numbers toward
+ * zero. Eight slices did it.
  *
- * Measured against the committed fixtures on a production build. They are stable to the
- * pixel across runs, and the differences between viewports track viewport width exactly
- * (Holdings: 1231 at 360, 1201 at 390, 1161 at 430), so a number that moves means the
- * layout moved rather than that the measurement is noisy.
+ * Do not raise a number to make a test pass. A raised number is the defect coming back —
+ * and from here every raise is a *regression* rather than a defect getting worse, because
+ * there is no longer any defect for it to be worse than.
+ *
+ * Measured against the committed fixtures on a production build. They were stable to the
+ * pixel across runs, and the differences between viewports tracked viewport width exactly
+ * (Holdings: 1231 at 360, 1201 at 390, 1161 at 430), so a number that moved meant the
+ * layout moved rather than that the measurement was noisy.
  *
  * Above 1024px there is no gate and therefore no entries here — `HSCROLL_GATE_APPLIES_BELOW`
- * in `viewports.js` says why those three viewports are exempt.
+ * in `viewports.js` says why those three viewports are exempt. **That exemption is the only
+ * horizontal overflow the app still has anywhere**, and it is not this file's: the widest
+ * position table measures 1272px against 1024px of content at 1280. Whoever takes the pin to
+ * desktop widths owns it.
  *
- * LOWERED SEVEN TIMES SO FAR.
+ * LOWERED EIGHT TIMES, AND THE EIGHTH WAS THE LAST.
  *
  * 1. The unconditional fixes. `.grid2`'s `auto-fit` did most of it: two 419px tracks side by
  *    side became one, so `Portfolio › Overview` went 619 → 288 at 360px, `Spending › By
@@ -143,6 +156,38 @@
  *    every number here is zero and the file can be deleted for the `<= 0` gate it was always
  *    standing in for.
  *
+ * 8. The 420px track floor. **The last entry, and it takes the file to zero.** One character
+ *    class of a change — `minmax(420px, 1fr)` became `minmax(min(420px, 100%), 1fr)` — and
+ *    the shared residual the last four entries have been naming goes with it: `Portfolio ›
+ *    Overview`, `Portfolio › Options`, `Spending › Overview` and `Spending › By Category`
+ *    fall 74 / 44 / 4 / 0 / 8 / 0 / 0 → zero at all seven, together, to the pixel. The
+ *    percentage resolves against the grid container, so the track floor became "420px, or
+ *    the whole pane, whichever is smaller" and `auto-fit` could finally collapse below a
+ *    number it had been given as a hard one. It moved the floor and not the collapse point:
+ *    `unconditional.spec.js`'s gate — one track below 858px of grid box, two above it, never
+ *    three — passes **unchanged at all ten viewports**, which is also the whole of the
+ *    desktop claim, since above 858 the `min()` resolves to 420px and there is nothing left
+ *    to differ.
+ *
+ *    `Spending › Overview` IS NOT THE EXCEPTION THIS TICKET WAS WRITTEN EXPECTING. #44 was
+ *    filed against entry 6's reading, where that view carried 48 at 640 rather than 8, and it
+ *    asked for the extra 40px to be measured rather than assumed to fall with the floor.
+ *    Measured: **it is zero, and it was already zero before this entry** — entry 7's tablet
+ *    tier took it, which is recorded there. The instruction was still the right one; the
+ *    answer had simply arrived one ticket early. The 519px `spending/Overview.jsx` needs
+ *    against the live DB's longest subcategory name is a *different* claim, is still true,
+ *    and is still not this file's: it spills inside a track between 1024 and ~1256, where
+ *    there is no gate. `RESPONSIVE.md`'s Traps keeps it.
+ *
+ *    `Net Worth` IS THE ONE THIS TICKET DID NOT PREDICT, and it is the reason the ticket
+ *    said measure rather than assume. It shared the 74 / 44 / 4 to the pixel and did **not**
+ *    go to zero with the other four: `min(420px, 100%)` left 38 at 360 and 8 at 390, because
+ *    a collapsed track handed its `New Snapshot` card 298px and `.nw-formhead` — Date and
+ *    Note, two flex items of 176 and 177 — has a min-content of 367 and no way to wrap. Two
+ *    causes reading as one number is exactly what four identical rows can hide, and the only
+ *    reason it was caught is that the four were fixed first and this one did not follow.
+ *    `flex-wrap: wrap` on that one row is the whole of it. Nothing else in the file moved.
+ *
  * NOT LOWERED, AND NOT RAISED, BY #35 — recorded because that ticket predicted otherwise.
  * `/api/spending/trends` used to 500 and `Spending › Overview` rendered with no stacked chart
  * at all, so the fix was expected to move that row, and to be the one legitimate reason to
@@ -154,46 +199,46 @@
  */
 export const HSCROLL_BASELINE = {
   "small-phone": {
-    "Portfolio › Overview": 74,
+    "Portfolio › Overview": 0,
     "Portfolio › Holdings": 0,
     "Portfolio › Performance": 0,
     "Portfolio › Dividends": 0,
-    "Portfolio › Options": 74,
+    "Portfolio › Options": 0,
     "Portfolio › Transactions": 0,
     "Portfolio › SecurityDetail": 0,
-    "Net Worth": 74,
-    "Spending › Overview": 74,
-    "Spending › By Category": 74,
+    "Net Worth": 0,
+    "Spending › Overview": 0,
+    "Spending › By Category": 0,
     "Spending › Classify": 0,
     "Spending › Recurring": 0,
     "Spending › Transactions": 0,
   },
   "design-width": {
-    "Portfolio › Overview": 44,
+    "Portfolio › Overview": 0,
     "Portfolio › Holdings": 0,
     "Portfolio › Performance": 0,
     "Portfolio › Dividends": 0,
-    "Portfolio › Options": 44,
+    "Portfolio › Options": 0,
     "Portfolio › Transactions": 0,
     "Portfolio › SecurityDetail": 0,
-    "Net Worth": 44,
-    "Spending › Overview": 44,
-    "Spending › By Category": 44,
+    "Net Worth": 0,
+    "Spending › Overview": 0,
+    "Spending › By Category": 0,
     "Spending › Classify": 0,
     "Spending › Recurring": 0,
     "Spending › Transactions": 0,
   },
   "large-phone": {
-    "Portfolio › Overview": 4,
+    "Portfolio › Overview": 0,
     "Portfolio › Holdings": 0,
     "Portfolio › Performance": 0,
     "Portfolio › Dividends": 0,
-    "Portfolio › Options": 4,
+    "Portfolio › Options": 0,
     "Portfolio › Transactions": 0,
     "Portfolio › SecurityDetail": 0,
-    "Net Worth": 4,
-    "Spending › Overview": 4,
-    "Spending › By Category": 4,
+    "Net Worth": 0,
+    "Spending › Overview": 0,
+    "Spending › By Category": 0,
     "Spending › Classify": 0,
     "Spending › Recurring": 0,
     "Spending › Transactions": 0,
@@ -214,21 +259,22 @@ export const HSCROLL_BASELINE = {
     "Spending › Transactions": 0,
   },
   "tablet-tier-first-pixel": {
-    "Portfolio › Overview": 8,
+    "Portfolio › Overview": 0,
     "Portfolio › Holdings": 0,
     "Portfolio › Performance": 0,
     "Portfolio › Dividends": 0,
-    "Portfolio › Options": 8,
+    "Portfolio › Options": 0,
     "Portfolio › Transactions": 0,
     "Portfolio › SecurityDetail": 0,
-    "Net Worth": 8,
-    "Spending › Overview": 8,
-    "Spending › By Category": 8,
+    "Net Worth": 0,
+    "Spending › Overview": 0,
+    "Spending › By Category": 0,
     "Spending › Classify": 0,
     "Spending › Recurring": 0,
     "Spending › Transactions": 0,
   },
-  // Zero, every view. The pin and the shell's height guard together — see entry 7.
+  // Reached zero at entry 7, and by both halves of the tablet tier at once: the pin, and
+  // the shell's `(max-height: 500px)` arm taking the 200px rail out of the flow.
   "rotated-phone": {
     "Portfolio › Overview": 0,
     "Portfolio › Holdings": 0,
@@ -244,7 +290,8 @@ export const HSCROLL_BASELINE = {
     "Spending › Recurring": 0,
     "Spending › Transactions": 0,
   },
-  // Zero, every view. Above every `.grid2` collapse, so the pin was the whole job here.
+  // Reached zero at entry 7. Above every `.grid2` collapse, so the pin was the whole job
+  // here and entry 8's track floor never applied.
   "ipad-portrait": {
     "Portfolio › Overview": 0,
     "Portfolio › Holdings": 0,

--- a/web/tests/hscroll-baseline.js
+++ b/web/tests/hscroll-baseline.js
@@ -8,11 +8,13 @@
  * THIS FILE WAS A LIST OF DEFECTS, NOT A SPECIFICATION, and its own instruction for this
  * moment is the one below: it is now a table of zeroes standing in for `<= 0`, and the gate
  * the spec actually describes is `expect(overflow).toBeLessThanOrEqual(0)` with no table at
- * all. **DELETING IT IS THE NEXT TICKET'S, AND IT IS THREE EDITS**: `baseline.spec.js`'s
- * lookup, `inventory.spec.js`'s key-parity test — which exists to catch a stale entry and
- * has nothing left to guard once the entries are gone — and this file. It was deliberately
- * not folded into #44, whose subject is a CSS track floor: a layout change and a harness
- * change land better apart, and a green ratchet is worth one ticket's wait.
+ * all. **DELETING IT IS THE NEXT TICKET'S, AND IT IS FOUR EDITS**: `baseline.spec.js`'s
+ * lookup, `baseline.spec.js`'s own header — which describes this gate and would otherwise
+ * go on describing a table that is gone — `inventory.spec.js`'s key-parity test, which
+ * exists to catch a stale entry and has nothing left to guard once the entries are, and
+ * this file. It was deliberately not folded into #44, whose subject is a CSS track floor:
+ * a layout change and a harness change land better apart, and a green ratchet is worth one
+ * ticket's wait.
  *
  * The suite gated against these numbers rather than against zero because this harness had
  * to run green against the code as it stood, before any layout change landed — a baseline
@@ -31,10 +33,14 @@
  * layout moved rather than that the measurement was noisy.
  *
  * Above 1024px there is no gate and therefore no entries here — `HSCROLL_GATE_APPLIES_BELOW`
- * in `viewports.js` says why those three viewports are exempt. **That exemption is the only
- * horizontal overflow the app still has anywhere**, and it is not this file's: the widest
- * position table measures 1272px against 1024px of content at 1280. Whoever takes the pin to
- * desktop widths owns it.
+ * in `viewports.js` says why those three viewports are exempt. **Everything the app still
+ * overflows by is up there**, and none of it is this file's. Two things, and they are not the
+ * same shape: the widest position table measures 1272px against 1024px of content at 1280,
+ * which is a *table* against a pane and belongs to whoever takes the pin to desktop widths;
+ * and `spending/Overview.jsx`'s top-line-items card needs 519px against the live DB's longest
+ * subcategory name, which is *content* spilling inside a track between 1024 and ~1256 and is
+ * not a pane problem at all. `RESPONSIVE.md`'s Traps holds both. Neither is reachable from
+ * here, because there is no gate above 1024.
  *
  * LOWERED EIGHT TIMES, AND THE EIGHTH WAS THE LAST.
  *

--- a/web/tests/support/tables.js
+++ b/web/tests/support/tables.js
@@ -28,12 +28,15 @@
  *     views owe this one; the editors' cells hold live inputs and neither table pattern
  *     applies to them.
  *
- * `room` IS THE TABLE'S OWN PARENT, NOT THE PANE, and the difference is a whole other ticket.
- * `.grid2`'s `minmax(420px, 1fr)` track floor is wider than a 360px pane, so on four views a
- * table that fits its card perfectly well sits inside a box that does not fit the pane.
- * Measured against the pane those read as unpinned overflowing tables and a sweep would
- * demand a wrapper that fixes nothing; measured against the parent they are what they are —
- * #44's residual, and the pane ratchet's.
+ * `room` IS THE TABLE'S OWN PARENT, NOT THE PANE, and the distinction outlived the case that
+ * forced it. `.grid2`'s track floor used to be a hard `minmax(420px, 1fr)` — wider than a 360px
+ * pane — so on four views a table that fitted its card perfectly well sat inside a box that did
+ * not fit the pane. Measured against the pane those read as unpinned overflowing tables and a
+ * sweep would have demanded a wrapper that fixed nothing; measured against the parent they were
+ * what they were, and #44's `min(420px, 100%)` is what actually moved them. **Keep the parent.**
+ * A table is responsible for fitting the box it was put in; whether that box fits the pane is
+ * the box's problem and a different fix, and reading the pane here would make every future
+ * ancestor-width bug look like a missing wrapper.
  */
 export function tableFacts(page) {
   return page.evaluate(() => {

--- a/web/tests/tablet.spec.js
+++ b/web/tests/tablet.spec.js
@@ -313,12 +313,14 @@ test("the pane's remaining overflow in the tier is not a table", async ({ page, 
   test.skip(vp.width >= HSCROLL_GATE_APPLIES_BELOW, "no pane gate above 1024");
   test.skip(vp.width < PHONE_TIER_BELOW, "the tier, not the phone — below 640 the ratchet owns this");
 
-  // The acceptance criterion in its strongest checkable form. `hscroll-baseline.js` is a
-  // ratchet on *how much* the pane overflows and is deliberately allowed to be non-zero while
-  // `.grid2`'s 420px track floor is still #44's; this asserts the part that is this ticket's,
-  // which is that none of what is left is a table. Both are needed: the ratchet would go
-  // green on a build that swapped a table's overflow for a wider one somewhere else, and this
-  // would go green on a build that let the residual grow.
+  // The acceptance criterion in its strongest checkable form, and it did NOT become redundant
+  // when #44 took `hscroll-baseline.js` to zero. The ratchet is a claim about *how much* the
+  // pane overflows; this is a claim about *what shape* the overflow is, and the two answer
+  // different questions. The ratchet would go green on a build that swapped a table's overflow
+  // for a wider one somewhere else, and it would keep the pane at zero while a table quietly
+  // handed its width to a wrapper that absorbed it — this reads the table against the pane
+  // directly. When the ratchet becomes a plain `<= 0`, this is what still says the zero was
+  // reached by containing tables rather than by hiding them.
   // ALL THIRTEEN VIEWS, the two editors included — which is what this adds over the sweep at
   // the top of the file. That one runs on the eleven fully-responsive views and asks whether
   // a table overflows *its own parent*; this asks the pane's question of every view in the


### PR DESCRIPTION
Closes #44

`.grid2` was `repeat(auto-fit, minmax(420px, 1fr))`. The 420px is a hard number, so `auto-fit` could not collapse a track below it however narrow the pane got: at 390px the pane is 362 and the single track was still 420, which the pane took as horizontal scroll. Five views carried it identically — 74 / 44 / 4 / 0 / 8 / 0 / 0 at all seven gated viewports — and it was the last horizontal overflow below 640 anywhere in the app.

**`minmax(min(420px, 100%), 1fr)`.** The percentage resolves against the grid container, so the floor reads "420px, or the whole pane, whichever is smaller" and gives way only where there is no room. It moves the floor and **not** the collapse point: two tracks still need 858px of grid box, which is what `unconditional.spec.js` asserts at ten viewports and which passes unchanged, and above that width the `min()` resolves to 420px, so desktop is untouched.

## Four of the five went to zero together and `Net Worth` did not

It was left holding **38 at 360 and 8 at 390**, because a collapsed track hands its New Snapshot card 298px and `.nw-formhead` — Date and Note, two flex items of 176 and 177 — has a min-content of 367 and no way to wrap. A second cause that had been invisible underneath the shared number for four tickets, and only visible now because the shared one was fixed first. `flex-wrap: wrap` on that one row.

**Rows that agree to the pixel are evidence of a shared cause and are not proof of a single one.** The way to tell is to fix the cause and see which rows fail to move — which only works if you fix before you rewrite the baseline. That is in `RESPONSIVE.md`'s Traps now.

## `Spending › Overview`'s 40px at 640: measured, not assumed

**It is zero, and it was already zero before this.** #44 was filed against entry 6's reading, where that view carried 48 at 640 rather than 8; the tablet tier took the extra 40px a ticket early, and `hscroll-baseline.js`'s entry 7 is where it went. The instruction was still the right one; the answer had simply already arrived. The 519px `spending/Overview.jsx` needs against the live DB's longest subcategory name is a *different* claim, is still true, and is content spilling inside a track between 1024 and ~1256 rather than a pane problem — named separately rather than folded in.

## The ratchet is at zero and is not deleted here

`hscroll-baseline.js` is now zero at every viewport and every view. Its header says so, says what deleting it costs — **four edits**: `baseline.spec.js`'s lookup, `baseline.spec.js`'s own header, `inventory.spec.js`'s key-parity test, and the file — and says why that is the next ticket's rather than folded in: a layout change and a harness change land better apart. `RESPONSIVE.md`'s "Not built yet" section is empty for the first time.

## Verification

- `make test-web`: **1345 passed, 470 skipped, 0 failed** (8.6m). An intermediate run had 4 `pinned.spec.js` "Loading…" timeouts at one viewport under load; re-running that slice was green and the final full run was clean.
- Measured red-first: the baseline was zeroed against the *unfixed* CSS and failed at 74 / 44 / 4 / 8 before the change, so every zero in this diff is a number watched going to zero rather than an assumption.
- `unconditional.spec.js`'s collapse gate passes unchanged at all ten viewports; desktop still resolves the floor to 420px.

## Second commit: stale references, from the code review

All prose, no behaviour. `baseline.spec.js`'s header claimed the gate "does not hold today" — it holds now, and `TESTING.md` names that docstring the authority on what the suite asserts. `TESTING.md`'s opening contradicted its own updated sibling paragraph. The ratchet called the desktop exemption "the only overflow anywhere" when two live there, of different shapes. `spending/Overview.jsx` used the present tense for a number already gone. And `RESPONSIVE.md` said the rejected in-place drilldown cards were 386px where `ByCategory.jsx` said 388px — one is wrong, neither is checkable now that the layout was rejected, so it is stated once with the uncertainty explicit.