### PR TITLE
fix(portfolio): the clock the endpoint was blamed for, and the Yahoo call it was hiding

### DIFF
--- a/portfolio/twr.py
+++ b/portfolio/twr.py
@@ -9,10 +9,10 @@ The same unit-delta contribution series feeds the money-weighted XIRR, so a posi
 arrives without a txn price (transfer, snapshot-diff open, fund switch) still carries a cost
 basis instead of landing in the terminal value for free.
 
-The daily series comes from Yahoo on every call, NOT from the `price` table — so this module's
-output is not pinned by the database, and it can value the book differently from
-/api/positions, which reads the table. `_returns` takes both the clock and the fetch as
-arguments so the two can be told apart; see its docstring and issue #52.
+The daily series comes from Yahoo on every call, NOT from the `price` table (ADR 0001 keeps
+that split deliberate) — so an unchanged database does not pin this module's output, and it
+can value the book differently from /api/positions, which reads the table. `_returns` takes
+the clock and the fetch as arguments so the two can be told apart; see it and issue #52.
 Run: PYTHONPATH=. .venv/bin/python -m portfolio.twr
 """
 import bisect
@@ -204,17 +204,14 @@ def _returns(held, txns, divs, last_px, as_of, fetch=daily):
     `fetch` still and advancing `as_of` is the only moving input, which is the only way to
     say which output fields the clock actually owns. See tests/test_twr.py and issue #52.
 
-    What `as_of` legitimately moves: `xirr_annualised`, `twr_annualised`, `years` — each
-    divides a fixed total by an elapsed-time denominator that grows daily. What it must not
-    move, given no new close between the two dates: `twr_cumulative`,
-    `value_plus_income_sgd`, `invested_sgd`, `from`. Note "no new close" is the real
-    condition, not "same `fetch`" — `ffill` truncates the series at `as_of`, so a later date
-    picks up any close the series already held past the earlier one.
-
-    Note `fetch` is Yahoo, not the `price` table. This endpoint's daily series is pulled live,
-    so an unchanged database does NOT pin its output — that is what #52 was chasing. (The
-    `last_px` fallback below, and /api/positions, do read the table; the two valuations can
-    therefore disagree.)"""
+    What `as_of` legitimately moves: `years`; `twr_annualised`, which raises a fixed `factor`
+    to `1/years`; and `xirr_annualised`, which re-solves with the terminal inflow discounted
+    over a longer span. All three decay on a book standing still. What it must not move:
+    `twr_cumulative`, `value_plus_income_sgd`, `invested_sgd`, `from` — but only while no
+    close lands between the two dates. "No new close" is the real condition, not "same
+    `fetch`": `ffill` truncates the series at `as_of`, so a later date picks up any close the
+    series already held past the earlier one. Advancing the clock is therefore the trigger,
+    while Yahoo remains the source."""
     ids = sorted({h[0] for h in held})
     start = min((t["trade_date"] for t in txns), default=as_of)
     days = [start + dt.timedelta(d) for d in range((as_of - start).days + 1)]

--- a/portfolio/twr.py
+++ b/portfolio/twr.py
@@ -8,6 +8,11 @@ unadjusted. TWR strips out contribution timing -> comparable to an index.
 The same unit-delta contribution series feeds the money-weighted XIRR, so a position that
 arrives without a txn price (transfer, snapshot-diff open, fund switch) still carries a cost
 basis instead of landing in the terminal value for free.
+
+The daily series comes from Yahoo on every call, NOT from the `price` table — so this module's
+output is not pinned by the database, and it can value the book differently from
+/api/positions, which reads the table. `_returns` takes both the clock and the fetch as
+arguments so the two can be told apart; see its docstring and issue #52.
 Run: PYTHONPATH=. .venv/bin/python -m portfolio.twr
 """
 import bisect
@@ -192,29 +197,27 @@ def _twr(days, txns, prices, ccy_of, fx, contrib, div_by_day=None):
     return factor - 1, ann
 
 
