### PR TITLE
fix(ledger): the buy that reported as money coming in

### DIFF
--- a/build/_ledgercommon.py
+++ b/build/_ledgercommon.py
@@ -37,6 +37,42 @@ def num(s):
     return -v if neg else v
 
 
+# ---------- amount sign ----------
+# The ledger's `amount` is investor cash flow: a buy is money out (negative), a sell is
+# money in (positive). The SG broker CSVs already write it that way ("($9,281.18)" for a
+# buy), and portfolio.performance.cdp_cost reads them on exactly that assumption. The two
+# statement exports below each mean something *else* by their money column, so they are
+# normalised here rather than copied through.
+
+def trade_cash_flow(amount, qty_signed):
+    """Tiger's flex `Amount` is qty x price, so it carries the *position's* sign: positive
+    on a buy, negative on a sell — the inverse of cash flow. Flip it: shares in means money
+    out. A zero quantity leaves the figure alone (nothing changed hands)."""
+    if not qty_signed:
+        return amount
+    return -abs(amount) if qty_signed > 0 else abs(amount)
+
+
+# iFast writes a magnitude in "Product Amount" and puts the direction in *which* of its two
+# amount columns is filled; an unfilled one is blank or a bare dash.
+FSM_NO_AMOUNT = ("", "-", "--")
+
+
+def fsm_amount_is_into_product(row):
+    """True when iFast booked this row as money going *into* the product ("Investment
+    Amount"), false when it came back out ("Redemption Amount"). Exactly one is ever
+    filled. A literal "0" counts as filled — nil-paid rights rows carry a real zero."""
+    return str(row.get("Investment Amount") or "").strip() not in FSM_NO_AMOUNT
+
+
+def fsm_cash_flow(amount, into_product, is_cash_leg):
+    """Turn an iFast magnitude into cash flow. The polarity inverts between the two legs
+    iFast books for one trade: investing in the *stock* spends cash, while that same money
+    landing in the *cash account* is cash received."""
+    into_cash = into_product if is_cash_leg else not into_product
+    return abs(amount) if into_cash else -abs(amount)
+
+
 def norm_ticker(sym, market):
     """Normalise a display symbol to its bare exchange code: pull a trailing
     "(00823)" out of "Link Reit (00823)", drop a ".SI/.US/.HK" suffix, zero-pad

--- a/build/build_ledger.py
+++ b/build/build_ledger.py
@@ -13,7 +13,8 @@ import csv, glob, os, re
 from collections import defaultdict
 from _csvout import write_csv
 from _dates import try_date
-from _ledgercommon import canon, is_transfer_in, is_transfer_out, norm_ticker, num
+from _ledgercommon import (canon, fsm_amount_is_into_product, fsm_cash_flow, is_transfer_in,
+                           is_transfer_out, norm_ticker, num, trade_cash_flow)
 
 DATA = os.path.join(os.path.dirname(__file__), "..", "data")
 ROOT = os.path.join(os.path.dirname(__file__), "..")
@@ -125,7 +126,7 @@ def load_tiger():
                         add(date=parse_date(tt), account=racct, market=mkt,
                             ticker=canon(norm_ticker(sym, mkt)), asset_type=atype_l,
                             action=("buy" if qty > 0 else "sell"), qty_signed=qty,
-                            price=row[9], amount=num(row[10]), fees=fee,
+                            price=row[9], amount=trade_cash_flow(num(row[10]), qty), fees=fee,
                             currency=row[-1], source=rel, raw=sym)
                 elif sec == "Transfer" and len(row) > 14 and row[3] == "DATA" and row[4] == "Stock":
                     # gifted / transferred-in shares (e.g. BABA, AMZN gifts)
@@ -185,10 +186,19 @@ def load_fsm():
             if code == "S51" and pn.startswith("Seatrium"):
                 sign = -1
         qsig = (sign * abs(qty)) if (sign and is_stock and qty) else 0
+        # Custody transfers and cash dividends move no money through the position: iFast
+        # books both as "into the product", but the figure is a valuation / a receipt, not
+        # the cost of a trade. Left positive, matching the transfer_out legs in the simple
+        # CSVs, which record the same custody move at the same market value.
+        if is_stock and t in ("Transfer In", "Transfer Out", "Stock Dividend"):
+            amt = abs(num(r.get("Product Amount")))
+        else:
+            amt = fsm_cash_flow(num(r.get("Product Amount")),
+                                fsm_amount_is_into_product(r), is_cash_leg=not is_stock)
         add(date=parse_date(r.get("Transaction Date")), account=fsm_acct, market=mkt,
             ticker=code, asset_type=("stock" if is_stock else "cash"),
             action=action, qty_signed=qsig,
-            price=r.get("Transaction Price", ""), amount=num(r.get("Product Amount")),
+            price=r.get("Transaction Price", ""), amount=amt,
             fees=num(r.get("Total Fee")),
             currency=(r.get("Product Currency") or "").strip(),
             source="fsm/ifast_historical.csv", raw=pn)
@@ -198,10 +208,19 @@ def load_moomoo():
     p = os.path.join(os.path.dirname(__file__), "moomoo_events.csv")
     if not os.path.exists(p): return
     for r in csv.DictReader(open(p)):
+        qty = float(r["qty_signed"])
+        # the snapshot-diff records a magnitude; only the traded legs are a cash flow
+        # (a custody move carries a valuation, so it keeps its positive mark).
+        amt = num(r["amount"]) if r.get("amount") else ""
+        act = r["action"]
+        # "transfer" catches this file's slash-spellings ("open/transfer_in",
+        # "sell/transfer") that is_transfer_in/out were never written for.
+        if amt != "" and "transfer" not in act:
+            amt = trade_cash_flow(amt, qty)
         add(date=r["date"], account="Moomoo", market=r["market"],
             ticker=canon(norm_ticker(r["ticker"], r["market"])),
-            asset_type="stock", action=r["action"], qty_signed=float(r["qty_signed"]),
-            price=r.get("price", ""), amount=num(r.get("amount")) if r.get("amount") else "",
+            asset_type="stock", action=act, qty_signed=qty,
+            price=r.get("price", ""), amount=amt,
             source=r["source"], raw=r["raw"])
 
 # ---------- CDP (from parse_cdp.py snapshot-diff — authoritative custody) ----------
@@ -221,9 +240,17 @@ def load_endowus():
     if not os.path.exists(p): return
     for r in csv.DictReader(open(p)):
         acct = ENDOWUS_BUCKET.get(r["src"], "CPF")
+        qty = float(r["qty_signed"])
+        act = r["action"]
+        # the snapshot-diff records a magnitude. Endowus takes its advisory fee in units,
+        # so a fee row looks like a small sale — but it is a cost, not proceeds, and stays
+        # negative whichever way the units moved.
+        amt = num(r["amount"]) if r.get("amount") else ""
+        if amt != "":
+            amt = -abs(amt) if act == "fee" else trade_cash_flow(amt, qty)
         add(date=r["date"], account=acct, market="SG", ticker="0P0001OOJG",
-            asset_type="fund", action=r["action"], qty_signed=float(r["qty_signed"]),
-            price=r.get("price", ""), amount=r.get("amount", ""),
+            asset_type="fund", action=act, qty_signed=qty,
+            price=r.get("price", ""), amount=amt,
             currency="SGD", source="endowus (pdf)", raw=r["fund"])
 
 # ---------- synthesize missing transfer-in legs ----------

--- a/tests/test_ledger_amount_sign.py
+++ b/tests/test_ledger_amount_sign.py
@@ -1,0 +1,90 @@
+"""The ledger's `amount` column means one thing: investor cash flow, buy negative.
+
+The SG broker CSVs already write it that way, and portfolio.performance.cdp_cost reads
+them on exactly that assumption ("buys negative (cash out), sells positive"). Two exports
+disagreed and were copied through unnormalised, so a buy rendered as a positive amount in
+the transaction history — a 2020-02-27 FSM buy of 34,000 QAF showed S$29,773.43 next to a
+CDP buy showing S$-10,033.71:
+
+  - Tiger's flex `Amount` is qty x price, so it follows the position (+ buy, - sell).
+  - iFast's `Product Amount` is an unsigned magnitude; the direction lives in which of
+    "Investment Amount" / "Redemption Amount" is filled — and that flips meaning between
+    the stock leg and the cash-account leg of the very same trade.
+
+Run: PYTHONPATH=. .venv/bin/python -m pytest tests/test_ledger_amount_sign.py -q
+"""
+from build._ledgercommon import fsm_amount_is_into_product, fsm_cash_flow, trade_cash_flow
+
+
+# ---------- Tiger flex ----------
+
+def test_tiger_buy_becomes_cash_out():
+    # tiger_prime_2020: C52.SI, qty 6000 @ 1.70, Amount "10,200.00"
+    assert trade_cash_flow(10200.0, 6000) == -10200.0
+
+
+def test_tiger_sell_becomes_cash_in():
+    # tiger_cash_boost: BIDU, qty -100, Amount "-15,465.00" — already negative, and wrong
+    # way round. Flipping the sign of the magnitude (not of the value) is what fixes it.
+    assert trade_cash_flow(-15465.0, -100) == 15465.0
+
+
+def test_tiger_flip_does_not_depend_on_the_incoming_sign():
+    """Guard the ordering: qty decides the direction, the money column only supplies size.
+    A file that ever emits an unsigned Amount must still come out signed correctly."""
+    assert trade_cash_flow(500.0, 10) == trade_cash_flow(-500.0, 10) == -500.0
+    assert trade_cash_flow(500.0, -10) == trade_cash_flow(-500.0, -10) == 500.0
+
+
+def test_tiger_zero_quantity_leaves_the_figure_alone():
+    # forex/cash rows reach this with no position change; inventing a sign would be a lie
+    assert trade_cash_flow(1234.0, 0) == 1234.0
+
+
+# ---------- the other snapshot-diff sources, which report the same bare magnitude ----------
+
+def test_snapshot_diff_buys_are_cash_out_too():
+    """moomoo_events.csv and endowus_events.csv are diffs of PDF statements, so they carry a
+    magnitude with no direction at all. Both had one buy row reading positive."""
+    assert trade_cash_flow(10071.0, 2700.0) == -10071.0        # Moomoo C31 2021-04-28
+    assert trade_cash_flow(3000.0, 16.62603) == -3000.0        # Endowus Amundi 2025-04-09
+
+
+# ---------- iFast / FSM ----------
+
+def test_fsm_stock_buy_is_cash_out():
+    # 27 Feb 2020 Buy QAF (Q01): Investment Amount 29773.43, Product Amount 29773.43
+    assert fsm_cash_flow(29773.43, into_product=True, is_cash_leg=False) == -29773.43
+
+
+def test_fsm_stock_sell_is_cash_in():
+    # 19 Mar 2020 Sell QAF (Q01): Redemption Amount 21901.85
+    assert fsm_cash_flow(21901.85, into_product=False, is_cash_leg=False) == 21901.85
+
+
+def test_fsm_cash_leg_is_the_mirror_of_the_stock_leg():
+    """iFast books both legs of one trade. "Purchase of Stock" on the cash account carries
+    a Redemption Amount (money leaving the cash product) for the same trade whose stock leg
+    carries an Investment Amount. Both must read as one cash outflow, not cancel out."""
+    stock_leg = fsm_cash_flow(29773.43, into_product=True, is_cash_leg=False)
+    cash_leg = fsm_cash_flow(29773.43, into_product=False, is_cash_leg=True)
+    assert stock_leg == cash_leg == -29773.43
+
+
+def test_fsm_deposit_and_withdrawal_are_signed_from_the_cash_account_side():
+    assert fsm_cash_flow(1000.0, into_product=True, is_cash_leg=True) == 1000.0    # Deposit
+    assert fsm_cash_flow(1000.0, into_product=False, is_cash_leg=True) == -1000.0  # Withdrawal
+
+
+def test_fsm_column_probe_reads_a_filled_investment_amount():
+    assert fsm_amount_is_into_product({"Investment Amount": "29773.43",
+                                       "Redemption Amount": "-"}) is True
+    assert fsm_amount_is_into_product({"Investment Amount": "-",
+                                       "Redemption Amount": "21901.85"}) is False
+
+
+def test_fsm_column_probe_treats_a_literal_zero_as_filled():
+    """Nil-paid rights rows carry "0" in one column and "-" in the other. A truthiness test
+    would read the zero as empty and silently pick the wrong direction."""
+    assert fsm_amount_is_into_product({"Investment Amount": "0",
+                                       "Redemption Amount": "-"}) is True


### PR DESCRIPTION
A 2020-02-27 FSM buy of 34,000 QAF rendered as `S$29,773.43` in the transaction history, directly above a CDP buy rendered as `S$-10,033.71`. Same direction, opposite sign.


## What `amount` means

Investor cash flow: a buy is money out. The SG broker CSVs already write it that way — `"($9,281.18)"` — and `portfolio.performance.cdp_cost` reads them on exactly that assumption ("buys negative (cash out), sells positive").

Three sources meant something else by their money column and were copied straight through:

| Source | Its money column actually meant | Symptom |
|---|---|---|
| iFast / FSM | unsigned magnitude; direction lives in *which* of `Investment Amount` / `Redemption Amount` is filled | buy read `+29,773.43` |
| Tiger flex | `qty × price` — follows the *position*, not cash | every buy positive, every sell negative |
| Moomoo / Endowus | bare magnitude from a PDF snapshot-diff | 1 buy each positive; 12 Endowus fees positive |

The iFast case is the awkward one: its polarity flips between the two legs it books for a single trade. Investing in the *stock* spends cash; that same money landing in the *cash account* is cash received. Both legs have to read as one outflow rather than cancelling out.

Already correct and untouched: `cdp-stocks`, `cpf-stocks`, `srs-stocks`, `vickers-stocks`, archive-tiger. `cdp_events.csv` carries no amounts.

## Approach

Normalised in `build/_ledgercommon.py` beside `num`, where the other parse-layer conventions already live, rather than at each of the four call sites — `trade_cash_flow`, `fsm_amount_is_into_product`, `fsm_cash_flow`.

**Left positive on purpose:**
- **Custody transfers** — the figure is a market-value mark, not a trade. The matching `transfer_out` legs in the simple CSVs record the same move at the same value, and `build_ledger`'s `transfer cost carried` output is byte-identical before and after.
- **iFast `Stock Dividend`** — a cash dividend wearing a ticker (qty 0). A receipt, not a cost.

## Blast radius

Display only. `performance._apply_txn` derives cash from `-qty_signed × px - fee` and never reads `gross_amount`, so returns and XIRR were never wrong. The two readers are `server/main.py:301,372`, both rendering the history table.

## Verification

- 920 ledger rows changed, **amount column only** — `diff` across every other column is empty.
- Sign distribution after rebuild: `buy` 240 NEG / 0 POS, `sell` 491 POS / 0 NEG. The residual `buy POS` / `sell NEG` rows are FSM auto-sweep cash legs (blank ticker, qty 0), which pair correctly with their `Purchase of Auto-Sweep` / `Sale of Auto-Sweep` counterparts.
- Re-ingested. Reproducing the loader's dedup hashes against the rebuilt ledger gives a clean 1:1 — 548 emitted, 548 in `txn`, **0 orphaned, 0 unrefreshed**. The dedup key excludes amount precisely so a corrected ledger updates in place rather than duplicating.
- `tests/test_ledger_amount_sign.py`, 12 new tests pinning each source's convention. Full suite **329 passed**; `ruff` clean.

## Known, not fixed here

Tiger **Forex** rows read `num(row[10])`, but that section's columns are offset — `row[10]` is a timestamp, so `num` has been returning `0.0` for those amounts all along. Pre-existing and separate.
