### PR TITLE
fix(ingest): the nightly job that hung for fourteen hours

### DIFF
--- a/portfolio/db.py
+++ b/portfolio/db.py
@@ -5,7 +5,41 @@ from sqlalchemy.orm import sessionmaker
 
 from .config import settings
 
-engine = create_engine(settings.database_url, future=True)
+# How long a statement may sit on a socket nothing is listening to. The scheduled ingest runs
+# from a laptop that sleeps mid-run, so its connection to Neon dies routinely; with no timeout
+# and no keepalive, psycopg blocked until macOS's own TCP retransmit gave up. Four consecutive
+# nightly runs failed that way, and the wall-clocks say it plainly — 721s, 3693s, 21225s and
+# 50452s for work that takes a couple of minutes awake. Almost none of that is work; it is a
+# dead socket. Neon closing an idle compute produces the same hang from the other direction.
+# Keepalives make the OS notice within ~a minute, and the ceiling turns "hangs until morning"
+# into an error the caller can retry.
+#
+# connect_timeout is the loose one on purpose. It only bounds *establishing* a connection, and
+# Neon suspends an idle compute — a cold start measured 5.3s here, so a tight value would fail
+# runs for being early rather than for being hung. The keepalives are what answer the actual
+# bug, which was a socket dying mid-statement.
+PG_CONNECT_ARGS = {
+    "connect_timeout": 30,
+    "keepalives": 1,
+    "keepalives_idle": 30,
+    "keepalives_interval": 10,
+    "keepalives_count": 3,
+}
+
+
+def connect_args(url: str) -> dict:
+    """libpq connection options, for a Postgres URL only. The other engines in this repo are
+    the in-memory SQLite ones the tests build, and sqlite3 raises on kwargs it doesn't know —
+    so the driver, not the caller, decides whether these apply."""
+    return dict(PG_CONNECT_ARGS) if url.startswith("postgresql") else {}
+
+
+# pool_pre_ping because a pooled connection outlives the network under it: after a sleep or a
+# Neon autosuspend the pool still holds a socket that is already gone, and the next checkout
+# hands it out. pre_ping spends one round-trip to find out, and reconnects instead of failing.
+# pool_recycle retires connections before Neon's own idle cutoff can.
+engine = create_engine(settings.database_url, future=True, pool_pre_ping=True, pool_recycle=300,
+                       connect_args=connect_args(settings.database_url))
 SessionLocal = sessionmaker(bind=engine, autoflush=False, future=True)
 
 

--- a/scripts/scheduled_run.sh
+++ b/scripts/scheduled_run.sh
@@ -49,12 +49,37 @@ case "$DATABASE_URL" in
   *localhost*|*127.0.0.1*) say "FATAL: DATABASE_URL is the local docker DB — refusing"; exit 1 ;;
 esac
 
+# Stay awake for the whole run. launchd wakes the Mac to *start* a StartCalendarInterval job
+# and then lets it go straight back to sleep — on 2026-08-14 this script logged its first line
+# at 06:18:47 and the power log recorded "Sleep Service Back to Sleep" at 06:18:48, two seconds
+# in. What follows is a stutter of 45-second DarkWakes, and the connection to Neon does not
+# survive it. `-i` holds off idle sleep and is the one that matters here, because the machine
+# runs this on battery; `-s` covers the AC case. Each flag is ignored where it doesn't apply.
+#
+# The ceiling is for the run that hangs anyway. A dead socket once kept one going for 50452s —
+# long enough to still be holding the log when the next night's run arrived. Better a failure
+# at 30 minutes, which launchd will simply try again tomorrow.
+MAX_SECS="${INGEST_MAX_SECS:-1800}"
+runner=(caffeinate -is make "$JOB")
+# coreutils' timeout is not in a stock macOS; skip the ceiling rather than fail to run at all.
+if command -v timeout >/dev/null 2>&1; then
+  runner=(timeout -k 30 "$MAX_SECS" "${runner[@]}")
+else
+  say "note: no timeout(1) on PATH — running without the ${MAX_SECS}s ceiling"
+fi
+
 say "=== $JOB -> $(printf '%s' "$DATABASE_URL" | sed -E 's#.*@([^/?]+).*#\1#')"
 start=$(date +%s)