-def compute_twr():
-    s = SessionLocal()
-    # one row per (account, security): the same counter can sit in FSM and CPF at once
-    held = s.execute(text(
-        "SELECT DISTINCT security_id, canonical_ticker, market, asset_type, currency "
-        "FROM current_position WHERE units > 0")).all()
-    ids = sorted({h[0] for h in held})
-    # txns for held securities (units over time + external cash flows)
-    txns = s.execute(text(
-        "SELECT security_id, trade_date, action, qty_signed, price, fees, currency FROM txn "
-        "WHERE trade_date IS NOT NULL AND security_id = ANY(:ids)"), {"ids": ids}).mappings().all()
-    # dividends scoped to held securities: a dividend whose purchase cost never entered `flows`
-    # (sold-out position) is a free inflow that inflates XIRR.
-    divs = s.execute(text(
-        "SELECT security_id, COALESCE(ex_date, pay_date) AS ex_date, pay_date, gross, currency "
-        "FROM dividend WHERE pay_date IS NOT NULL AND security_id = ANY(:ids)"),
-        {"ids": ids}).mappings().all()
-    # last known close per security — covers what Yahoo can't price (funds, delisted tickers)
-    last_px = latest_close(s)
-    s.close()
+def _returns(held, txns, divs, last_px, as_of, fetch=daily):
+    """The whole return calculation, once the database rows are in hand.
 
-    start = min((t["trade_date"] for t in txns), default=dt.date.today())
-    days = [start + dt.timedelta(d) for d in range((dt.date.today() - start).days + 1)]
+    Split out from `compute_twr` so the clock and the price source are both arguments: hold
+    `fetch` still and advancing `as_of` is the only moving input, which is the only way to
+    say which output fields the clock actually owns. See tests/test_twr.py and issue #52.
+
+    What `as_of` legitimately moves: `xirr_annualised`, `twr_annualised`, `years` — each
+    divides a fixed total by an elapsed-time denominator that grows daily. What it must not
+    move, given no new close between the two dates: `twr_cumulative`,
+    `value_plus_income_sgd`, `invested_sgd`, `from`. Note "no new close" is the real
+    condition, not "same `fetch`" — `ffill` truncates the series at `as_of`, so a later date
+    picks up any close the series already held past the earlier one.
+
+    Note `fetch` is Yahoo, not the `price` table. This endpoint's daily series is pulled live,
+    so an unchanged database does NOT pin its output — that is what #52 was chasing. (The
+    `last_px` fallback below, and /api/positions, do read the table; the two valuations can
+    therefore disagree.)"""
+    ids = sorted({h[0] for h in held})
+    start = min((t["trade_date"] for t in txns), default=as_of)
+    days = [start + dt.timedelta(d) for d in range((as_of - start).days + 1)]
 
     # daily prices (native) + fx
     prices, ccy_of = {}, {}
@@ -223,13 +226,13 @@ def compute_twr():
         if atype == "fund":
             continue  # fund: no daily series (Endowus monthly) -> skip from TWR
         try:
-            prices[sid] = ffill(daily(ysym(tk, market)), days)
+            prices[sid] = ffill(fetch(ysym(tk, market)), days)
         except Exception:
             prices[sid] = {}
     fx = {"SGD": {d: 1.0 for d in days}}
     for c in ("USD", "HKD", "EUR"):
         try:
-            fx[c] = ffill(daily(f"{c}SGD=X"), days)
+            fx[c] = ffill(fetch(f"{c}SGD=X"), days)
         except Exception:
             fx[c] = {}
     price_sids = [sid for sid, p in prices.items() if p]
@@ -292,22 +295,21 @@ def compute_twr():
                 flows.append((t["trade_date"], -abs(float(t["fees"])) * rate))
     flows.extend(div_flows)
 
-    today = dt.date.today()
     cum_all = running_units(txns, ids)
     mv = 0.0
     for sid in ids:
-        u = units_on(cum_all, sid, today)
+        u = units_on(cum_all, sid, as_of)
         px = prices[sid][max(prices[sid])] if prices.get(sid) else last_px.get(sid)
-        rate = fx_on(fx, ccy_of[sid], today)
+        rate = fx_on(fx, ccy_of[sid], as_of)
         if u > 1e-9 and px and rate is not None:
             mv += u * px * rate
     if mv > 0:
-        flows.append((today, mv))
+        flows.append((as_of, mv))
     xirr = _xirr(flows)
     twr_cum, twr_ann = _twr(days, txns, prices, ccy_of, fx, contrib_twr, div_by_day)
     invested = sum(-a for _, a in flows if a < 0)
     received = sum(a for _, a in flows if a > 0)
