### PR TITLE
docs(ci): correct the uv-ecosystem claim that no Dependabot PR had tested

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,13 +10,20 @@ version: 2
 
 updates:
   # ---------------------------------------------------------------------------
-  # Python — pyproject.toml + uv.lock
+  # Python — pyproject.toml + uv.lock + requirements.txt, all three in one PR
   #
-  # This ecosystem edits uv.lock ONLY. requirements.txt (the runtime subset Vercel installs
-  # into the function) is not a manifest dependabot knows about here, so a bump landing in
-  # the lockfile leaves the deployed pins behind. CI's `sync_requirements --check` is what
-  # catches that: a production bump fails until `make sync-requirements` is committed onto
-  # the PR. Deliberate — the versions that reach production get a human.
+  # `uv` names the RESOLVER, not the file set: dependabot's python updater rewrites every
+  # manifest in the directory it can, requirements.txt included. Measured, not assumed —
+  # PR #70 carried fastapi 0.138.0 -> 0.141.1 into the lockfile and the runtime pins
+  # together, and CI's drift check passed on it.
+  #
+  # (This comment used to claim the opposite, that the lockfile moved alone and every
+  # production bump needed `make sync-requirements` committed onto the PR by hand. It was
+  # written before any dependabot PR existed to check it against. It was wrong.)
+  #
+  # So `sync_requirements --check` in CI is an invariant, not a chore anyone performs. What
+  # it actually guards is a hand-run `uv lock` — which is how the lockfile came to have no
+  # entry for anthropic at all while requirements.txt pinned it.
   # ---------------------------------------------------------------------------
   - package-ecosystem: "uv"
     directory: "/"

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -243,9 +243,9 @@ the 300s function ceiling. It stays sequential and unretried — a failed run is
   **Actions** tab, or locally with `uvx pip-audit -r requirements.txt`. Lock files (`uv.lock`,
   pinned `requirements.txt`) are committed.
 - **Dependency updates**: Dependabot (`.github/dependabot.yml`) opens grouped PRs weekly for