-if make "$JOB"; then
+if "${runner[@]}"; then
   say "=== $JOB ok in $(( $(date +%s) - start ))s"
 else
   code=$?
-  say "=== $JOB FAILED (exit $code) in $(( $(date +%s) - start ))s"
+  # 124 is timeout(1)'s own signal that it killed the job, and it is the interesting one:
+  # it means the run hung rather than errored, which is a different thing to go looking at.
+  if [ "$code" -eq 124 ]; then
+    say "=== $JOB TIMED OUT after ${MAX_SECS}s (killed)"
+  else
+    say "=== $JOB FAILED (exit $code) in $(( $(date +%s) - start ))s"
+  fi
   exit "$code"
 fi

--- a/tests/test_db_connect_args.py
+++ b/tests/test_db_connect_args.py
@@ -1,0 +1,57 @@
+"""The engine settings that decide how a dead connection fails.
+
+Four consecutive nightly ingests failed the same way: the laptop running them slept mid-run,
+the connection to Neon died, and psycopg sat on the dead socket until macOS's TCP retransmit
+gave up. The wall-clocks are the tell — 721s, 3693s, 21225s, 50452s for work that takes a
+couple of minutes awake. Almost none of it was work.
+
+Nothing here can prove the timeouts fire (that needs a real severed socket), so these pin the
+two things that are checkable and that a later edit could quietly drop: the options are
+actually handed to the driver, and they are withheld from a driver that would reject them.
+
+Run: PYTHONPATH=. .venv/bin/python -m pytest tests/test_db_connect_args.py -q
+"""
+from sqlalchemy import create_engine
+
+from portfolio.db import PG_CONNECT_ARGS, connect_args, engine
+
+
+def test_postgres_urls_get_a_connect_timeout_and_keepalives():
+    a = connect_args("postgresql+psycopg://u:p@ep-x.neon.tech/db")
+    assert a["keepalives"] == 1
+    # loose enough to outlast a Neon compute cold start (measured 5.3s), which is a slow
+    # connection rather than a hung one. Tightening this fails runs for being early.
+    assert a["connect_timeout"] >= 20
+    # idle * interval * count bounds how long a severed socket can look alive: ~a minute here,
+    # against the hours the OS default took.
+    assert a["keepalives_idle"] * 1 + a["keepalives_interval"] * a["keepalives_count"] <= 90
+
+
+def test_bare_postgresql_scheme_is_covered_too():
+    """config._use_psycopg3 rewrites postgres:// to postgresql+psycopg://, but the prefix test
+    must not depend on having run after it."""
+    assert connect_args("postgresql://u:p@host/db") == PG_CONNECT_ARGS
+
+
+def test_sqlite_gets_nothing():
+    """The tests build in-memory SQLite engines, and sqlite3 raises TypeError on a kwarg it
+    doesn't know. Handing libpq options to every driver would break the suite, not the socket."""
+    assert connect_args("sqlite://") == {}
+    assert connect_args("sqlite:///tmp/x.db") == {}
+
+
+def test_a_sqlite_engine_still_builds_with_what_connect_args_returns():
+    # the guard's whole point, exercised rather than asserted
+    create_engine("sqlite://", connect_args=connect_args("sqlite://")).connect().close()
+
+
+def test_returned_dict_is_a_copy_so_a_caller_cannot_mutate_the_module_default():
+    connect_args("postgresql://x")["connect_timeout"] = 9999
+    assert PG_CONNECT_ARGS["connect_timeout"] == 30
+
+
+def test_the_real_engine_pre_pings_and_recycles():
+    """A pooled connection outlives the network under it: after a sleep or a Neon autosuspend
+    the pool still holds a socket that is gone. Without pre_ping the next checkout hands it out."""
+    assert engine.pool._pre_ping is True
+    assert 0 < engine.pool._recycle <= 300


### PR DESCRIPTION
Follow-up to #88. While confirming that fix had reached the deployed site, the site turned out to be stale for an unrelated reason: `com.portfolio.ingest-all` has failed four nights running, so nothing had been ingested into Neon since 2026-08-07.

## The wall-clocks are the diagnosis