-    years = max((today - start).days / 365.0, 0.1)
+    years = max((as_of - start).days / 365.0, 0.1)
     return {"xirr_annualised": _r4(xirr),
             "twr_annualised": _r4(twr_ann),
             "twr_cumulative": _r4(twr_cum),
@@ -315,6 +317,30 @@ def compute_twr():
             "years": round(years, 1), "from": str(start),
             "note": "money-weighted (XIRR, pay-date dividends) + time-weighted (TWR, ex-date "
                     "dividends); fund excluded from the daily series but not from XIRR"}
+
+
+def compute_twr(as_of=None, fetch=daily):
+    """Read the held book out of the database and hand it to `_returns`."""
+    s = SessionLocal()
+    # one row per (account, security): the same counter can sit in FSM and CPF at once
+    held = s.execute(text(
+        "SELECT DISTINCT security_id, canonical_ticker, market, asset_type, currency "
+        "FROM current_position WHERE units > 0")).all()
+    ids = sorted({h[0] for h in held})
+    # txns for held securities (units over time + external cash flows)
+    txns = s.execute(text(
+        "SELECT security_id, trade_date, action, qty_signed, price, fees, currency FROM txn "
+        "WHERE trade_date IS NOT NULL AND security_id = ANY(:ids)"), {"ids": ids}).mappings().all()
+    # dividends scoped to held securities: a dividend whose purchase cost never entered `flows`
+    # (sold-out position) is a free inflow that inflates XIRR.
+    divs = s.execute(text(
+        "SELECT security_id, COALESCE(ex_date, pay_date) AS ex_date, pay_date, gross, currency "
+        "FROM dividend WHERE pay_date IS NOT NULL AND security_id = ANY(:ids)"),
+        {"ids": ids}).mappings().all()
+    # last known close per security — covers what Yahoo can't price (funds, delisted tickers)
+    last_px = latest_close(s)
+    s.close()
+    return _returns(held, txns, divs, last_px, as_of or dt.date.today(), fetch)
 
 
 if __name__ == "__main__":

--- a/scripts/capture_web_fixtures.py
+++ b/scripts/capture_web_fixtures.py
@@ -20,20 +20,42 @@ in from a targeted query against the same database — see `_ensure_long_merchan
 Re-run only when the fixtures genuinely need to move. Regenerating them casually
 re-tethers every measured assertion in the suite to whatever the database holds today.
 
-Three fixtures are not reproducible byte-for-byte, because three endpoints compute against
-`dt.date.today()`: `return.json` and every `xirr` in `positions.json` /
-`positions-closed.json`. Two captures four days apart moved all four of `return.json`'s
-computed fields — `xirr_annualised`, `twr_annualised`, `twr_cumulative` and
-`value_plus_income_sgd` — and the `xirr` of most positions, while the database held no new
-price, FX rate, dividend or transaction between them. Same rows in, different numbers out:
-that is the clock, not the data.
+Three fixtures are not reproducible byte-for-byte: `return.json`, and every `xirr` in
+`positions.json` / `positions-closed.json`. They move for two different reasons, and a
+recapture diff is only readable if you keep them apart (issue #52, which is where the
+numbers below come from).
 
-Do not tighten this into "only annualised rates move". That reading was written here once
-and is wrong — `value_plus_income_sgd` moved by 3,580 SGD and is not a rate, and the exact
-path by which `portfolio/twr.py` turns a later `today` into a lower terminal valuation on
-frozen data is not pinned down. What IS established is the direction to check in: a moved
-number in these three files is worth a `git log` on the database's newest row before it is
-worth reading as new data.
+1. The clock. `xirr`, `xirr_annualised` and `twr_annualised` divide a fixed total return by
+   an elapsed-years denominator that grows every day, so they drift downward on a book that
+   is standing still. Correct arithmetic, nothing to investigate. This is the only reason
+   `positions.json` moves — its `price`, `mv_native` and `mv_sgd` come from the `price`
+   table via `latest_close` and were byte-identical across the four-day capture.
+
+2. Yahoo. `portfolio/twr.py` fetches `return.json`'s whole daily price and FX series live
+   from Yahoo on every call; it does not read the `price` table (only its `last_px` fallback
+   does, for funds and delisted tickers Yahoo cannot price). So "the database gained no
+   rows" does not pin `return.json` at all, and the four-day capture that moved
+   `value_plus_income_sgd` by 3,580 SGD moved it because Yahoo had printed closes the
+   database had not ingested — not because `today` advanced.
+
+Which gives the split to read a diff by. Run against the real book with the Yahoo series
+truncated so no close lands between the two dates, four days apart:
+
+    xirr_annualised     0.1339 -> 0.1336   moved
+    twr_annualised      0.0772 -> 0.0771   moved
+    twr_cumulative      0.991  -> 0.991
+    value_plus_income_sgd  2142504 -> 2142504
+    invested_sgd           1634953 -> 1634953
+
+So `twr_cumulative`, `value_plus_income_sgd`, `invested_sgd` and `from` do NOT move on the
+clock alone. If they have moved, a close landed — check Yahoo, not the database, because the
+database is not where this endpoint gets its prices. `tests/test_twr.py` holds the split as
+a regression test, running `_returns` twice a week apart against a fetch that stops before
+both dates.
+
+(The two valuation paths disagreeing is a real inconsistency — `/api/return` can report a
+market value `/api/positions` does not — but it is a live-correctness question, out of scope
+for the fixtures, and left open.)
 
 None of it changes a rendered width — 19.64% and 19.62% are the same number of characters —
 so expect the churn in a recapture diff rather than going looking for a cause.

--- a/scripts/capture_web_fixtures.py
+++ b/scripts/capture_web_fixtures.py
@@ -25,18 +25,22 @@ Three fixtures are not reproducible byte-for-byte: `return.json`, and every `xir
 recapture diff is only readable if you keep them apart (issue #52, which is where the
 numbers below come from).
 