-  `uv.lock`, `web/package-lock.json`, and monthly for the workflow actions. Minor/patch
-  **development** bumps auto-merge once CI passes; anything that reaches production waits for
-  you. See [§Dependency updates](#dependency-updates) below.
+  the Python manifests and `web/package-lock.json`, monthly for the workflow actions.
+  Minor/patch **development** bumps auto-merge once CI passes; anything that reaches
+  production waits for you. See [§Dependency updates](#dependency-updates) below.
 - **Local dev**: copy `.env.example` → `.env` (`COOKIE_SECURE=false` for http), and
   `web/.env.example` → `web/.env.local`. Run API (`make api`, i.e. `uvicorn server.main:app
   --port 8000`) + `npm run dev` (Vite proxies `/api` **and** `/ingest` → 8000, so the
@@ -278,13 +278,27 @@ real `[project].dependencies`), so the package *list* in `requirements.txt` is a
 choice. The *versions* are not: `scripts/sync_requirements.py` re-pins them from `uv.lock`,
 and CI fails on drift.
 
-That check is what makes Dependabot's `uv` ecosystem safe. It edits `uv.lock` only, so a
-production bump landing alone would ship a version nobody reviewed to the deployed function.
-Instead:
+**Dependabot updates all three files itself.** `uv` names the resolver, not the file set —
+its Python updater rewrites every manifest in the directory it can, `requirements.txt`
+included. PR #70 carried `fastapi` 0.138.0 → 0.141.1 into `pyproject.toml`, `uv.lock` *and*
+the runtime pins in one PR, and the drift check passed on it. So there is no routine step
+here: you do not run `make sync-requirements` on a Dependabot PR.
+
+What the check actually guards is a **hand-run `uv lock`** — which is exactly how this repo
+ended up with a lockfile that had no entry for `anthropic` at all while `requirements.txt`
+pinned it. If CI ever fails on drift:
 
 ```
-make sync-requirements     # re-pin requirements.txt from uv.lock, then commit onto the PR
+make sync-requirements     # re-pin requirements.txt from uv.lock, then commit
 ```
+
+**Grouping, and the trap in it.** Most groups are scoped `update-types: [minor, patch]`,
+which **silently excludes majors** — a major falls out of its group and gets its own PR.
+Harmless for an independent package; a deadlock for a coupled pair, which is what happened
+on the first run: react 18→19 and react-dom 18→19 arrived as two PRs (#67, #69), and neither
+could be merged alone. The pairs that must travel together are therefore grouped by *name*,
+which covers every update type: `react`+`react-dom`, `vite`+`@vitejs/plugin-react`,
+`sqlalchemy`+`alembic`. Add to those patterns before adding a coupled dependency, not after.
 
 **What auto-merges**: minor and patch **development** dependencies (ruff, pytest, vite,
 `@playwright/test`, `@vitejs/plugin-react`), and only once both CI jobs pass. Nothing that

--- a/Makefile
+++ b/Makefile
@@ -83,10 +83,11 @@ capture-web-fixtures:   ## re-derive the suite's fixtures from the live DB (need
 	@# today — read the docstring in the script before running it.
 	$(PY) scripts/capture_web_fixtures.py --base http://localhost:8000
 
-sync-requirements:   ## re-pin requirements.txt from uv.lock (run this on a dependabot uv.lock PR)
+sync-requirements:   ## re-pin requirements.txt from uv.lock (only when CI reports drift)
 	@# Two manifests, one resolver: uv.lock resolves everything, requirements.txt is the
-	@# runtime subset Vercel installs. A lockfile bump that lands alone ships an unreviewed
-	@# version to the function, so CI fails on drift — this is the fix it asks for.
+	@# runtime subset Vercel installs. NOT a step for dependabot PRs — it updates both files
+	@# itself. This is for a hand-run `uv lock`, which is how the lockfile once ended up with
+	@# no entry for anthropic while requirements.txt pinned it.
 	$(PY) scripts/sync_requirements.py
 
 net:          ## per-ticker net verdict (+/-) incl dividends + option premiums


### PR DESCRIPTION
Corrects a claim I introduced in #63 and asserted in three places. It was written before any Dependabot PR existed to check it against, and it was wrong.

## What was claimed

> This ecosystem edits uv.lock **ONLY**. requirements.txt … is not a manifest dependabot knows about here, so a bump landing in the lockfile leaves the deployed pins behind. […] a production bump fails until `make sync-requirements` is committed onto the PR.

## What actually happens

`uv` names the **resolver**, not the file set. Dependabot's Python updater rewrites every manifest in the directory it can, `requirements.txt` included.

Evidence — **PR #70**, the first Python bump to arrive:

```
pyproject.toml
requirements.txt      fastapi 0.138.0 -> 0.141.1, pydantic-settings, google-auth
uv.lock
```

All three in one PR, and the `python` check — which runs `sync_requirements --check` — passed on it. Verified again on current `main`: `requirements.txt is in sync with uv.lock`, `fastapi==0.141.1` in both.

So there is **no routine step**. Nobody runs `make sync-requirements` on a Dependabot PR.

## Why the check stays

It guards something real, just not what I said. A **hand-run `uv lock`** is what drifts — which is precisely how this repo ended up with a lockfile containing no entry for `anthropic` while `requirements.txt` pinned it (found and fixed in #63). Restated as an invariant rather than a chore.

## Also

Documents the grouping trap fixed in #71 — `update-types: [minor, patch]` silently excludes majors — in DEPLOY.md, so the next coupled dependency gets added to the right pattern list before it costs two deadlocked PRs rather than after.

## Files

| File | Change |
|---|---|
| `.github/dependabot.yml` | Corrected comment, with the retraction left visible rather than quietly rewritten |
| `DEPLOY.md` | Corrected §Dependency updates + Security ops bullet; added the grouping trap |
| `Makefile` | Help text said "run this on a dependabot uv.lock PR" — now "only when CI reports drift" |

Docs and comments only; no behaviour change.