| Run | Duration | Died in | Error |
|---|---|---|---|
| 2026-08-07 | **50452s** (14h) | `seed` | `SSL SYSCALL error: Operation timed out` |
| 2026-08-09 | 3693s | `seed` | `server closed the connection unexpectedly` |
| 2026-08-11 | 721s | `load` | `server closed the connection unexpectedly` |
| 2026-08-14 | **21225s** (5.9h) | `seed` | `SSL SYSCALL error: Operation timed out` |

The same job takes **109s** awake. Almost none of that time was work — it was a dead socket nobody had told to give up. Which step died is incidental; it was whichever statement happened to be in flight.

## Root cause: the job runs while the Mac sleeps

launchd wakes the machine to *start* a `StartCalendarInterval` job; it does not keep it awake, and the plist's `ProcessType: Background` marks the job sleep-eligible. The last run matches `pmset -g log` to the second:

| Time (SGT) | Event |
|---|---|
| 06:18:46 | `DarkWake … rtc/SleepService` — launchd wakes the Mac for the job |
| 06:18:47 | `scheduled_run.sh` logs `=== ingest-all -> ep-shiny-star…neon.tech` |
| **06:18:48** | **`Entering Sleep state due to 'Sleep Service Back to Sleep'`** — 2s in |
| 06:19–12:12 | 45-second DarkWakes separated by Maintenance Sleeps, on battery |
| 12:12:32 | `SSL SYSCALL error: Operation timed out` → `seed` Error 1 |

(The `TCPKeepAlive=active` in those pmset lines is Power Nap maintaining iCloud/push sockets. It does nothing for a psycopg connection.)

Two compounding defects turned "connection dropped" into "hangs until noon":

- `portfolio/db.py` was a bare `create_engine(url, future=True)` — no connect timeout, no keepalives, no pre-ping, no recycle. I grepped the project: zero occurrences of any of them. So psycopg blocked on a socket with nothing at the far end until macOS's own TCP retransmit gave up.
- Nothing bounded the run, so a 14-hour hang was still holding the log when the next night's run arrived.

Neon's compute autosuspend makes this worse but isn't the cause — an awake run finishes long before idle-suspend matters.

## Changes

1. **`caffeinate -is`** around `make` in `scripts/scheduled_run.sh`. `-i` is the one that matters (the machine does this on battery); `-s` covers AC, and the flag that doesn't apply is ignored.
2. **Engine hardening** in `portfolio/db.py`: client keepalives (`keepalives_idle` 30 / `interval` 10 / `count` 3 — a dead socket is noticed in about a minute rather than a morning), `connect_timeout`, `pool_pre_ping=True`, `pool_recycle=300`. Guarded by `connect_args(url)` so libpq options only go to a Postgres URL — the test suite builds in-memory SQLite engines and `sqlite3` raises on kwargs it doesn't know.
3. **A wall-clock ceiling** (`INGEST_MAX_SECS`, default 1800) reported as its own outcome, because "hung" and "errored" send you to different places.

`connect_timeout` is deliberately loose at **30s**: it bounds only *establishing* a connection, and a Neon cold start measured 5.3s here. Tight would fail runs for being early rather than for being hung. The keepalives are what answer the actual bug.

## Verification

- **End to end through the wrapper against Neon**: `=== load ok in 109s`, `+0 new` on all four tables (idempotent, no duplicates).
- **`connect_args` genuinely reaches libpq** — a bogus keyword is rejected with `invalid connection option`, so it isn't being silently dropped. The real options connect against both local Postgres and Neon over SSL.
- **The ceiling fires**: exit `124`, `=== load TIMED OUT after 3s (killed)` in the log, **no orphaned child** — `caffeinate` propagates the kill through to the grandchild (verified for both nestings).
- **Graceful degradation**: with no `timeout(1)` on PATH it logs `note: no timeout(1) on PATH — running without the 1800s ceiling` and runs anyway, rather than not running.
- Full suite **335 passed** (6 new); `ruff` clean.

## Note

`pool_pre_ping` also applies to the Vercel deployment, where it's a plain win against Neon — a serverless instance holding a pooled connection across an autosuspend currently hands out a dead one.

The plist itself is unchanged, so no reinstall is needed; `scripts/schedule.sh` already points at this script.