-1. The clock. `xirr`, `xirr_annualised` and `twr_annualised` divide a fixed total return by
-   an elapsed-years denominator that grows every day, so they drift downward on a book that
-   is standing still. Correct arithmetic, nothing to investigate. This is the only reason
-   `positions.json` moves — its `price`, `mv_native` and `mv_sgd` come from the `price`
-   table via `latest_close` and were byte-identical across the four-day capture.
+1. The clock alone. `twr_annualised` raises a fixed total return to `1/years`, and `xirr`
+   / `xirr_annualised` re-solve with the terminal inflow discounted over a longer span —
+   so both drift downward on a book that is standing still. Correct arithmetic, nothing to
+   investigate. This is the only reason `positions.json` moves: its `price`, `mv_native`
+   and `mv_sgd` come from the `price` table via `latest_close` and were byte-identical
+   across the four-day capture.
 
-2. Yahoo. `portfolio/twr.py` fetches `return.json`'s whole daily price and FX series live
-   from Yahoo on every call; it does not read the `price` table (only its `last_px` fallback
-   does, for funds and delisted tickers Yahoo cannot price). So "the database gained no
-   rows" does not pin `return.json` at all, and the four-day capture that moved
-   `value_plus_income_sgd` by 3,580 SGD moved it because Yahoo had printed closes the
-   database had not ingested — not because `today` advanced.
+2. The clock reaching a Yahoo close. `portfolio/twr.py` fetches `return.json`'s whole daily
+   price and FX series live from Yahoo on every call; it does not read the `price` table
+   (only its `last_px` fallback does, for funds and delisted tickers Yahoo cannot price).
+   So "the database gained no rows" does not pin `return.json` at all. Advancing `today` is
+   the trigger — `ffill` truncates the series at today, so a close Yahoo has already
+   printed is invisible until the date reaches it — but Yahoo, not the clock, is the source
+   of the new number. That is the likeliest account of the 3,580 SGD in
+   `value_plus_income_sgd`: inference from where the prices come from, not something
+   re-measured against the original captures, which are gone.
 
 Which gives the split to read a diff by. Run against the real book with the Yahoo series
 truncated so no close lands between the two dates, four days apart:
@@ -47,15 +51,17 @@ truncated so no close lands between the two dates, four days apart:
     value_plus_income_sgd  2142504 -> 2142504
     invested_sgd           1634953 -> 1634953
 
