### PR TITLE
The pinned column that left 47px for the numbers

### DIFF
--- a/web/src/modules/portfolio/Holdings.jsx
+++ b/web/src/modules/portfolio/Holdings.jsx
@@ -68,9 +68,16 @@ function DataRow({ r, onClick, max }) {
   const { net, partial } = netOf(r);
   return (
     <tr className="rowlink" style={{ cursor: "pointer", opacity: closed ? 0.7 : 1 }} onClick={onClick}>
-      <td className="l">{r.name} <span className="pill">{r.ticker}</span>
+      {/* The ticker sits on the sub-line rather than beside the name, and this cell is the
+          pinned one — so its width is the width of everything the numbers have to scroll
+          under. Measured at 390×844: name+pill inline made it 281px of a 328px window, 86%,
+          leaving 47px for the thirteen numbers the pin exists to let you reach; at 360 it was
+          94% and 17px, narrower than a single figure. Moving the pill down costs no row
+          height, because the accounts line was already there. */}
+      <td className="l">{r.name}
         {closed && <span className="pill" style={{ marginLeft: 4, color: "var(--mut)" }}>closed</span>}
-        <div className="mut" style={{ fontSize: 11 }}>{(r.accounts || []).join(", ")}</div></td>
+        <div className="mut" style={{ fontSize: 11 }}>
+          <span className="pill">{r.ticker}</span>{(r.accounts || []).length ? " " + (r.accounts || []).join(", ") : ""}</div></td>
       <td className="l"><span className="pill">{r.bucket}</span></td>
       <td className="l"><span className="pill">{r.market}</span></td>
       <td>{closed ? <span className="mut">—</span> : fmt(r.units, r.units < 10 ? 2 : 0)}</td>


### PR DESCRIPTION
Holdings' pinned `Security` cell is the width everything else has to scroll under, and nobody had ever measured it.

## What it measured

With the ticker pill inline beside the name, against the committed fixtures:

| viewport | scroll window | pinned cell | share | numbers visible |
|---|---|---|---|---|
| 360×640 | 298px | 281px | **94%** | **17px** |
| 390×844 | 328px | 281px | **86%** | **47px** |
| 430×932 | 368px | 281px | 76% | 87px |
| 640×1024 | 350px | 283px | 81% | 67px |

On a 360px phone you read a 1328px table through a 17px slot — narrower than a single figure. The pin was not leaving room for the thing it exists to let you reach.

## What this does

The ticker pill moves down to the sub-line the accounts were already on. It costs no row height — **60.5px before and after, no rows lost** — because that line was already rendering.

| viewport | pin | share | numbers |
|---|---|---|---|
| 360×640 | 281 → **256px** | 94% → 86% | 17 → **42px** |
| 390×844 | 281 → **256px** | 86% → 78% | 47 → **72px** |
| 430×932 | 281 → **256px** | 76% → 70% | 87 → **112px** |
| 640×1024 | 283 → **258px** | 81% → 74% | 67 → **92px** |

## What it does not do

**It is a dent, not a fix.** The remaining 256px is the security name — *DBS Group Holdings Ltd* in the fixtures — and nothing bounds it, so the longest holding in the book still sets the column for every row and the pin still holds 78% of the window at 390.

Capping the cell is the lever that actually moves it: `max-width: 150px` with the name ellipsed puts the numbers past half the screen for the first time (~178px of 328 at 390) and takes the row to one line, which is the two rows `RESPONSIVE.md` records as missed (10 achieved against 12–13 predicted). That is left out deliberately — it costs the tail of the name, which is a design decision rather than a tidy-up.

## The gap that let it ship

`pinned.spec.js` asserts the pin **is** `Security` and never asserts how wide it is. Ten viewport projects watched 94% of the window go by. A cap wants that gate written alongside it.

## Verification

`make test-web` — **1,345 passed, 470 skipped, 0 failed**, matching the baseline exactly.

One caveat worth recording: the suite hit an intermittent page-load timeout under parallel load twice during this work (`.app` never mounting within 20s, unrelated views). Re-running the affected spec in isolation passed. A red `make test-web` needs a re-run before it is believed.