### PR TITLE
Holdings holds 10 rows: accept 10, correct the map

### DIFF
--- a/.wayfinder/map-mobile-responsive.md
+++ b/.wayfinder/map-mobile-responsive.md
@@ -84,7 +84,8 @@ body `font: 14px/1.5` (:7), and the nested-scroll machinery `.fillpane`/`.grow`/
 - [Wide numeric tables on a phone](tickets/013-wide-tables-on-phone.md) — **two patterns, assigned by
   one test: does the table exist to compare a number down the column, or to read one row at a time?**
   Compare → **the real table, horizontally scrolled behind a pinned identity column** (measured **15
-  rows** on screen vs 3 for cards; every column keeps its alignment, `tabular-nums` and sticky headers
+  rows** on screen vs 3 for cards — the prototype figure, pre-tap-floor; it shipped at **10** and the
+  argument holds at 10-vs-3, see 015 below; every column keeps its alignment, `tabular-nums` and sticky headers
   intact — the trap is that sticky cells need `border-collapse: separate`). Read → **card per row**
   (a ledger row has six fields, reads top-to-bottom, and fits two lines with nothing hidden and no
   interaction). **A third bucket the inventory missed: the 8 views hold 13 tables, and four are ≤4
@@ -128,8 +129,22 @@ body `font: 14px/1.5` (:7), and the nested-scroll machinery `.fillpane`/`.grow`/
   **11px holds everywhere, no floor** (it is *at* iOS HIG's 11pt line, and the one place a bump helps most
   — `th` — is where it costs most, since the uppercase header is often the widest thing in a short numeric
   column). **No carve-out for table rows**: `th, td { padding: 11px 8px }` puts the pitch at a true 44px,