-So `twr_cumulative`, `value_plus_income_sgd`, `invested_sgd` and `from` do NOT move on the
-clock alone. If they have moved, a close landed — check Yahoo, not the database, because the
-database is not where this endpoint gets its prices. `tests/test_twr.py` holds the split as
-a regression test, running `_returns` twice a week apart against a fetch that stops before
-both dates.
+So `twr_cumulative`, `value_plus_income_sgd`, `invested_sgd` and `from` do NOT move while no
+close lands. If they have moved, one did — check Yahoo, not the database, because the
+database is not where this endpoint gets its prices. Note this is NOT the old "only
+annualised rates move" reading the header used to carry and #52 warned off: that one was
+unconditional and false. This one is conditional on the price series, and the condition is
+the whole point. `tests/test_twr.py` holds both halves as regression tests.
 
 (The two valuation paths disagreeing is a real inconsistency — `/api/return` can report a
 market value `/api/positions` does not — but it is a live-correctness question, out of scope
-for the fixtures, and left open.)
+for the fixtures, and left open. ADR 0001 already records the split price source as
+deliberate, so this is a question about the two endpoints agreeing, not about the design.)
 
 None of it changes a rendered width — 19.64% and 19.62% are the same number of characters —
 so expect the churn in a recapture diff rather than going looking for a cause.

--- a/tests/test_twr.py
+++ b/tests/test_twr.py
@@ -154,16 +154,18 @@ def test_twr_annualises_from_first_live_day():
 # database that had gained no price, FX rate, dividend or transaction. The tests below split
 # that observation in two, because the two halves have different causes.
 #
-#   Clock-dependent by construction: `xirr_annualised`, `twr_annualised`. Both divide a fixed
-#   total return by an elapsed-years denominator that grows every day. Holding the same value
-#   for longer IS a lower annualised return; there is nothing to fix.
+#   Clock-dependent by construction: `xirr_annualised`, `twr_annualised`. Same money held for
+#   longer IS a lower annualised return; there is nothing to fix.
 #
 #   Clock-INdependent, as long as no close lands between the two dates: `twr_cumulative`,
 #   `value_plus_income_sgd`, `invested_sgd`, `from`. So those two moving in the real capture