-  and **the stated bill is 013's 15 rows on screen becoming 12** — its 15-vs-3 argument against cards
-  survives, so no pattern assignment changes. Mechanism is **literal values in one
+  and the stated bill was **013's 15 rows on screen becoming 12** — its 15-vs-3 argument against cards
+  survives, so no pattern assignment changes. **The bill came in at 10, not 12, and 10 was accepted**
+  (#50) — the correction every other row-count figure in this map and its tickets now defers to.
+  **`44px` is the floor, not the pitch, and this bullet conflated them**: the rule gives a 44px row for
+  a *one-line* cell, and Holdings' pinned `Security` cell is **two** lines, so the 11px is paid on both
+  and a data row lands at **60.5px** — **10 rows portrait** (9 data + 1 group) against the forecast 12,
+  and **4 landscape**, which is what 844×390 already held before the floor, since this whole block is
+  `max-width`-scoped and 844 is not the phone tier. Measured in #49 after #47, recorded under
+  Observations in [`RESPONSIVE.md`](../RESPONSIVE.md). Accepted rather than tuned away on this bullet's
+  own argument, which survives the smaller number: the density case was **15-vs-3 against cards** and is
+  still **10-vs-3**. Both alternatives cost more than the two rows — a one-line pin spends content on the
+  identity column pattern A exists to make readable, and scoping the padding away from `.pinned` tables
+  makes the floor a different number per selector, the thing this bullet already refuses twice.
+  **The earlier "prediction met" was a coincidence of the wrong cause**: #34 read 12 rows as meeting
+  the forecast, but measured *before the pitch rule existed* — the two-line cell alone made a row
+  52.5px — so the forecast was never tested against the thing it forecast. Mechanism is **literal values in one
   `@media (max-width: 639.98px)` block**, not a token layer — most of what phone changes (012's column
   flip, 014's deleted donuts, 013's table surgery) *can't* be a token override, so tokens would split the
   phone story across two mechanisms; `--tap: 44px` is the single exception, being the one number that
@@ -221,7 +236,9 @@ body `font: 14px/1.5` (:7), and the nested-scroll machinery `.fillpane`/`.grow`/
   `.main` stops scrolling** — a side effect of pattern A, not anyone's decision. **Ratified**, because the
   trade is binary (shrinking wrapper → sticky `th` works; `flex: none` → pane scrolls, header dead) and
   re-measuring reproduces **exactly the 15 rows** 013 reported, so its prototype already assumed this and
-  its "sticky headers survive under A" claim depends on it. Item 1's nested-scroll worry largely dissolves:
+  its "sticky headers survive under A" claim depends on it. (15 is the pre-#47 prototype figure, and stands
+  as the historical measurement it was — what it ratified was the scroll *owner*, which no row count
+  changes. The shipped count is **10 portrait / 4 landscape**; see 015 above.) Item 1's nested-scroll worry largely dissolves:
   `.main` stops scrolling, so Holdings has **one** scrollable region, not two. But the behaviour is free
   only for a **direct flex child of `.main`** — and only `Holdings.jsx:142` is one; the other three
   pattern-A tables sit inside `.card`, where the wrapper never scrolls and **the sticky header is dead**.
@@ -234,6 +251,12 @@ body `font: 14px/1.5` (:7), and the nested-scroll machinery `.fillpane`/`.grow`/
   columns-for-rows trade** (844px shows 8+ of Holdings' 13 columns vs 2–3 in portrait; a header that
   vanishes on rotate would be worse than a short table), with Holdings' footnote becoming a phone
   `<details>` — the real lever, measured at 44px pitch: portrait **11 → 13 rows**, landscape **2 → 4**.
+  **Both pairs are arithmetically stale (#50)**, computed at a pitch neither orientation has —
+  portrait's row is 60.5px (see 015 above) and landscape's is 52.5px, the pre-floor number, since 844
+  is outside this `max-width` block. Shipped: **portrait 10** against the 13 forecast for collapsed;
+  **landscape 4 with the disclosure open**, i.e. the footnote-*full* column, which forecast 2 —
+  `Holdings.jsx` reads its query by width once at mount, so landscape gets the markup but not the
+  collapse. The lever itself is unaffected: the footnote is still what moves the count.
   **Two live desktop defects recorded, not fixed**: `Dividends.jsx:30` already has a dead sticky header
   (provably harmless — `CONTEXT.md:18` fixes funding buckets as a closed set of three, so it is 3 rows plus
   a Total and can never scroll), and Classify's rules cap is **inline** at `Classify.jsx:126`, unreachable
@@ -292,7 +315,10 @@ body `font: 14px/1.5` (:7), and the nested-scroll machinery `.fillpane`/`.grow`/
   second-widest table** at **921px with 2 of 9 columns visible** — a whole Portfolio tab, → **A**, and the
   *cheapest* A in the map because its row count is bounded by the grouping dimension (max 8), making 020's
   `60svh` cap a permanent no-op. **013's least-certain B is overturned to A** for `Options.jsx:71` *and*
-  `SecurityDetail.jsx:102`: a 9-field card measures **121px → 4 rows per screen** against A's 12, where 013
+  `SecurityDetail.jsx:102`: a 9-field card measures **121px → 4 rows per screen** against A's 12 (a
+  *forecast* at 44px; the one A row anyone has measured is Holdings' at 60.5px, and this table's pin is
+  two lines too, so read A as probably nearer 8 — unmeasured, and 4 sits on the rejected side at either
+  number, so the call is unchanged — #50), where 013
   rejected B for Holdings at 3 and accepted it at 9 — **`ledger → B` over-generalised on the word *ledger***,
   and the real test is how many numbers a row carries (a cash ledger has one; an options row has five).
   `Options:71` already ships `overflow-x: auto` today, so A *keeps* behaviour. **013's "pin the first `.l`
@@ -331,11 +357,14 @@ body `font: 14px/1.5` (:7), and the nested-scroll machinery `.fillpane`/`.grow`/
   the Options monthly series halved to 6 bars — so there is no plausible re-render cost the desktop
   build doesn't already pay. What remains is whether the scrolled-table pattern from ticket 013 needs
   a row cap on a phone — and [Touch targets & type scale](tickets/015-touch-targets-type-scale.md) has
-  moved the goalposts: the 44px row pitch means **12 rows on screen, not 15**, so any cap is now judged
-  against a viewport that holds ~20% less. [The four unassigned tables](tickets/022-unassigned-tables.md)
+  moved the goalposts: the 44px floor means **10 rows on screen, not 15** — forecast as 12 and measured
+  at 10 after #47, because 44px is a floor and Holdings' two-line pin makes the pitch 60.5px (#50) — so
+  any cap is now judged against a viewport that holds a **third** less, not ~20%. [The four unassigned tables](tickets/022-unassigned-tables.md)
   sharpened the worst case without making it decidable: the longest render in the app is not a table at all
   but the **By Category drilldown**, which fetches `limit=1000` and becomes **B cards at ~2× an A row's
-  height** (121px vs 44px) — and "Dining Out" alone is 285 transactions in one year in the live DB.
+  height** (121px vs a *forecast* 44px; the only A row anyone has measured is Holdings' at **60.5px**,
+  at which the ratio is the ~2× this line already claimed — #50) — and "Dining Out" alone is 285
+  transactions in one year in the live DB.
   `SecurityDetail:102` is likewise uncapped at 73 rows. Still unknown, and still not answerable at a desk;
   019's routing to observation during verification stands.
 

--- a/.wayfinder/tickets/013-wide-tables-on-phone.md
+++ b/.wayfinder/tickets/013-wide-tables-on-phone.md
@@ -71,6 +71,13 @@ Measured at 390×844:
 | B — card per row | **3 rows** | 9 rows |
 | C — priority + expand | 9 rows | 11 rows |
 
+**Correction (#50): the 15 above is a historical prototype figure and stays one.** It was measured
+before [Touch targets & type scale](015-touch-targets-type-scale.md)'s tap floor existed; shipped,
+Holdings holds **10** rows at 390×844 (9 data + 1 group) and **4** at 844×390. The reason, and the
+decision to accept 10, live in 015's point 5 — this ticket's own numbers are all *comparisons*, and
+each survives: A-vs-B for positions was 15-vs-3 and is now 10-vs-3, so **no pattern assignment below
+changes**.
+
 **Verdict: not one pattern — two, chosen per table by one test.**
 
 > **Does this table exist so you can compare a number down the column, or so you can read one row

--- a/.wayfinder/tickets/015-touch-targets-type-scale.md
+++ b/.wayfinder/tickets/015-touch-targets-type-scale.md
@@ -71,7 +71,7 @@ phone. The 11px labels hold everywhere.
 | Selector | Rule | Effect |
 |---|---|---|
 | `input, select, textarea` | `font-size: 16px` | kills the iOS focus-zoom. Must be **explicit** — `font: inherit` (:48) will not pick up a body change. |
-| `th, td` | `padding: 11px 8px` | **44px row pitch** = 11 + 21 (14px×1.5) + 11 + 1px border. Horizontal 10→8 returns ~40px of scroll distance on a 10-column table. |
+| `th, td` | `padding: 11px 8px` | **44px row floor** = 11 + 21 (14px×1.5) + 11 + 1px border — **for a one-line cell**. Wrap the cell to two lines and the 11px is paid on both: Holdings' pinned `Security` makes it **60.5px** (#50, see point 5's correction). Horizontal 10→8 returns ~40px of scroll distance on a 10-column table. |
 | `.navitem`, `.logout-btn`, `.link-btn`, `.refresh-btn`, `select` | `min-height: var(--tap); min-width: var(--tap)` | square. |
 | `SecurityDetail.jsx:24` back link | `display: inline-flex; align-items: center; min-height: var(--tap); min-width: var(--tap)` | a bare `<a>` has no box to size. It is the only way home (013). |
 | `Transactions.jsx:35` "show excluded" `<label>` | `display: inline-flex; align-items: center; min-height: var(--tap)` | the **label** is the target; `<label>` is inline, so it needs the flex to materialise a box. |
@@ -98,7 +98,8 @@ phone. The 11px labels hold everywhere.
 3. **Body stays 14px.** Raising body to 16px would fix the input zoom for free via `font: inherit` — and
    silently invalidate every measurement in 013 and 014 (15 rows on screen, the pinned-column widths, the
    ⌀216px donut, S2's ~38px pitch), while widening the columns 013 already calls "already-overflowing" by
-   ~14%. The readability case for 16px is a *prose* case; this app renders ~90% right-aligned
+   ~14%. (The 15 is 10 as shipped — point 5's correction. The argument is untouched: it turns on those
+   numbers being *invalidated*, not on what they are.) The readability case for 16px is a *prose* case; this app renders ~90% right-aligned
    `tabular-nums` inside tables. Accepted consequence: on phone, form controls render visibly larger than
    the text around them — which is what iOS Safari users see across most of the web anyway.
 
@@ -115,6 +116,20 @@ phone. The 11px labels hold everywhere.
    judgement call. This ticket exists so downstream stops re-deciding. **Stated bill: 013's measured 15
    rows on screen becomes 12** — a ~20% density loss. Its argument was 15-vs-3 against cards, so every
    pattern assignment in 013 survives intact.
+
+   **Correction (#50): the bill came in at 10, not 12, and 10 was accepted.** **44px is the floor, not
+   the pitch, and this point conflated them** — `th, td { padding: 11px 8px }` gives a 44px row only for
+   a *one-line* cell, and Holdings' pinned `Security` cell is **two** lines, so the 11px is paid on both
+   and a data row lands at **60.5px**. Shipped: 10 rows at 390×844 (9 data + 1 group) against the 12
+   forecast here, and 4 at 844×390, which is what that viewport already held — this whole block is
+   `max-width`-scoped, so a rotated phone never got the floor and its row is still 52.5px. The
+   **~20% density loss** priced above is therefore **~33%**.
+
+   Accepted rather than tuned away, on this point's own argument: the density case was 15-vs-3 and is
+   still **10-vs-3**, so every pattern assignment in 013 survives at 10 too. The two rejected
+   alternatives — a one-line pin, and scoping the padding away from `.pinned` tables — are weighed in
+   [the map's line for this ticket](../map-mobile-responsive.md), which is where the decision is
+   recorded; measured in #49, values under Observations in [`RESPONSIVE.md`](../../RESPONSIVE.md).
 
 6. **Literal values, not a token layer.** A large share of what phone changes **cannot** be a token
    override at all — 012 flips `.app` to `flex-direction: column`, 014 deletes three donuts and drops
@@ -141,7 +156,10 @@ phone. The 11px labels hold everywhere.
    `matchMedia` hook, and JS cannot read a CSS custom property. A single source of truth is unreachable
    without a build step, and the map bars new dependencies — so: a cross-referencing comment on both sides.
 3. **Verify tables at 12 rows, not 15** — see point 5 above. Feed this to
-   [Verification checklist](019-verification-checklist.md).
+   [Verification checklist](019-verification-checklist.md). **Superseded (#50): verify at 10, not 12**
+   — and note that #34 read 12 and called the forecast met, but measured *before* the pitch rule
+   existed, where the two-line cell alone made a row 52.5px. The forecast was never actually tested
+   against the rule it was a forecast about.
 
 ### Inventory correction
 

--- a/.wayfinder/tickets/020-scroll-ownership-on-phone.md
+++ b/.wayfinder/tickets/020-scroll-ownership-on-phone.md
@@ -115,6 +115,18 @@ The trade is binary — the two halves cannot both be had:
    | portrait 390×844 | 529px box → **11 rows** | 625px → **13 rows** |
    | landscape 844×390 | 161px box → **2 rows** | 221px → **4 rows** |
 
+   **Correction (#50): every cell above is computed at a pitch neither orientation has.** 44px is a
+   *floor*, not a pitch, and Holdings' pinned cell is two lines, so portrait's real data row is
+   **60.5px**; landscape's is **52.5px**, because this block is `max-width`-scoped and 844 is not the
+   phone tier, so a rotated phone kept the old 7px padding. Shipped (#49, at 390×844 and 844×390):
+   **portrait 10**, against the 13 this table forecast for the collapsed state. **Landscape 4 — with
+   the disclosure OPEN**, i.e. the *footnote-full* column, which forecast 2. `Holdings.jsx` reads its
+   query by width, once, at mount, so landscape gets the `<details>` markup but not the phone's
+   collapse; landscape therefore came out **better** than this table predicted for the state it is
+   actually in, not "unchanged". **The finding is untouched** — the footnote is still the lever, and
+   which cell you land in still turns on whether it is open. What is dead is the arithmetic, not the
+   design. Nobody has measured collapsed landscape post-#47 and this correction does not claim to.
+
    Rejected moving the footnote *inside* the wrapper: a block child of an `overflow-x: auto` container
    sizes to the container, not the table, so the paragraph would sit at the far left and slide out of
    view as you scrolled right to read columns. `<details>` is real UI, which 018 forbade for the cheap

--- a/.wayfinder/tickets/022-unassigned-tables.md
+++ b/.wayfinder/tickets/022-unassigned-tables.md
@@ -85,6 +85,10 @@ The mechanical reading was B (contract ledger → read one row at a time). It do
 - **Density.** A 9-field `.rowcard` built to 013's own prototype markup measures **121px** (+8 gap) →
   **4 rows** in the ~528px pane. Pattern A at 015's 44px pitch → **12 rows**. 013 rejected B for Holdings at
   **3** rows and accepted it for `spending/Transactions` at **9**. Four sits on the rejected side.
+  (**#50**: 44px is a floor, not a pitch. The only A row anyone has measured is Holdings' at
+  **60.5px**, where the pin wraps to two lines; this table's merged `Contract` cell is two lines by
+  construction, so A here is **probably nearer 8 than 12** — unmeasured, and flagged rather than
+  restated as fact. Four sits on the rejected side at either number, so the call is unchanged.)
 - **Ledger-sized and uncapped.** Real DB: PLTR **73** option trades, RIVN 64, BABA 53. Under B that is
   ~9,400px of scroll, ~18 screens.
 - **The test itself pointed to A all along.** What you do with one security's wheel log is scan P/L and

--- a/RESPONSIVE.md
+++ b/RESPONSIVE.md
@@ -92,7 +92,8 @@ the only gates left in this file:
    in the eleven fully-responsive views**, not only the navigation. The drawer in portrait, the app
    bar, the tab picker and the footnote disclosure had it before; the tables' own controls, the
    filter `<select>`s, the checkbox labels, `Recurring`'s `+ Track` / `✕` pairs and the 44px row
-   pitch under every `tr.rowlink` and `tr.rowtap` have it now. `tap.spec.js` gates the geometry at
+   floor under every `tr.rowlink` and `tr.rowtap` have it now (a floor, not a pitch — a row whose
+   pinned cell wraps is taller; see [Observations](#observations)). `tap.spec.js` gates the geometry at
    four phone viewports; **whether it is comfortable is still an eye**, and the two places to look
    first are the ones where 44px cost something visible: `Recurring`'s action column (100.72 →
    118.8px) and `Holdings`, which lost two rows a screen.
@@ -205,6 +206,9 @@ reconciliation unless marked otherwise.
   same reason — the two-line cell made a row 52.5px without any pitch rule at all — so the earlier
   reading of "prediction met" was a coincidence of the wrong cause. **Two rows is the price of the
   floor on this screen**, and 015 stated the bill as 15 → 12 on a one-line cell.
+  **10 was accepted rather than tuned away** — decided in #50, reasoned in the map's line for ticket
+  015, which is where the two rejected alternatives are weighed. Recorded here because this entry is
+  the measured value the map and tickets 013/015/020/022 now defer to; nothing in the build moved.
   At 844×390 the footnote disclosure is **open**, because `Holdings.jsx` reads its query by *width*,
   once, at mount — so the landscape count is with the footnote expanded, the harder case.
 - **`SecurityDetail`'s `← Holdings` — 76.45 × 44px below the tier, 76.45 × 17px above it.** Recorded
@@ -282,7 +286,9 @@ Failing these **changes a decision**, rather than reporting a bug.
   notices.
 
 *(`Options.jsx:71` left this list: resolved to **A**, on the measurement that a 9-field card is 4
-rows per screen against A's 12 — the same reasoning that rejected B for Holdings at 3.)*
+rows per screen against A's 12 — the same reasoning that rejected B for Holdings at 3. A's 12 was a
+forecast at 44px; the one A row measured is Holdings' at 60.5px, so read it as nearer 8. Four is on
+the rejected side either way, so the resolution stands — see [Observations](#observations).)*
 
 ## Not built yet
 


### PR DESCRIPTION
Closes #50.

## The decision

**Option 1 — accept 10 and correct the map.** Docs only: no CSS, no JSX, no test moves. The full suite is green (1345 pass / 0 fail), `tap.spec.js` passes 108 at the four phone viewports, and `hscroll-baseline.js` is untouched — which is the point. Only numbers were stale.

**44px is the floor, not the pitch, and 015 priced the density bill by conflating them.** `th, td { padding: 11px 8px }` gives a 44px row for a *one-line* cell; Holdings' pinned `Security` cell is two lines, so the 11px is paid on both and a data row lands at 60.5px. Measured in #49 after #47: **10 rows at 390×844** (9 data + 1 group) against a predicted 12–13, and **4 at 844×390** — which is what that viewport already held, because the block is `max-width`-scoped and 844 is not the phone tier.

`styles.css:682` had already written the finding down and said to record it rather than tune it away. This PR is the rest of that sentence.

Accepted on 015's own argument, which survives the smaller number: the density case was 15-vs-3 against cards and is still **10-vs-3**, so every pattern assignment in 013 holds. Both alternatives cost more than the two rows — a one-line pin spends content on the identity column pattern A exists to make readable, and scoping the padding away from `.pinned` tables makes 44px a different number per selector, the line the phone block already refuses twice (`styles.css:641`, `:682`).

## What was reconciled

The reason is recorded **once**, in the map's line for 015; everything else points at it. Figures measured *before* the tap floor existed are left as the history they are, with a pointer. Figures that *forecast* the shipped build are corrected.

| site | treatment |
|---|---|
| `map:87`, `013:70` | the 15-row prototype figure — kept as history |
| `map:132`, `015` point 5 | the stated bill; the decision and its reason. ~20% density loss is ~33% |
| `map:238`, `020:78` | 020 ratified the scroll *owner*; 15 was its evidence, and no row count changes what it ratified |
| `map:253`, `020:118` | the footnote lever — see below |
| `map:318`, `map:360`, `022:86`, `RESPONSIVE:289` | A's row height, which fed four density comparisons as a forecast 44px |
| `map:356` | "12 rows, not 15" → 10; ~20% less → a third less |
| `015:74`, `RESPONSIVE:94` | said "44px row pitch" — the conflation itself |
| `015` point 3 / point 6 | the 16px-body argument is untouched (it turns on those numbers being *invalidated*, not on their value); "verify at 12" is superseded by 10 |

## Two findings the code review turned up

**The landscape column was stale too, and my first pass said it held.** 020's table forecasts landscape 2 rows *footnote-full* / 4 *collapsed*. Shipped is 4 **with the disclosure open** — the footnote-full state, which forecast 2. It matched the wrong cell. Every cell in that table is computed at 44px and *neither* orientation has that pitch: portrait is 60.5px, landscape 52.5px (the pre-floor number, since the floor never reaches 844). `Holdings.jsx` reads its query by width, once, at mount, so landscape gets the `<details>` markup but not the phone's collapse — it came out **better** than forecast for the state it is actually in, not unchanged. Collapsed landscape has not been measured post-#47 and nothing here claims it has.

**Only Holdings' A row has ever been measured.** The options-history figure is marked *probably* nearer 8 than 12 rather than restated as fact. Four sits on the rejected side at either number, so that call is unchanged.

## Acceptance criteria

- [x] One of the three options chosen, with its reason recorded — option 1, reasoned in the map's line for 015
- [x] Every quoted row-count figure in the map and the 013/015 tickets reconciled against 10/4, or explicitly left as the historical figure it was
- [x] `tap.spec.js` passes at all four phone viewports (108 pass / 0 fail); no control drops below 44px square
- [x] Landscape stays 4; nothing here reaches 844×390 — no rule changed at all
- n/a Re-measurement and a `RESPONSIVE.md` Observations update — that criterion is option 2/3 only

## Scope notes

Tickets **020** and **022** are also touched, which the criteria don't name: they quote the same figure, and leaving it stale there is the thing this issue exists about. `018:135` still says "44px pitch" in a hypothetical about handing the rule to desktop — the argument there is unaffected, so it was left alone.