-#   was never the clock — it was the price series, which `compute_twr` fetches live from Yahoo
-#   rather than reading from the `price` table. "Unchanged database" does not freeze this
-#   endpoint's inputs. Confirmed on the real book: with the Yahoo series truncated so nothing
-#   lands in the window, four days apart moves only the two annualised rates.
+#   took a price series that moved — and `compute_twr` fetches that live from Yahoo rather
+#   than reading the `price` table, so "unchanged database" never froze this endpoint's
+#   inputs. Confirmed on the real book: with the Yahoo series truncated so nothing lands in
+#   the window, four days apart moves only the two annualised rates.
+#
+# The last test is the one that stops this being read as "only rates move" — advancing the
+# clock alone moves the levels too, whenever it reaches a close the series already held.
 
 HELD = [(1, "AAA", "SG", "equity", "SGD")]                 # SGD -> fx_on is 1.0 throughout
 TXNS = [{"security_id": 1, "trade_date": D(2024, 1, 1), "action": "buy",

--- a/tests/test_twr.py
+++ b/tests/test_twr.py
@@ -1,14 +1,15 @@
 """Unit tests for the return engine: _xirr (money-weighted) and _twr (time-weighted).
 
 Both are pure once contributions and dividends are passed in, so nothing here touches the
-database or Yahoo.
+database or Yahoo. `_returns` — the whole `/api/return` body below the DB read — is tested
+here too, with the Yahoo fetch injected, which is what makes the clock isolatable.
 """
 import datetime as dt
 
 import pytest
 
 from portfolio.performance import _xirr
-from portfolio.twr import _twr, contributions, fx_on
+from portfolio.twr import _returns, _twr, contributions, fx_on
 
 D = dt.date
 
@@ -145,3 +146,85 @@ def test_twr_annualises_from_first_live_day():
     cum, ann = _twr(days, txns, prices, {1: "SGD"}, FX1, contrib)
     assert cum == pytest.approx(0.21, abs=1e-3)
     assert ann == pytest.approx(0.10, abs=1e-3)
+
+
+# ------------------------------------------------------- _returns: what moves with the clock
+#
+# Issue #52: two captures of /api/return four days apart moved every computed field against a
+# database that had gained no price, FX rate, dividend or transaction. The tests below split
+# that observation in two, because the two halves have different causes.
+#
+#   Clock-dependent by construction: `xirr_annualised`, `twr_annualised`. Both divide a fixed
+#   total return by an elapsed-years denominator that grows every day. Holding the same value
+#   for longer IS a lower annualised return; there is nothing to fix.
+#
+#   Clock-INdependent, as long as no close lands between the two dates: `twr_cumulative`,
+#   `value_plus_income_sgd`, `invested_sgd`, `from`. So those two moving in the real capture
+#   was never the clock — it was the price series, which `compute_twr` fetches live from Yahoo
+#   rather than reading from the `price` table. "Unchanged database" does not freeze this
+#   endpoint's inputs. Confirmed on the real book: with the Yahoo series truncated so nothing
+#   lands in the window, four days apart moves only the two annualised rates.
+
+HELD = [(1, "AAA", "SG", "equity", "SGD")]                 # SGD -> fx_on is 1.0 throughout
+TXNS = [{"security_id": 1, "trade_date": D(2024, 1, 1), "action": "buy",
+         "qty_signed": 100.0, "price": 10.0, "fees": 5.0, "currency": "SGD"}]
+
+
+def _fetch(closes):
+    """Stand in for `daily`: a fixed close series for AAA.SI, nothing for the FX symbols."""
+    return lambda sym: dict(closes) if sym == "AAA.SI" else {}
+
+
+# stops well before either as_of below, so no close lands in the window: ffills 12.0 to both
+FROZEN = _fetch([(D(2024, 1, 1), 10.0), (D(2024, 6, 1), 12.0)])
+
+
+def test_no_close_in_the_window_holds_the_levels_as_the_clock_advances():
+    """Regression for #52: with no new close between the two dates, a later `today` must not
+    restate what the portfolio is worth or what it has returned in total."""
+    a = _returns(HELD, TXNS, [], {}, D(2026, 1, 1), fetch=FROZEN)
+    b = _returns(HELD, TXNS, [], {}, D(2026, 1, 8), fetch=FROZEN)
+
+    assert a["value_plus_income_sgd"] == b["value_plus_income_sgd"] == 1200   # 100 units @ 12.00
+    assert a["twr_cumulative"] == b["twr_cumulative"] == pytest.approx(0.20)
+    assert a["invested_sgd"] == b["invested_sgd"] == 1005                     # 1000 + 5 fees
+    assert a["from"] == b["from"] == "2024-01-01"
+
+
+def test_annualised_rates_decay_as_the_clock_advances():
+    """The other half of #52, and not a bug: same money, more elapsed time, lower rate."""
+    a = _returns(HELD, TXNS, [], {}, D(2026, 1, 1), fetch=FROZEN)
+    b = _returns(HELD, TXNS, [], {}, D(2026, 1, 8), fetch=FROZEN)
+
+    assert b["xirr_annualised"] < a["xirr_annualised"]
+    assert b["twr_annualised"] < a["twr_annualised"]
+    assert a["years"] == b["years"] == 2.0        # rounded to 1dp, so it holds — as it did in #52
+
+
+def test_a_close_inside_the_window_is_what_restates_the_levels():
+    """The mechanism #52 was missing, and the reason "same `fetch`" is not the same as "frozen":
+    `ffill` truncates the series at `as_of`, so one unchanged fetch holding a 2026-01-05 close
+    is invisible on the 1st and priced on the 8th. Only `as_of` moves here, and the levels move
+    anyway — the shape the real capture showed (levels moved, database untouched)."""
+    yahoo = _fetch([(D(2024, 1, 1), 10.0), (D(2024, 6, 1), 12.0), (D(2026, 1, 5), 11.5)])
+
+    a = _returns(HELD, TXNS, [], {}, D(2026, 1, 1), fetch=yahoo)
+    b = _returns(HELD, TXNS, [], {}, D(2026, 1, 8), fetch=yahoo)
+
+    assert a["value_plus_income_sgd"] == 1200 and a["twr_cumulative"] == pytest.approx(0.20)
+    assert b["value_plus_income_sgd"] == 1150 and b["twr_cumulative"] == pytest.approx(0.15)
+
+
+def test_a_security_yahoo_cannot_price_falls_back_to_the_stored_close():
+    """Candidate 1 in #52 — a security ageing out of a rolling price window — does not happen:
+    `daily` asks for a 10y range ending now, so nothing ages out. The `last_px` fallback fires
+    on absence of a series, not on its staleness, and is therefore clock-stable."""
+    fund = [(2, "FUND", "SG", "fund", "SGD")]
+    txns = [{"security_id": 2, "trade_date": D(2024, 1, 1), "action": "buy",
+             "qty_signed": 50.0, "price": 8.0, "fees": None, "currency": "SGD"}]
+
+    a = _returns(fund, txns, [], {2: 9.0}, D(2026, 1, 1), fetch=_fetch([]))
+    b = _returns(fund, txns, [], {2: 9.0}, D(2026, 1, 8), fetch=_fetch([]))
+
+    assert a["value_plus_income_sgd"] == b["value_plus_income_sgd"] == 450   # 50 units @ 9.00
+    assert a["twr_cumulative"] is None and b["twr_cumulative"] is None       # no daily sleeve


### PR DESCRIPTION
Closes #52.

## The mechanism

#52's premise — "the only moving input is `dt.date.today()`" — was wrong, and so were both of its candidates.

`compute_twr` **fetches the entire daily price and FX series live from Yahoo on every call** (`daily()` -> `query1.finance.yahoo.com`). It never reads the `price` table; only its `last_px` fallback does, for funds and delisted tickers. So "the database gained no rows between the captures" never pinned this endpoint's inputs.

That also explains the detail #52 found most puzzling: `positions.json`'s `price`, `mv_native` and `mv_sgd` were byte-identical because `performance.py` values from `latest_close` — the table — while `/api/return` values from Yahoo. Two price sources, one of them not in the database at all.

Both candidates eliminated:

- **Candidate 1** (a security ageing out of a rolling window): `daily()` asks for a 10y range ending now, so nothing ages out. The `last_px` fallback fires on *absence* of a series, not staleness of one.
- **Candidate 2** (the fund revaluing invisibly): funds are skipped from the daily series entirely and priced from `last_px`, which is clock-stable.

## The split

| moves on the clock alone | moves only when a close lands |
| --- | --- |
| `xirr_annualised`, `twr_annualised`, `years` | `twr_cumulative`, `value_plus_income_sgd`, `invested_sgd`, `from` |

Verified on the real book, Yahoo truncated so no close lands in the window, 07-31 -> 08-04:

```
xirr_annualised          0.1339 -> 0.1336   moved
twr_annualised           0.0772 -> 0.0771   moved
twr_cumulative           0.991  -> 0.991
value_plus_income_sgd  2142504 -> 2142504
invested_sgd           1634953 -> 1634953
```

One subtlety worth flagging, because the first draft of this PR got it wrong: **"same fetch" is not "frozen"**. `ffill` truncates the series at `as_of`, so a close Yahoo has *already printed* is invisible on the earlier date and priced on the later one. Advancing the clock is the trigger; Yahoo is the source. A test pins this.

## The change

`_returns(held, txns, divs, last_px, as_of, fetch)` split out of `compute_twr`, making the clock and the price source both arguments — the only way to hold one still and move the other. `compute_twr(as_of=None, fetch=daily)` keeps its old signature and behaviour; `server/main.py` is untouched.

This is the seam **ADR 0001 already endorsed** as its Consequences item 3: *"Give `compute_twr` an injectable price/FX seam... the single highest-value change."* Nothing moves toward the unification the ADR forbids — `performance.py` is untouched and the cadence split widens rather than narrows.

`scripts/capture_web_fixtures.py` can now tell a recapturer which diffs to read instead of explicitly declining to. It is careful not to reinstate the unconditional "only annualised rates move" reading #52 warned off: the claim here is conditional on the price series, and the condition is the point.

## Tests

264 -> 268, all green, ruff clean. Four regressions covering: no close in the window holds the levels; annualised rates decay anyway; a close *inside* the window moves the levels with `as_of` as the only moving input; and the `last_px` fallback is clock-stable.

## Not fixed here

`/api/return` and `/api/positions` value the same book from different sources — 29,451 SGD / 2.50% apart as of today — and neither declares an as-of date. Filed as #56 rather than fixed here; ADR 0001 records the split as deliberate, so it is a question about the two endpoints agreeing, not about the design.

Also spotted and left alone: `fx_map` (`portfolio/db.py:12`) selects from `fx_rate` with no `ORDER BY` over 5 dated rows per currency, so which rate it returns is undefined. Captured in #56.
