### PR TITLE
chore(networth): promote the two June snapshots to the deployed store (#93)

### DIFF
--- a/portfolio/networth.py
+++ b/portfolio/networth.py
@@ -15,11 +15,11 @@ from __future__ import annotations
 import datetime as dt
 from decimal import Decimal
 
-from sqlalchemy import select, text
+from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from .db import session_scope
-from .models import NwItem, NwSnapshot, NwValue
+from .models import FxRate, NwItem, NwSnapshot, NwValue
 
 # Catalogue codes auto-pulled from broker/bank statements (see scripts/snapshot_from_statements.py).
 # Everything else is manual: entered in-app or carried forward. Single source of truth so the UI
@@ -36,17 +36,27 @@ def live_portfolio_sgd(s: Session) -> Decimal:
     return Decimal(str(round(total, 4)))
 
 
+def fx_row_for(s: Session, ccy: str, on_date: dt.date) -> FxRate | None:
+    """The fx_rate row a freeze at `on_date` reads from — newest with date <= on_date, or None.
+
+    The freeze rule itself, held once. `rate_for` wraps it for the "what rate" question and
+    raises on None (BR4); scripts/promote_networth_snapshots.py needs the *row* — to carry it
+    into a store that has no rate that early — and needs to report a miss across every currency
+    rather than abort on the first, so it takes the None. Two callers, one definition of which
+    row wins; a second copy would be free to drift from this one."""
+    return s.execute(select(FxRate).where(FxRate.currency == ccy, FxRate.date <= on_date)
+                     .order_by(FxRate.date.desc()).limit(1)).scalar_one_or_none()
+
+
 def rate_for(s: Session, ccy: str, on_date: dt.date) -> Decimal:
     """Frozen FX: 1 for SGD; else latest fx_rate.rate_to_sgd with date <= on_date.
     Raises ValueError when no rate exists (BR4 — no silent fallback)."""
     if ccy == "SGD":
         return Decimal(1)
-    r = s.execute(text(
-        "SELECT rate_to_sgd FROM fx_rate WHERE currency = :c AND date <= :d "
-        "ORDER BY date DESC LIMIT 1"), {"c": ccy, "d": on_date}).scalar()
-    if r is None:
+    row = fx_row_for(s, ccy, on_date)
+    if row is None:
         raise ValueError(f"no FX rate for {ccy} on or before {on_date}")
-    return Decimal(str(r))
+    return Decimal(str(row.rate_to_sgd))
 
 
 def _active_items(s: Session) -> tuple[dict, dict]:

--- a/scripts/promote_networth_snapshots.py
+++ b/scripts/promote_networth_snapshots.py
@@ -25,6 +25,12 @@ starts 2026-06-27). Without it the no-carry-back check cannot reproduce in the t
 arrive un-editable. Only the rows the promoted snapshots actually read are copied, and an
 existing target row is never overwritten.
 
+**The write is guarded.** The pre-existing series is fingerprinted — ids included — before the
+write and re-read after the flush; any drift rolls the whole promotion back rather than
+committing it and reporting the damage afterwards. "No existing snapshot is modified, renumbered
+or deleted" is the one criterion `frozen_money_diff` structurally cannot cover, since that only
+compares dates *both* stores hold and the target's own snapshots are in neither intersection.
+
 Two integrity checks gate every promotion, the two the map ran on the June pair (#86):
   - **no BR2 omission** — every active catalogue item has a value row on the snapshot. A missing
     item is silently defaulted to 0 by `create_snapshot`, which is not a smaller net worth but a
@@ -39,15 +45,22 @@ Usage (SOURCE is read-only; TARGET is the store being written):
   ... --verify                          # both checks over the target's whole series, plus a
                                         # readback of every shared snapshot against the source
 
+`--expect-count` / `--expect-span` assert the shape of the series rather than only its soundness.
+They take no defaults on purpose: the count and span belong to the ticket, not the tool. For #93,
+
+  ... --verify --expect-count 5 --expect-span 2026-06-21..2026-08-05
+
 Both URLs default to `$PROMOTE_SOURCE_URL` / `$PROMOTE_TARGET_URL`. `--verify` is the re-runnable
-form of the acceptance criteria: the checks answer "is each snapshot sound", the readback answers
-"did the frozen money and the frozen portfolio value survive the copy unchanged" — a claim only a
-comparison against the store it came from can make, and one that should not rest on a diff taken
-by hand before the write.
+form of the acceptance criteria: the integrity checks answer "is each snapshot sound", the series
+check answers "is this the series that was asked for", and the readback answers "did the frozen
+money and the frozen portfolio value survive the copy unchanged" — a claim only a comparison
+against the store it came from can make, and one that should not rest on a diff taken by hand
+before the write.
 """
 from __future__ import annotations
 
 import argparse
+import datetime as dt
 import os
 import sys
 
@@ -71,18 +84,28 @@ def _items(s: Session) -> dict[str, NwItem]:
     return {i.code: i for i in s.scalars(select(NwItem)).all()}
 
 
+def _only_in(a: dict, b: dict) -> list:
+    """Keys `a` holds and `b` does not, sorted."""
+    return sorted(a.keys() - b.keys())
+
+
+def _field_diffs(a: dict, b: dict, fields: tuple) -> list[tuple]:
+    """(key, field, source_value, target_value) for every field that differs on a key both dicts
+    hold. The comparison shape the catalogue check and both halves of the readback share — three
+    different sentences to report, but one definition of what "differs" means."""
+    return [(k, f, getattr(a[k], f), getattr(b[k], f))
+            for k in sorted(a.keys() & b.keys()) for f in fields
+            if getattr(a[k], f) != getattr(b[k], f)]
+
+
 def catalogue_diff(src: Session, tgt: Session) -> list[str]:
     """Every way the two catalogues disagree, as human-readable lines. Empty means the snapshots
     band identically in both stores and merge without reconciliation."""
     a, b = _items(src), _items(tgt)
-    out = [f"{c}: in source, not in target" for c in sorted(a.keys() - b.keys())]
-    out += [f"{c}: in target, not in source" for c in sorted(b.keys() - a.keys())]
-    for code in sorted(a.keys() & b.keys()):
-        for f in ITEM_FIELDS:
-            x, y = getattr(a[code], f), getattr(b[code], f)
-            if x != y:
-                out.append(f"{code}: {f} source={x!r} target={y!r}")
-    return out
+    return ([f"{c}: in source, not in target" for c in _only_in(a, b)]
+            + [f"{c}: in target, not in source" for c in _only_in(b, a)]
+            + [f"{c}: {f} source={x!r} target={y!r}"
+               for c, f, x, y in _field_diffs(a, b, ITEM_FIELDS)])
 
 
 def missing_item_values(s: Session, snap: NwSnapshot) -> list[str]:
@@ -155,9 +178,37 @@ def plan(src: Session, tgt: Session) -> list[dict]:
     return rows
 
 
-def apply(tgt: Session, rows: list[dict]) -> None:
+def series_fingerprint(s: Session) -> dict:
+    """Every snapshot in a store reduced to a comparable tuple, keyed by date: its id, the frozen
+    snapshot fields, and every value row. The `id` is in there deliberately — "renumbered" is one
+    of the three things the promotion promises not to do, and it is the one a field-by-field money
+    comparison would miss entirely."""
+    return {sn.date: (sn.id, sn.note, sn.portfolio_value_sgd, sn.created_at,
+                      tuple(sorted((v.item.code, v.native_value, v.currency, v.rate_to_sgd,
+                                    v.value_sgd) for v in sn.values)))
+            for sn in s.scalars(select(NwSnapshot))}
+
+
+def fingerprint_drift(before: dict, after: dict) -> list[str]:
+    """AC4 — no existing snapshot modified, renumbered or deleted. Dates present in `before` that
+    changed or vanished. Dates only in `after` are the promotion doing its job, never drift.
+
+    This is the criterion `frozen_money_diff` structurally cannot cover: that one compares dates
+    *both* stores hold, so the target's own pre-existing snapshots — the very rows AC4 is about —
+    sit in no comparison at all."""
+    return ([f"{d}: snapshot no longer in the target" for d in _only_in(before, after)]
+            + [f"{d}: existing snapshot changed\n      was {before[d]!r}\n      now {after[d]!r}"
+               for d in sorted(before.keys() & after.keys()) if before[d] != after[d]])
+
+
+def write_snapshots(tgt: Session, rows: list[dict]) -> None:
     """Write the planned snapshots. Insert-only: no existing snapshot, value, catalogue item or
-    fx_rate row is touched, and the target's own id sequence assigns the new ids."""
+    fx_rate row is touched, and the target's own id sequence assigns the new ids.
+
+    "Insert-only" is enforced, not just intended: the pre-existing series is fingerprinted before
+    the write and re-read after the flush, and any drift rolls the whole thing back rather than
+    committing damage and reporting it afterwards. AC4 fails closed."""
+    before = series_fingerprint(tgt)
     items = _items(tgt)
     for r in rows:
         for f in r["fx"]:
@@ -179,6 +230,12 @@ def apply(tgt: Session, rows: list[dict]) -> None:
             tgt.add(NwValue(snapshot_id=snap.id, item_id=items[v["code"]].id,
                             native_value=v["native_value"], currency=v["currency"],
                             rate_to_sgd=v["rate_to_sgd"], value_sgd=v["value_sgd"]))
+    tgt.flush()
+    drift = fingerprint_drift(before, series_fingerprint(tgt))
+    if drift:
+        tgt.rollback()
+        raise RuntimeError("the write disturbed an existing snapshot; rolled back:\n  "
+                           + "\n  ".join(drift))
     tgt.commit()
 
 
@@ -193,6 +250,26 @@ def verify(s: Session) -> list[str]:
     for snap in s.scalars(select(NwSnapshot).order_by(NwSnapshot.date)):
         problems += missing_item_values(s, snap) + fx_carry_backs(s, snap)
     return problems
+
+
+def series_expectation(s: Session, count: int | None = None,
+                       span: tuple | None = None) -> list[str]:
+    """AC1 — the shape of the series the promotion was for: how many snapshots, spanning which
+    dates. Both optional, because the count and span belong to the *ticket*, not to the tool —
+    baking #93's five points and 2026-06-21..2026-08-05 in as defaults would make a general
+    promotion script quietly wrong for the next one. Passing neither checks nothing.
+
+    Worth asserting at all because `plan` promotes whatever dates the target happens to lack: a
+    source missing a snapshot, or a target that already held a stray one, both merge cleanly and
+    leave a series that is sound but not the one that was asked for."""
+    dates = sorted(d for (d,) in s.execute(select(NwSnapshot.date)))
+    out = []
+    if count is not None and len(dates) != count:
+        out.append(f"expected {count} snapshot(s), found {len(dates)}")
+    if span is not None and dates and (dates[0], dates[-1]) != tuple(span):
+        out.append(f"expected the series to span {span[0]}..{span[1]}, "
+                   f"found {dates[0]}..{dates[-1]}")
+    return out
 
 
 # What must survive the copy untouched, per row. `native_value` and `currency` are here as much
@@ -213,23 +290,17 @@ def frozen_money_diff(src: Session, tgt: Session) -> list[str]:
     whether a snapshot is internally sound; this asks whether the copy was faithful, which only
     a comparison against the store it came from can answer. Re-runnable, so the claim does not
     rest on a diff someone took by hand before the write."""
-    out = []
     a = {sn.date: sn for sn in src.scalars(select(NwSnapshot))}
     b = {sn.date: sn for sn in tgt.scalars(select(NwSnapshot))}
+    out = [f"{d}: {f} source={x!r} target={y!r}"
+           for d, f, x, y in _field_diffs(a, b, SNAPSHOT_FIELDS)]
     for date in sorted(a.keys() & b.keys()):
-        for f in SNAPSHOT_FIELDS:
-            x, y = getattr(a[date], f), getattr(b[date], f)
-            if x != y:
-                out.append(f"{date}: {f} source={x!r} target={y!r}")
         va = {v.item.code: v for v in a[date].values}
         vb = {v.item.code: v for v in b[date].values}
-        out += [f"{date}: {c} valued in source, not in target" for c in sorted(va.keys() - vb.keys())]
-        out += [f"{date}: {c} valued in target, not in source" for c in sorted(vb.keys() - va.keys())]
-        for code in sorted(va.keys() & vb.keys()):
-            for f in VALUE_FIELDS:
-                x, y = getattr(va[code], f), getattr(vb[code], f)
-                if x != y:
-                    out.append(f"{date}: {code}.{f} source={x!r} target={y!r}")
+        out += [f"{date}: {c} valued in source, not in target" for c in _only_in(va, vb)]
+        out += [f"{date}: {c} valued in target, not in source" for c in _only_in(vb, va)]
+        out += [f"{date}: {c}.{f} source={x!r} target={y!r}"
+                for c, f, x, y in _field_diffs(va, vb, VALUE_FIELDS)]
     return out
 
 
@@ -260,9 +331,29 @@ def _print_problems(label: str, clean: str, problems: list[str]) -> int:
 
 INTEGRITY_CLEAN = "CLEAN — no BR2 omission, no FX carry-back"
 READBACK_CLEAN = "CLEAN — frozen money and frozen portfolio value identical to the source"
+SERIES_CLEAN = "CLEAN — the series is the count and span that were asked for"
 
 
-def main(argv) -> int:
+def _readback(source_url: str, tgt: Session) -> int:
+    """Read every shared snapshot back against the store it came from. Opens its own session so
+    the caller never has to hold one open across the write."""
+    src = _session(source_url)
+    try:
+        return _print_problems("readback vs source", READBACK_CLEAN, frozen_money_diff(src, tgt))
+    finally:
+        src.close()
+
+
+def _span(text: str) -> tuple:
+    """`--expect-span FIRST..LAST`, as two dates."""
+    try:
+        first, last = text.split("..")
+        return dt.date.fromisoformat(first), dt.date.fromisoformat(last)
+    except ValueError:
+        raise argparse.ArgumentTypeError(f"expected FIRST..LAST as ISO dates, got {text!r}")
+
+
+def main(argv: list[str]) -> int:
     ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
     ap.add_argument("--source", default=os.environ.get("PROMOTE_SOURCE_URL"),
                     help="store to read snapshots from (never written)")
@@ -272,22 +363,25 @@ def main(argv) -> int:
     ap.add_argument("--verify", action="store_true",
                     help="run both integrity checks over the target's whole series and stop; "
                          "with --source, also read every shared snapshot back against it")
+    ap.add_argument("--expect-count", type=int, metavar="N",
+                    help="assert the target holds exactly N snapshots (AC1)")
+    ap.add_argument("--expect-span", type=_span, metavar="FIRST..LAST",
+                    help="assert the target's series runs from FIRST to LAST (AC1)")
     args = ap.parse_args(argv)
     if not args.target:
         ap.error("--target (or PROMOTE_TARGET_URL) is required")
+    expected = (args.expect_count, args.expect_span)
 
     tgt = _session(args.target)
     try:
         if args.verify:
             _report(tgt, f"target {_host(args.target)}")
             rc = _print_problems("integrity", INTEGRITY_CLEAN, verify(tgt))
+            if any(e is not None for e in expected):
+                rc |= _print_problems("series", SERIES_CLEAN,
+                                      series_expectation(tgt, *expected))
             if args.source:
-                src = _session(args.source)
-                try:
-                    rc |= _print_problems("readback vs source", READBACK_CLEAN,
-                                          frozen_money_diff(src, tgt))
-                finally:
-                    src.close()
+                rc |= _readback(args.source, tgt)
             return rc
 
         if not args.source:
@@ -322,16 +416,14 @@ def main(argv) -> int:
             print("\nDRY-RUN. Re-run with --commit to write.")
             return 0
 
-        apply(tgt, rows)
-        print(f"\nCOMMITTED {len(rows)} snapshot(s).\n")
+        write_snapshots(tgt, rows)
+        print(f"\nCOMMITTED {len(rows)} snapshot(s). "
+              "No pre-existing snapshot changed — the write is guarded and rolls back if one does.\n")
         _report(tgt, f"target {_host(args.target)}")
         rc = _print_problems("integrity over the merged series", INTEGRITY_CLEAN, verify(tgt))
-        src = _session(args.source)
-        try:
-            rc |= _print_problems("readback vs source", READBACK_CLEAN,
-                                  frozen_money_diff(src, tgt))
-        finally:
-            src.close()
+        if any(e is not None for e in expected):
+            rc |= _print_problems("series", SERIES_CLEAN, series_expectation(tgt, *expected))
+        rc |= _readback(args.source, tgt)
         return rc
     finally:
         tgt.close()

--- a/scripts/promote_networth_snapshots.py
+++ b/scripts/promote_networth_snapshots.py
@@ -58,6 +58,7 @@ from sqlalchemy.orm import Session, sessionmaker
 
 from portfolio.db import connect_args
 from portfolio.models import FxRate, NwItem, NwSnapshot, NwValue
+from portfolio.networth import fx_row_for
 
 # The catalogue fields promotion depends on. `label` is included because the composition chart
 # reads it; `id` is deliberately excluded — the stores keep separate sequences, which is the
@@ -100,12 +101,6 @@ def missing_item_values(s: Session, snap: NwSnapshot) -> list[str]:
             for c in sorted(c for c in _items(s) if c not in valued)]
 
 
-def _dated_fx(s: Session, ccy: str, on_date) -> FxRate | None:
-    """The fx_rate row `networth.rate_for` would freeze from — newest on or before `on_date`."""
-    return s.execute(select(FxRate).where(FxRate.currency == ccy, FxRate.date <= on_date)
-                     .order_by(FxRate.date.desc()).limit(1)).scalar_one_or_none()
-
-
 def _currencies(snap: NwSnapshot) -> list[str]:
     """The non-SGD currencies this snapshot values. SGD is 1:1 by policy and never looked up."""
     return sorted({v.currency for v in snap.values if v.currency != "SGD"})
@@ -116,7 +111,7 @@ def fx_carry_backs(s: Session, snap: NwSnapshot) -> list[str]:
     snapshot date. `ensure_fx` resolves that case by back-stamping the nearest *later* rate,
     which values a June snapshot at a later month's FX."""
     return [f"{snap.date}: no fx_rate for {c} on or before {snap.date}"
-            for c in _currencies(snap) if _dated_fx(s, c, snap.date) is None]
+            for c in _currencies(snap) if fx_row_for(s, c, snap.date) is None]
 
 
 def _fx_rows(s: Session, snap: NwSnapshot) -> list[dict]:
@@ -124,7 +119,7 @@ def _fx_rows(s: Session, snap: NwSnapshot) -> list[dict]:
     the target. Carries the row as dated in the source, not the frozen rate off the value: the
     two can differ where a day's rate was refreshed after the snapshot froze it, and it is the
     row — the evidence that no carry-back was needed — that the target lacks."""
-    rows = [_dated_fx(s, ccy, snap.date) for ccy in _currencies(snap)]
+    rows = [fx_row_for(s, ccy, snap.date) for ccy in _currencies(snap)]
     return [{"date": r.date, "currency": r.currency, "rate_to_sgd": r.rate_to_sgd} for r in rows]
 
 
@@ -173,9 +168,10 @@ def apply(tgt: Session, rows: list[dict]) -> None:
         snap = NwSnapshot(date=r["date"], note=r["note"],
                           portfolio_value_sgd=r["portfolio_value_sgd"])
         if r.get("created_at") is not None:
-            # When it was captured, not when it was copied. Guarded because the column carries
-            # only a server_default and is nullable: assigning a source NULL straight through
-            # would suppress that default and leave the target row with no creation time at all.
+            # When it was captured, not when it was copied. Guarded rather than assigned blind:
+            # the column is NOT NULL with only a server_default, so passing a source NULL
+            # straight through would suppress that default and fail the insert instead of
+            # falling back to it.
             snap.created_at = r["created_at"]
         tgt.add(snap)
         tgt.flush()
@@ -202,7 +198,10 @@ def verify(s: Session) -> list[str]:
 # What must survive the copy untouched, per row. `native_value` and `currency` are here as much
 # as the money is: a rate that round-trips against a rewritten native is still a rewritten value.
 VALUE_FIELDS = ("native_value", "currency", "rate_to_sgd", "value_sgd")
-SNAPSHOT_FIELDS = ("note", "portfolio_value_sgd")
+# `created_at` is here because `apply` carries it deliberately — when the snapshot was captured,
+# not when it was copied. Left out, a snapshot that arrived stamped with the copy time would read
+# back clean and the promotion's "verbatim" claim would go unchecked.
+SNAPSHOT_FIELDS = ("note", "portfolio_value_sgd", "created_at")
 
 
 def frozen_money_diff(src: Session, tgt: Session) -> list[str]:

--- a/scripts/promote_networth_snapshots.py
+++ b/scripts/promote_networth_snapshots.py
@@ -1,0 +1,342 @@
+"""Promote net-worth snapshots from one store to another, frozen money intact.
+
+Two databases hold different halves of the net-worth history (#86): the deployed Neon store holds
+2026-07-10 / 07-25 / 08-05, local dev holds **two earlier** snapshots, 2026-06-21 and 06-30, on
+its own id sequence. `portfolio/config.py` sets `env_file=".env"` and `.env` carries no
+`DATABASE_URL`, so local Python always hits localhost while the deployed app always hits Neon —
+neither environment has ever shown the whole series. This copies the missing snapshots across so
+one store holds all five.
+
+**Copy, never recompute.** `networth.create_snapshot` cannot do this job: it stamps *today's*
+`live_portfolio_sgd()` and derives `value_sgd` from native x rate at the target's FX. Both are
+frozen money captured at the snapshot date, and the target store has neither the prices nor the
+rates that produced them — recomputing would rewrite history to the value of the day it ran. So
+every one of `native_value`, `currency`, `rate_to_sgd`, `value_sgd`, `portfolio_value_sgd`,
+`note` and `created_at` is carried over verbatim.
+
+Items are matched by **code**, never by id: the two stores keep their own `nw_item` id sequences,
+and a copied `item_id` would land a value on the wrong band or on nothing at all. The catalogues
+must agree on every field the banding reads before anything is written.
+
+**FX rows travel with the snapshots.** A promoted snapshot's frozen rate was read from an
+`fx_rate` row dated on or before its own date; the target has no such row (deployed `fx_rate`
+starts 2026-06-27). Without it the no-carry-back check cannot reproduce in the target, and
+`update_snapshot` on the promoted snapshot would raise BR4 rather than edit — the snapshot would
+arrive un-editable. Only the rows the promoted snapshots actually read are copied, and an
+existing target row is never overwritten.
+
+Two integrity checks gate every promotion, the two the map ran on the June pair (#86):
+  - **no BR2 omission** — every active catalogue item has a value row on the snapshot. A missing
+    item is silently defaulted to 0 by `create_snapshot`, which is not a smaller net worth but a
+    wrong one.
+  - **no FX carry-back** — every non-SGD currency the snapshot values has an `fx_rate` row dated
+    on or before the snapshot date, so nothing was valued at a later month's rate.
+
+Usage (SOURCE is read-only; TARGET is the store being written):
+  PYTHONPATH=. .venv/bin/python scripts/promote_networth_snapshots.py \
+      --source postgresql+psycopg://... --target postgresql+psycopg://...            # dry-run
+  ... --commit                                                                        # write
+  ... --verify                          # both checks over the target's whole series, plus a
+                                        # readback of every shared snapshot against the source
+
+Both URLs default to `$PROMOTE_SOURCE_URL` / `$PROMOTE_TARGET_URL`. `--verify` is the re-runnable
+form of the acceptance criteria: the checks answer "is each snapshot sound", the readback answers
+"did the frozen money and the frozen portfolio value survive the copy unchanged" — a claim only a
+comparison against the store it came from can make, and one that should not rest on a diff taken
+by hand before the write.
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from sqlalchemy import create_engine, select
+from sqlalchemy.orm import Session, sessionmaker
+
+from portfolio.db import connect_args
+from portfolio.models import FxRate, NwItem, NwSnapshot, NwValue
+
+# The catalogue fields promotion depends on. `label` is included because the composition chart
+# reads it; `id` is deliberately excluded — the stores keep separate sequences, which is the
+# whole reason values are matched by code.
+ITEM_FIELDS = ("kind", "currency_default", "is_liquid", "is_housing", "is_cpf", "sort_order",
+               "label", "active")
+
+
+def _items(s: Session) -> dict[str, NwItem]:
+    return {i.code: i for i in s.scalars(select(NwItem)).all()}
+
+
+def catalogue_diff(src: Session, tgt: Session) -> list[str]:
+    """Every way the two catalogues disagree, as human-readable lines. Empty means the snapshots
+    band identically in both stores and merge without reconciliation."""
+    a, b = _items(src), _items(tgt)
+    out = [f"{c}: in source, not in target" for c in sorted(a.keys() - b.keys())]
+    out += [f"{c}: in target, not in source" for c in sorted(b.keys() - a.keys())]
+    for code in sorted(a.keys() & b.keys()):
+        for f in ITEM_FIELDS:
+            x, y = getattr(a[code], f), getattr(b[code], f)
+            if x != y:
+                out.append(f"{code}: {f} source={x!r} target={y!r}")
+    return out
+
+
+def missing_item_values(s: Session, snap: NwSnapshot) -> list[str]:
+    """Integrity check 1 — no BR2 omission: catalogue items with no value row on this snapshot.
+
+    Not "no zero values": a zero is a legitimate reading (the deployed store's `tiger_sgd` and
+    `ibkr_sgd` are genuinely empty accounts), and the data model cannot tell a real zero from a
+    defaulted one. A *missing row* is the part that is unambiguous.
+
+    Every catalogue item, not just the active ones. `create_snapshot` writes a row per *active*
+    item, so scoping this check the same way would let an item deactivated between capture and
+    promotion go missing without a word — and the acceptance criterion is "every catalogue
+    item". Over-reporting here costs a line of output; under-reporting loses a band."""
+    valued = {v.item.code for v in snap.values}
+    return [f"{snap.date}: no value row for {c}"
+            for c in sorted(c for c in _items(s) if c not in valued)]
+
+
+def _dated_fx(s: Session, ccy: str, on_date) -> FxRate | None:
+    """The fx_rate row `networth.rate_for` would freeze from — newest on or before `on_date`."""
+    return s.execute(select(FxRate).where(FxRate.currency == ccy, FxRate.date <= on_date)
+                     .order_by(FxRate.date.desc()).limit(1)).scalar_one_or_none()
+
+
+def _currencies(snap: NwSnapshot) -> list[str]:
+    """The non-SGD currencies this snapshot values. SGD is 1:1 by policy and never looked up."""
+    return sorted({v.currency for v in snap.values if v.currency != "SGD"})
+
+
+def fx_carry_backs(s: Session, snap: NwSnapshot) -> list[str]:
+    """Integrity check 2 — no FX carry-back: currencies with no fx_rate row on or before the
+    snapshot date. `ensure_fx` resolves that case by back-stamping the nearest *later* rate,
+    which values a June snapshot at a later month's FX."""
+    return [f"{snap.date}: no fx_rate for {c} on or before {snap.date}"
+            for c in _currencies(snap) if _dated_fx(s, c, snap.date) is None]
+
+
+def _fx_rows(s: Session, snap: NwSnapshot) -> list[dict]:
+    """The fx_rate rows this snapshot's frozen rates were read from, so the check reproduces in
+    the target. Carries the row as dated in the source, not the frozen rate off the value: the
+    two can differ where a day's rate was refreshed after the snapshot froze it, and it is the
+    row — the evidence that no carry-back was needed — that the target lacks."""
+    rows = [_dated_fx(s, ccy, snap.date) for ccy in _currencies(snap)]
+    return [{"date": r.date, "currency": r.currency, "rate_to_sgd": r.rate_to_sgd} for r in rows]
+
+
+def plan(src: Session, tgt: Session) -> list[dict]:
+    """What promotion would write: one row per source snapshot the target has no date for,
+    oldest first. Writes nothing. Raises ValueError if the catalogues differ or any candidate
+    fails an integrity check — both are conditions the promotion claims do not hold, so finding
+    one means stopping rather than reconciling."""
+    diff = catalogue_diff(src, tgt)
+    if diff:
+        raise ValueError("catalogue differs between the stores; refusing to promote:\n  "
+                         + "\n  ".join(diff))
+    have = {d for (d,) in tgt.execute(select(NwSnapshot.date))}
+    rows = []
+    for snap in src.scalars(select(NwSnapshot).order_by(NwSnapshot.date)):
+        if snap.date in have:
+            continue
+        problems = missing_item_values(src, snap) + fx_carry_backs(src, snap)
+        if problems:
+            raise ValueError("integrity check failed; refusing to promote:\n  "
+                             + "\n  ".join(problems))
+        rows.append({
+            "date": snap.date,
+            "note": snap.note,
+            "created_at": snap.created_at,
+            "portfolio_value_sgd": snap.portfolio_value_sgd,
+            "values": [{"code": v.item.code, "native_value": v.native_value,
+                        "currency": v.currency, "rate_to_sgd": v.rate_to_sgd,
+                        "value_sgd": v.value_sgd}
+                       for v in sorted(snap.values, key=lambda v: v.item.sort_order)],
+            "fx": _fx_rows(src, snap),
+        })
+    return rows
+
+
+def apply(tgt: Session, rows: list[dict]) -> None:
+    """Write the planned snapshots. Insert-only: no existing snapshot, value, catalogue item or
+    fx_rate row is touched, and the target's own id sequence assigns the new ids."""
+    items = _items(tgt)
+    for r in rows:
+        for f in r["fx"]:
+            if _exists_fx(tgt, f):
+                continue
+            tgt.add(FxRate(date=f["date"], currency=f["currency"],
+                           rate_to_sgd=f["rate_to_sgd"]))
+        snap = NwSnapshot(date=r["date"], note=r["note"],
+                          portfolio_value_sgd=r["portfolio_value_sgd"])
+        if r.get("created_at") is not None:
+            # When it was captured, not when it was copied. Guarded because the column carries
+            # only a server_default and is nullable: assigning a source NULL straight through
+            # would suppress that default and leave the target row with no creation time at all.
+            snap.created_at = r["created_at"]
+        tgt.add(snap)
+        tgt.flush()
+        for v in r["values"]:
+            tgt.add(NwValue(snapshot_id=snap.id, item_id=items[v["code"]].id,
+                            native_value=v["native_value"], currency=v["currency"],
+                            rate_to_sgd=v["rate_to_sgd"], value_sgd=v["value_sgd"]))
+    tgt.commit()
+
+
+def _exists_fx(tgt: Session, f: dict) -> bool:
+    return tgt.get(FxRate, {"date": f["date"], "currency": f["currency"]}) is not None
+
+
+def verify(s: Session) -> list[str]:
+    """Run both integrity checks over every snapshot in a store. Empty means the whole series
+    is clean."""
+    problems = []
+    for snap in s.scalars(select(NwSnapshot).order_by(NwSnapshot.date)):
+        problems += missing_item_values(s, snap) + fx_carry_backs(s, snap)
+    return problems
+
+
+# What must survive the copy untouched, per row. `native_value` and `currency` are here as much
+# as the money is: a rate that round-trips against a rewritten native is still a rewritten value.
+VALUE_FIELDS = ("native_value", "currency", "rate_to_sgd", "value_sgd")
+SNAPSHOT_FIELDS = ("note", "portfolio_value_sgd")
+
+
+def frozen_money_diff(src: Session, tgt: Session) -> list[str]:
+    """Every way a snapshot both stores hold disagrees between them — the readback that says the
+    frozen money round-tripped rather than being recomputed, and that the frozen portfolio value
+    is the one captured at the time.
+
+    Separate from the integrity checks because it answers a different question. Those ask
+    whether a snapshot is internally sound; this asks whether the copy was faithful, which only
+    a comparison against the store it came from can answer. Re-runnable, so the claim does not
+    rest on a diff someone took by hand before the write."""
+    out = []
+    a = {sn.date: sn for sn in src.scalars(select(NwSnapshot))}
+    b = {sn.date: sn for sn in tgt.scalars(select(NwSnapshot))}
+    for date in sorted(a.keys() & b.keys()):
+        for f in SNAPSHOT_FIELDS:
+            x, y = getattr(a[date], f), getattr(b[date], f)
+            if x != y:
+                out.append(f"{date}: {f} source={x!r} target={y!r}")
+        va = {v.item.code: v for v in a[date].values}
+        vb = {v.item.code: v for v in b[date].values}
+        out += [f"{date}: {c} valued in source, not in target" for c in sorted(va.keys() - vb.keys())]
+        out += [f"{date}: {c} valued in target, not in source" for c in sorted(vb.keys() - va.keys())]
+        for code in sorted(va.keys() & vb.keys()):
+            for f in VALUE_FIELDS:
+                x, y = getattr(va[code], f), getattr(vb[code], f)
+                if x != y:
+                    out.append(f"{date}: {code}.{f} source={x!r} target={y!r}")
+    return out
+
+
+def _session(url: str) -> Session:
+    return sessionmaker(bind=create_engine(url, future=True, connect_args=connect_args(url)),
+                        future=True)()
+
+
+def _host(url: str) -> str:
+    return url.split("@")[-1].split("/")[0].split("?")[0] if "@" in url else url
+
+
+def _report(s: Session, label: str) -> None:
+    rows = [(snap.date, len(snap.values), float(snap.portfolio_value_sgd or 0))
+            for snap in s.scalars(select(NwSnapshot).order_by(NwSnapshot.date))]
+    print(f"{label}: {len(rows)} snapshot(s)")
+    for d, n, p in rows:
+        print(f"  {d}  {n:>2} values  portfolio {p:>16,.2f}")
+
+
+def _print_problems(label: str, clean: str, problems: list[str]) -> int:
+    """Print a check's verdict and return the exit code it implies."""
+    print(f"\n{label}: " + (clean if not problems else f"{len(problems)} PROBLEM(S)"))
+    for p in problems:
+        print(f"  ! {p}")
+    return 1 if problems else 0
+
+
+INTEGRITY_CLEAN = "CLEAN — no BR2 omission, no FX carry-back"
+READBACK_CLEAN = "CLEAN — frozen money and frozen portfolio value identical to the source"
+
+
+def main(argv) -> int:
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("--source", default=os.environ.get("PROMOTE_SOURCE_URL"),
+                    help="store to read snapshots from (never written)")
+    ap.add_argument("--target", default=os.environ.get("PROMOTE_TARGET_URL"),
+                    help="store to promote them into")
+    ap.add_argument("--commit", action="store_true", help="write (otherwise dry-run)")
+    ap.add_argument("--verify", action="store_true",
+                    help="run both integrity checks over the target's whole series and stop; "
+                         "with --source, also read every shared snapshot back against it")
+    args = ap.parse_args(argv)
+    if not args.target:
+        ap.error("--target (or PROMOTE_TARGET_URL) is required")
+
+    tgt = _session(args.target)
+    try:
+        if args.verify:
+            _report(tgt, f"target {_host(args.target)}")
+            rc = _print_problems("integrity", INTEGRITY_CLEAN, verify(tgt))
+            if args.source:
+                src = _session(args.source)
+                try:
+                    rc |= _print_problems("readback vs source", READBACK_CLEAN,
+                                          frozen_money_diff(src, tgt))
+                finally:
+                    src.close()
+            return rc
+
+        if not args.source:
+            ap.error("--source (or PROMOTE_SOURCE_URL) is required unless --verify")
+        src = _session(args.source)
+        try:
+            _report(src, f"source {_host(args.source)}")
+            print()
+            _report(tgt, f"target {_host(args.target)}")
+            rows = plan(src, tgt)
+        finally:
+            src.close()
+
+        if not rows:
+            print("\nNothing to promote: the target already holds every source date.")
+            return 0
+
+        print(f"\ncatalogue: identical across both stores ({len(_items(tgt))} items)")
+        for r in rows:
+            print(f"\n=== {r['date']}  note={r['note']!r}")
+            print(f"  portfolio_value_sgd {float(r['portfolio_value_sgd']):>16,.2f}  (frozen, copied)")
+            print(f"  integrity: no BR2 omission ({len(r['values'])} items valued), no FX carry-back")
+            for f in r["fx"]:
+                print(f"  fx carried: {f['date']} {f['currency']} {f['rate_to_sgd']}")
+            print(f"  {'code':<20}{'native':>16} {'ccy':<4}{'rate':>14}{'value_sgd':>16}")
+            print("  " + "-" * 70)
+            for v in r["values"]:
+                print(f"  {v['code']:<20}{float(v['native_value']):>16,.2f} {v['currency']:<4}"
+                      f"{float(v['rate_to_sgd']):>14.8f}{float(v['value_sgd']):>16,.2f}")
+
+        if not args.commit:
+            print("\nDRY-RUN. Re-run with --commit to write.")
+            return 0
+
+        apply(tgt, rows)
+        print(f"\nCOMMITTED {len(rows)} snapshot(s).\n")
+        _report(tgt, f"target {_host(args.target)}")
+        rc = _print_problems("integrity over the merged series", INTEGRITY_CLEAN, verify(tgt))
+        src = _session(args.source)
+        try:
+            rc |= _print_problems("readback vs source", READBACK_CLEAN,
+                                  frozen_money_diff(src, tgt))
+        finally:
+            src.close()
+        return rc
+    finally:
+        tgt.close()
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/tests/test_networth.py
+++ b/tests/test_networth.py
@@ -106,6 +106,21 @@ class FxAndCreateTest(unittest.TestCase):
         with self.assertRaises(ValueError):
             nw.rate_for(self.s, "EUR", dt.date(2026, 6, 1))
 
+    def test_fx_row_for_returns_the_row_rate_for_reads(self):
+        """`rate_for` answers "what rate", `fx_row_for` answers "from which row" — one freeze
+        rule, two callers. Promotion needs the row (to carry it to a store that lacks it);
+        `rate_for` needs only the number."""
+        row = nw.fx_row_for(self.s, "USD", dt.date(2026, 6, 20))
+        self.assertEqual(row.date, dt.date(2026, 6, 15))
+        self.assertEqual(Decimal(str(row.rate_to_sgd)),
+                         nw.rate_for(self.s, "USD", dt.date(2026, 6, 20)))
+
+    def test_fx_row_for_returns_none_rather_than_raising(self):
+        """The difference that stops promotion reusing `rate_for` directly: an integrity check
+        needs to *report* a missing rate across every currency, not abort on the first one."""
+        self.assertIsNone(nw.fx_row_for(self.s, "EUR", dt.date(2026, 6, 1)))
+        self.assertIsNone(nw.fx_row_for(self.s, "USD", dt.date(2026, 4, 1)))
+
     def test_create_freezes_and_defaults_missing_to_zero(self):
         d = nw.create_snapshot(dt.date(2026, 6, 20),
                                [{"code": "posb", "native_value": 5000, "currency": "SGD"},

--- a/tests/test_promote_networth.py
+++ b/tests/test_promote_networth.py
@@ -37,10 +37,10 @@ def make_session():
     return sessionmaker(bind=eng, future=True)()
 
 
-def seed_items(s, catalogue=CATALOGUE, id_offset=0):
+def seed_items(s, id_offset=0):
     """Seed the catalogue. `id_offset` forces the two stores onto different id sequences, which
     is what makes a by-id copy visibly wrong."""
-    for i, (code, kind, ccy, liq, hou, cpf) in enumerate(catalogue):
+    for i, (code, kind, ccy, liq, hou, cpf) in enumerate(CATALOGUE):
         s.add(NwItem(id=id_offset + i + 1, code=code, label=code.upper(), kind=kind,
                      currency_default=ccy, is_liquid=liq, is_housing=hou, is_cpf=cpf,
                      sort_order=i, active=True))
@@ -197,7 +197,7 @@ class PlanTest(Stores):
 class ApplyTest(Stores):
     def apply(self):
         rows = promote.plan(self.src, self.tgt)
-        promote.apply(self.tgt, rows)
+        promote.write_snapshots(self.tgt, rows)
         return rows
 
     def promoted(self, date):
@@ -278,7 +278,7 @@ class ApplyTest(Stores):
     def test_re_running_promotes_nothing(self):
         self.apply()
         self.assertEqual(promote.plan(self.src, self.tgt), [])
-        promote.apply(self.tgt, promote.plan(self.src, self.tgt))
+        promote.write_snapshots(self.tgt, promote.plan(self.src, self.tgt))
         self.assertEqual(len(self.target_dates()), 3)
 
     def test_both_checks_are_clean_across_the_merged_series(self):
@@ -294,7 +294,7 @@ class ReadbackTest(Stores):
     before the write."""
 
     def test_a_faithful_promotion_reads_back_clean(self):
-        promote.apply(self.tgt, promote.plan(self.src, self.tgt))
+        promote.write_snapshots(self.tgt, promote.plan(self.src, self.tgt))
         self.assertEqual(promote.frozen_money_diff(self.src, self.tgt), [])
 
     def test_it_ignores_dates_only_one_store_holds(self):
@@ -306,14 +306,14 @@ class ReadbackTest(Stores):
         rows = promote.plan(self.src, self.tgt)
         usd = [v for v in rows[0]["values"] if v["code"] == "tiger_usd"][0]
         usd["value_sgd"] = usd["native_value"] * usd["rate_to_sgd"]   # what a recompute produces
-        promote.apply(self.tgt, rows)
+        promote.write_snapshots(self.tgt, rows)
         self.assertTrue(any("tiger_usd.value_sgd" in d
                             for d in promote.frozen_money_diff(self.src, self.tgt)))
 
     def test_a_restamped_portfolio_value_is_caught(self):
         rows = promote.plan(self.src, self.tgt)
         rows[0]["portfolio_value_sgd"] = Decimal("1137390.0400")      # today's live value
-        promote.apply(self.tgt, rows)
+        promote.write_snapshots(self.tgt, rows)
         self.assertTrue(any("portfolio_value_sgd" in d
                             for d in promote.frozen_money_diff(self.src, self.tgt)))
 
@@ -323,12 +323,12 @@ class ReadbackTest(Stores):
         time would read back clean and the docstring's "verbatim" would be untested."""
         rows = promote.plan(self.src, self.tgt)
         rows[0]["created_at"] = dt.datetime(2026, 8, 15, 9, 0, tzinfo=dt.timezone.utc)
-        promote.apply(self.tgt, rows)
+        promote.write_snapshots(self.tgt, rows)
         self.assertTrue(any("created_at" in d
                             for d in promote.frozen_money_diff(self.src, self.tgt)))
 
     def test_a_faithfully_carried_created_at_reads_back_clean(self):
-        promote.apply(self.tgt, promote.plan(self.src, self.tgt))
+        promote.write_snapshots(self.tgt, promote.plan(self.src, self.tgt))
         self.assertEqual(promote.frozen_money_diff(self.src, self.tgt), [])
         promoted = self.tgt.scalar(select(NwSnapshot).where(NwSnapshot.date == dt.date(2026, 6, 21)))
         source = self.src.scalar(select(NwSnapshot).where(NwSnapshot.date == dt.date(2026, 6, 21)))
@@ -337,8 +337,89 @@ class ReadbackTest(Stores):
     def test_a_dropped_value_row_is_caught(self):
         rows = promote.plan(self.src, self.tgt)
         rows[0]["values"] = [v for v in rows[0]["values"] if v["code"] != "cpf_oa"]
-        promote.apply(self.tgt, rows)
+        promote.write_snapshots(self.tgt, rows)
         self.assertTrue(any("cpf_oa" in d for d in promote.frozen_money_diff(self.src, self.tgt)))
+
+
+class SeriesExpectationTest(Stores):
+    """AC1 — "the deployed store returns 5 snapshots spanning 2026-06-21 -> 2026-08-05". The
+    count and the span are the claim; `plan` promotes whatever dates the target lacks and would
+    happily leave a four-point series, so something has to assert the shape that was asked for."""
+
+    def test_a_matching_series_is_clean(self):
+        promote.write_snapshots(self.tgt, promote.plan(self.src, self.tgt))
+        self.assertEqual(promote.series_expectation(
+            self.tgt, count=3, span=(dt.date(2026, 6, 21), dt.date(2026, 7, 10))), [])
+
+    def test_a_short_count_is_flagged(self):
+        self.assertTrue(any("3" in p for p in promote.series_expectation(self.tgt, count=3)))
+
+    def test_a_wrong_span_is_flagged(self):
+        promote.write_snapshots(self.tgt, promote.plan(self.src, self.tgt))
+        problems = promote.series_expectation(
+            self.tgt, span=(dt.date(2026, 6, 1), dt.date(2026, 7, 10)))
+        self.assertTrue(any("2026-06-01" in p for p in problems))
+
+    def test_no_expectation_asked_for_is_no_check(self):
+        self.assertEqual(promote.series_expectation(self.tgt), [])
+
+
+class ExistingSnapshotsUntouchedTest(Stores):
+    """AC4 — "no existing snapshot is modified, renumbered or deleted". `frozen_money_diff` only
+    compares dates *both* stores hold, so the target's own pre-existing snapshots sit in no
+    comparison at all. This is the guard that covers them, at the moment they could be hurt."""
+
+    def test_fingerprint_drift_is_empty_for_an_untouched_store(self):
+        before = promote.series_fingerprint(self.tgt)
+        promote.write_snapshots(self.tgt, promote.plan(self.src, self.tgt))
+        self.assertEqual(promote.fingerprint_drift(before, promote.series_fingerprint(self.tgt)), [])
+
+    def test_a_renumbered_snapshot_is_drift(self):
+        before = promote.series_fingerprint(self.tgt)
+        d = dt.date(2026, 7, 10)
+        after = {**before, d: (99,) + before[d][1:]}           # same rows, new id
+        self.assertTrue(any("2026-07-10" in p for p in promote.fingerprint_drift(before, after)))
+
+    def test_a_deleted_snapshot_is_drift(self):
+        before = promote.series_fingerprint(self.tgt)
+        self.assertTrue(any("2026-07-10" in p for p in promote.fingerprint_drift(before, {})))
+
+    def test_a_new_snapshot_is_not_drift(self):
+        """Promotion adds dates; that is the point. Only the pre-existing ones are the claim."""
+        before = promote.series_fingerprint(self.tgt)
+        promote.write_snapshots(self.tgt, promote.plan(self.src, self.tgt))
+        after = promote.series_fingerprint(self.tgt)
+        self.assertEqual(promote.fingerprint_drift(before, after), [])
+        self.assertEqual(len(after), 3)
+
+    def test_the_write_rolls_back_rather_than_commit_drift(self):
+        """The guard has to fail closed: a write that disturbed an existing snapshot must leave
+        the store as it was, not commit the damage and report it afterwards.
+
+        Doctoring the "before" reading is how the drift is staged — it makes the untouched
+        2026-07-10 row *look* changed to the post-write comparison, which drives the same branch
+        a real modification would without this test needing a hook in the production path."""
+        rows = promote.plan(self.src, self.tgt)
+        real, d, seen = promote.series_fingerprint, dt.date(2026, 7, 10), []
+
+        def doctored_before(s):
+            fp = real(s)
+            seen.append(1)
+            if len(seen) == 1:
+                fp[d] = fp[d][:1] + ("a note it never had",) + fp[d][2:]
+            return fp
+
+        promote.series_fingerprint = doctored_before
+        try:
+            with self.assertRaises(RuntimeError) as cm:
+                promote.write_snapshots(self.tgt, rows)
+        finally:
+            promote.series_fingerprint = real
+        self.assertIn("2026-07-10", str(cm.exception))
+        self.assertEqual(self.target_dates(), [d])          # the two June rows never landed
+        self.assertEqual(
+            self.tgt.scalar(select(NwSnapshot).where(NwSnapshot.date == d)).portfolio_value_sgd,
+            Decimal("1117741.9400"))
 
 
 class InactiveItemTest(Stores):

--- a/tests/test_promote_networth.py
+++ b/tests/test_promote_networth.py
@@ -1,0 +1,342 @@
+"""Promotion of net-worth snapshots between two stores. Stdlib unittest + two in-memory
+SQLite sessions standing in for the local and deployed databases, matching tests/test_networth.py.
+
+The property under test throughout is that promotion **copies**, never recomputes: `value_sgd`
+and `portfolio_value_sgd` land byte-for-byte, because both are frozen money and the target store
+has neither the FX nor the prices that produced them. `create_snapshot` cannot be reused for
+exactly that reason — it stamps today's live portfolio value and recomputes `value_sgd` from
+native x rate.
+
+Run: PYTHONPATH=. .venv/bin/python tests/test_promote_networth.py
+"""
+import datetime as dt
+import os
+import sys
+import unittest
+from decimal import Decimal
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+from sqlalchemy import create_engine, select
+from sqlalchemy.orm import sessionmaker
+
+from portfolio.models import Base, FxRate, NwItem, NwSnapshot, NwValue
+from scripts import promote_networth_snapshots as promote
+
+# code, kind, ccy, liquid, housing, cpf — the shape of the real catalogue, four items deep.
+CATALOGUE = [
+    ("posb", "asset", "SGD", True, False, False),
+    ("tiger_usd", "asset", "USD", True, False, False),
+    ("cpf_oa", "asset", "SGD", False, False, True),
+    ("home_loan", "liability", "SGD", False, True, False),
+]
+
+
+def make_session():
+    eng = create_engine("sqlite://")
+    Base.metadata.create_all(eng)
+    return sessionmaker(bind=eng, future=True)()
+
+
+def seed_items(s, catalogue=CATALOGUE, id_offset=0):
+    """Seed the catalogue. `id_offset` forces the two stores onto different id sequences, which
+    is what makes a by-id copy visibly wrong."""
+    for i, (code, kind, ccy, liq, hou, cpf) in enumerate(catalogue):
+        s.add(NwItem(id=id_offset + i + 1, code=code, label=code.upper(), kind=kind,
+                     currency_default=ccy, is_liquid=liq, is_housing=hou, is_cpf=cpf,
+                     sort_order=i, active=True))
+    s.commit()
+
+
+def add_fx(s, date, ccy, rate):
+    s.add(FxRate(date=dt.date.fromisoformat(date), currency=ccy, rate_to_sgd=Decimal(str(rate))))
+    s.commit()
+
+
+def add_snapshot(s, date, portfolio, lines, note=None):
+    """lines: {code: (native, ccy, rate, value_sgd)}. value_sgd is supplied, never derived —
+    the tests need to be able to make it disagree with native x rate."""
+    items = {i.code: i for i in s.scalars(select(NwItem)).all()}
+    snap = NwSnapshot(date=dt.date.fromisoformat(date), note=note,
+                      portfolio_value_sgd=Decimal(str(portfolio)))
+    s.add(snap)
+    s.flush()
+    for code, (native, ccy, rate, sgd) in lines.items():
+        s.add(NwValue(snapshot_id=snap.id, item_id=items[code].id,
+                      native_value=Decimal(str(native)), currency=ccy,
+                      rate_to_sgd=Decimal(str(rate)), value_sgd=Decimal(str(sgd))))
+    s.commit()
+    s.refresh(snap)
+    return snap
+
+
+# tiger_usd's frozen value_sgd is deliberately NOT native x rate (1000 x 1.2903 = 1290.30), so
+# every test in this file runs against a row a recompute cannot reproduce. That is not a contrived
+# case: on the real deployed store the 07-10 and 07-25 snapshots froze rates their own fx_rate
+# table no longer agrees with, because the day's rate was refreshed after the snapshot took it.
+FULL_LINES = {
+    "posb": (500, "SGD", 1, 500),
+    "tiger_usd": (1000, "USD", "1.2903", "1290.29"),
+    "cpf_oa": (100000, "SGD", 1, 100000),
+    "home_loan": (250000, "SGD", 1, 250000),
+}
+
+
+class Stores(unittest.TestCase):
+    """A source holding two early snapshots, a target holding one later one — the shape of the
+    real disagreement (#86): local is earlier than everything deployed holds."""
+
+    def setUp(self):
+        self.src, self.tgt = make_session(), make_session()
+        seed_items(self.src)
+        seed_items(self.tgt, id_offset=100)          # same codes, different ids
+        add_fx(self.src, "2026-06-21", "USD", "1.2903")
+        add_fx(self.tgt, "2026-06-27", "USD", "1.2950")
+        add_snapshot(self.src, "2026-06-21", "1029006.95", FULL_LINES)
+        add_snapshot(self.src, "2026-06-30", "1117722.25", FULL_LINES, note="statements: dbs")
+        add_snapshot(self.tgt, "2026-07-10", "1117741.94", FULL_LINES)
+
+    def tearDown(self):
+        self.src.close()
+        self.tgt.close()
+
+    def target_dates(self):
+        return [d for (d,) in self.tgt.execute(select(NwSnapshot.date).order_by(NwSnapshot.date))]
+
+
+class CatalogueTest(Stores):
+    def test_identical_catalogues_do_not_differ(self):
+        self.assertEqual(promote.catalogue_diff(self.src, self.tgt), [])
+
+    def test_a_code_missing_from_the_target_is_a_difference(self):
+        self.tgt.delete(self.tgt.scalar(select(NwItem).where(NwItem.code == "cpf_oa")))
+        self.tgt.commit()
+        self.assertTrue(any("cpf_oa" in d for d in promote.catalogue_diff(self.src, self.tgt)))
+
+    def test_flag_drift_is_a_difference(self):
+        """Same codes both sides, but a band flag moved — the snapshots would promote and then
+        band differently in the two stores, which is the reconciliation this promotion claims
+        it does not need."""
+        it = self.tgt.scalar(select(NwItem).where(NwItem.code == "cpf_oa"))
+        it.is_cpf = False
+        self.tgt.commit()
+        self.assertTrue(any("cpf_oa" in d and "is_cpf" in d for d in promote.catalogue_diff(self.src, self.tgt)))
+
+
+class IntegrityCheckTest(Stores):
+    """The two checks the map ran on the June pair (#86), as code."""
+
+    def test_all_items_valued_is_clean_when_every_item_has_a_row(self):
+        snap = self.src.scalar(select(NwSnapshot).where(NwSnapshot.date == dt.date(2026, 6, 21)))
+        self.assertEqual(promote.missing_item_values(self.src, snap), [])
+
+    def test_all_items_valued_flags_a_br2_omission(self):
+        snap = self.src.scalar(select(NwSnapshot).where(NwSnapshot.date == dt.date(2026, 6, 21)))
+        self.src.delete([v for v in snap.values if v.item.code == "cpf_oa"][0])
+        self.src.commit()
+        self.src.refresh(snap)
+        self.assertTrue(any("cpf_oa" in p for p in promote.missing_item_values(self.src, snap)))
+
+    def test_no_carry_back_when_a_rate_is_dated_on_or_before_the_snapshot(self):
+        snap = self.src.scalar(select(NwSnapshot).where(NwSnapshot.date == dt.date(2026, 6, 21)))
+        self.assertEqual(promote.fx_carry_backs(self.src, snap), [])
+
+    def test_carry_back_flagged_when_the_only_rate_is_later(self):
+        """A rate dated after the snapshot is exactly what `ensure_fx` back-stamps, and what
+        would value a June snapshot at a later month's FX."""
+        snap = self.tgt.scalar(select(NwSnapshot).where(NwSnapshot.date == dt.date(2026, 7, 10)))
+        snap.date = dt.date(2026, 6, 21)             # now earlier than the target's only USD rate
+        self.tgt.commit()
+        self.assertTrue(any("USD" in p for p in promote.fx_carry_backs(self.tgt, snap)))
+
+    def test_sgd_needs_no_rate(self):
+        """SGD is 1:1 by policy, never a table lookup — a store with no fx_rate at all is clean
+        for an all-SGD snapshot."""
+        s = make_session()
+        seed_items(s)
+        snap = add_snapshot(s, "2026-06-21", 0, {k: v for k, v in FULL_LINES.items() if k != "tiger_usd"})
+        self.assertEqual(promote.fx_carry_backs(s, snap), [])
+        s.close()
+
+
+class PlanTest(Stores):
+    def test_plan_covers_source_dates_the_target_lacks(self):
+        rows = promote.plan(self.src, self.tgt)
+        self.assertEqual([r["date"] for r in rows], [dt.date(2026, 6, 21), dt.date(2026, 6, 30)])
+
+    def test_plan_skips_a_date_the_target_already_holds(self):
+        add_snapshot(self.tgt, "2026-06-21", 0, FULL_LINES)
+        rows = promote.plan(self.src, self.tgt)
+        self.assertEqual([r["date"] for r in rows], [dt.date(2026, 6, 30)])
+
+    def test_plan_refuses_a_catalogue_that_differs(self):
+        self.tgt.delete(self.tgt.scalar(select(NwItem).where(NwItem.code == "cpf_oa")))
+        self.tgt.commit()
+        with self.assertRaises(ValueError) as cm:
+            promote.plan(self.src, self.tgt)
+        self.assertIn("catalogue", str(cm.exception))
+
+    def test_plan_refuses_a_snapshot_that_fails_an_integrity_check(self):
+        snap = self.src.scalar(select(NwSnapshot).where(NwSnapshot.date == dt.date(2026, 6, 21)))
+        self.src.delete([v for v in snap.values if v.item.code == "cpf_oa"][0])
+        self.src.commit()
+        with self.assertRaises(ValueError) as cm:
+            promote.plan(self.src, self.tgt)
+        self.assertIn("cpf_oa", str(cm.exception))
+
+    def test_plan_carries_the_fx_rows_the_frozen_rates_were_read_from(self):
+        rows = promote.plan(self.src, self.tgt)
+        fx = rows[0]["fx"]
+        self.assertEqual([(f["date"], f["currency"], f["rate_to_sgd"]) for f in fx],
+                         [(dt.date(2026, 6, 21), "USD", Decimal("1.29030000"))])
+
+    def test_plan_alone_writes_nothing(self):
+        promote.plan(self.src, self.tgt)
+        self.assertEqual(self.target_dates(), [dt.date(2026, 7, 10)])
+
+
+class ApplyTest(Stores):
+    def apply(self):
+        rows = promote.plan(self.src, self.tgt)
+        promote.apply(self.tgt, rows)
+        return rows
+
+    def promoted(self, date):
+        return self.tgt.scalar(select(NwSnapshot).where(NwSnapshot.date == dt.date.fromisoformat(date)))
+
+    def test_the_target_ends_up_with_the_merged_series(self):
+        self.apply()
+        self.assertEqual(self.target_dates(),
+                         [dt.date(2026, 6, 21), dt.date(2026, 6, 30), dt.date(2026, 7, 10)])
+
+    def test_frozen_money_round_trips_rather_than_being_recomputed(self):
+        """The one assertion the whole ticket rests on. `value_sgd` is set to something native x
+        rate does NOT produce, so a target row holding native x rate is a recompute and fails."""
+        snap = self.src.scalar(select(NwSnapshot).where(NwSnapshot.date == dt.date(2026, 6, 21)))
+        row = [v for v in snap.values if v.item.code == "tiger_usd"][0]
+        row.value_sgd = Decimal("9999.0000")          # deliberately != 1000 x 1.2903
+        self.src.commit()
+        self.apply()
+        got = [v for v in self.promoted("2026-06-21").values if v.item.code == "tiger_usd"][0]
+        self.assertEqual(got.value_sgd, Decimal("9999.0000"))
+        self.assertEqual(got.native_value, Decimal("1000.0000"))
+        self.assertEqual(got.rate_to_sgd, Decimal("1.29030000"))
+        self.assertEqual(got.currency, "USD")
+
+    def test_the_frozen_portfolio_value_is_the_one_captured_at_the_time(self):
+        self.apply()
+        self.assertEqual(self.promoted("2026-06-21").portfolio_value_sgd, Decimal("1029006.9500"))
+        self.assertEqual(self.promoted("2026-06-30").portfolio_value_sgd, Decimal("1117722.2500"))
+
+    def test_items_are_matched_by_code_not_by_id(self):
+        """The two stores are seeded on different id sequences. A copy that carried `item_id`
+        across would land every value on the wrong band, or on no item at all."""
+        self.apply()
+        by_code = {v.item.code: v.value_sgd for v in self.promoted("2026-06-21").values}
+        self.assertEqual(by_code["cpf_oa"], Decimal("100000.0000"))
+        self.assertEqual(by_code["home_loan"], Decimal("250000.0000"))
+        self.assertEqual(len(by_code), len(CATALOGUE))
+
+    def test_the_note_is_carried(self):
+        self.apply()
+        self.assertEqual(self.promoted("2026-06-30").note, "statements: dbs")
+
+    def test_the_existing_snapshot_is_not_modified_or_renumbered(self):
+        before = self.tgt.scalar(select(NwSnapshot).where(NwSnapshot.date == dt.date(2026, 7, 10)))
+        was = (before.id, before.portfolio_value_sgd,
+               sorted((v.item.code, v.value_sgd) for v in before.values))
+        self.apply()
+        after = self.tgt.scalar(select(NwSnapshot).where(NwSnapshot.date == dt.date(2026, 7, 10)))
+        self.assertEqual((after.id, after.portfolio_value_sgd,
+                          sorted((v.item.code, v.value_sgd) for v in after.values)), was)
+
+    def test_the_target_catalogue_is_unchanged(self):
+        was = sorted((i.id, i.code, i.kind, i.sort_order) for i in self.tgt.scalars(select(NwItem)))
+        self.apply()
+        self.tgt.expire_all()
+        self.assertEqual(sorted((i.id, i.code, i.kind, i.sort_order)
+                                for i in self.tgt.scalars(select(NwItem))), was)
+
+    def test_the_backing_fx_rows_land_so_the_carry_back_check_reproduces(self):
+        """Without them the promoted 06-21 snapshot has no USD rate on or before its date in the
+        target — the check that was clean at capture would read as dirty, and `update_snapshot`
+        on that snapshot would raise (BR4) instead of editing."""
+        self.apply()
+        self.assertEqual(promote.fx_carry_backs(self.tgt, self.promoted("2026-06-21")), [])
+        self.assertEqual(
+            self.tgt.scalar(select(FxRate.rate_to_sgd).where(FxRate.date == dt.date(2026, 6, 21),
+                                                             FxRate.currency == "USD")),
+            Decimal("1.29030000"))
+
+    def test_an_existing_target_fx_row_is_left_alone(self):
+        add_fx(self.tgt, "2026-06-21", "USD", "1.4000")   # disagrees with the source
+        self.apply()
+        self.assertEqual(
+            self.tgt.scalar(select(FxRate.rate_to_sgd).where(FxRate.date == dt.date(2026, 6, 21),
+                                                             FxRate.currency == "USD")),
+            Decimal("1.40000000"))
+
+    def test_re_running_promotes_nothing(self):
+        self.apply()
+        self.assertEqual(promote.plan(self.src, self.tgt), [])
+        promote.apply(self.tgt, promote.plan(self.src, self.tgt))
+        self.assertEqual(len(self.target_dates()), 3)
+
+    def test_both_checks_are_clean_across_the_merged_series(self):
+        self.apply()
+        for snap in self.tgt.scalars(select(NwSnapshot)):
+            self.assertEqual(promote.missing_item_values(self.tgt, snap), [], snap.date)
+            self.assertEqual(promote.fx_carry_backs(self.tgt, snap), [], snap.date)
+
+
+class ReadbackTest(Stores):
+    """`frozen_money_diff` is the re-runnable form of the acceptance criteria: it compares the
+    promoted rows against the store they came from, rather than trusting a diff taken by hand
+    before the write."""
+
+    def test_a_faithful_promotion_reads_back_clean(self):
+        promote.apply(self.tgt, promote.plan(self.src, self.tgt))
+        self.assertEqual(promote.frozen_money_diff(self.src, self.tgt), [])
+
+    def test_it_ignores_dates_only_one_store_holds(self):
+        """The target's own 2026-07-10 is not in the source and is none of this check's business
+        — only the shared dates are a copy that could have gone wrong."""
+        self.assertEqual(promote.frozen_money_diff(self.src, self.tgt), [])
+
+    def test_a_recomputed_value_sgd_is_caught(self):
+        rows = promote.plan(self.src, self.tgt)
+        usd = [v for v in rows[0]["values"] if v["code"] == "tiger_usd"][0]
+        usd["value_sgd"] = usd["native_value"] * usd["rate_to_sgd"]   # what a recompute produces
+        promote.apply(self.tgt, rows)
+        self.assertTrue(any("tiger_usd.value_sgd" in d
+                            for d in promote.frozen_money_diff(self.src, self.tgt)))
+
+    def test_a_restamped_portfolio_value_is_caught(self):
+        rows = promote.plan(self.src, self.tgt)
+        rows[0]["portfolio_value_sgd"] = Decimal("1137390.0400")      # today's live value
+        promote.apply(self.tgt, rows)
+        self.assertTrue(any("portfolio_value_sgd" in d
+                            for d in promote.frozen_money_diff(self.src, self.tgt)))
+
+    def test_a_dropped_value_row_is_caught(self):
+        rows = promote.plan(self.src, self.tgt)
+        rows[0]["values"] = [v for v in rows[0]["values"] if v["code"] != "cpf_oa"]
+        promote.apply(self.tgt, rows)
+        self.assertTrue(any("cpf_oa" in d for d in promote.frozen_money_diff(self.src, self.tgt)))
+
+
+class InactiveItemTest(Stores):
+    """`create_snapshot` writes a row per *active* item, so scoping the omission check the same
+    way would let an item deactivated between capture and promotion vanish unremarked. The
+    criterion is "every catalogue item"."""
+
+    def test_a_deactivated_item_with_no_value_row_is_still_flagged(self):
+        snap = self.src.scalar(select(NwSnapshot).where(NwSnapshot.date == dt.date(2026, 6, 21)))
+        self.src.delete([v for v in snap.values if v.item.code == "cpf_oa"][0])
+        self.src.scalar(select(NwItem).where(NwItem.code == "cpf_oa")).active = False
+        self.src.commit()
+        self.src.refresh(snap)
+        self.assertTrue(any("cpf_oa" in p for p in promote.missing_item_values(self.src, snap)))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/test_promote_networth.py
+++ b/tests/test_promote_networth.py
@@ -317,6 +317,23 @@ class ReadbackTest(Stores):
         self.assertTrue(any("portfolio_value_sgd" in d
                             for d in promote.frozen_money_diff(self.src, self.tgt)))
 
+    def test_a_restamped_created_at_is_caught(self):
+        """`created_at` is carried verbatim — when it was captured, not when it was copied — so
+        the readback has to compare it. Left out, a snapshot that arrived stamped with the copy
+        time would read back clean and the docstring's "verbatim" would be untested."""
+        rows = promote.plan(self.src, self.tgt)
+        rows[0]["created_at"] = dt.datetime(2026, 8, 15, 9, 0, tzinfo=dt.timezone.utc)
+        promote.apply(self.tgt, rows)
+        self.assertTrue(any("created_at" in d
+                            for d in promote.frozen_money_diff(self.src, self.tgt)))
+
+    def test_a_faithfully_carried_created_at_reads_back_clean(self):
+        promote.apply(self.tgt, promote.plan(self.src, self.tgt))
+        self.assertEqual(promote.frozen_money_diff(self.src, self.tgt), [])
+        promoted = self.tgt.scalar(select(NwSnapshot).where(NwSnapshot.date == dt.date(2026, 6, 21)))
+        source = self.src.scalar(select(NwSnapshot).where(NwSnapshot.date == dt.date(2026, 6, 21)))
+        self.assertEqual(promoted.created_at, source.created_at)
+
     def test_a_dropped_value_row_is_caught(self):
         rows = promote.plan(self.src, self.tgt)
         rows[0]["values"] = [v for v in rows[0]["values"] if v["code"] != "cpf_oa"]


### PR DESCRIPTION
Closes #93.

Two databases held different halves of one history. Deployed Neon had 2026-07-10, 07-25 and
08-05; local dev held 2026-06-21 and 06-30, earlier than all of them, on its own id sequence.
`portfolio/config.py` sets `env_file=".env"` and `.env` carries no `DATABASE_URL`, so local
Python always hit localhost while the deployed app always hit Neon — neither environment had
ever shown the whole series (#86).

It matters because the composition chart is specced against the merged five. On the deployed
three the top edge sweeps 5,324.91 — 0.27% of the [0, 2,000,000] domain, about half a pixel on
the 189px plot band. On the merged five it sweeps 128,227.86, 6.41%, ~12.1px. Same chart, same
axis, 24x the movement: the flatness was a property of the three points prod happened to hold,
not of net worth.

**The data operation is already done.** It ran against Neon after a dry run and a table backup.
Every run in this PR's later commits was read-only `--verify`.

## What is in the diff

`scripts/promote_networth_snapshots.py` — promotion as a script rather than a psql one-liner
because `networth.create_snapshot` cannot do this copy: it stamps *today's* `live_portfolio_sgd()`
and derives `value_sgd` from native x rate at the target's FX, and both are frozen money captured
at the snapshot date that the target has neither the prices nor the rates to reproduce. So
`native_value`, `currency`, `rate_to_sgd`, `value_sgd`, `portfolio_value_sgd`, `note` and
`created_at` all carry over verbatim, and items are matched by code rather than id because the
two stores keep separate `nw_item` sequences.

The FX rows travel with the snapshots — 2026-06-21 USD 1.29030000 and HKD 0.16470000 — because
deployed `fx_rate` started 2026-06-27. **This is the one write outside the ticket's acceptance
criteria**, and it is not optional: without those rows the no-carry-back check cannot reproduce
in the target, and `update_snapshot` on a promoted snapshot would raise BR4 rather than edit, so
the snapshot would arrive un-editable. Only the rows those two snapshots actually read, never
overwriting an existing one. It also changes how `rate_for`/`ensure_fx` resolve any future
back-dated write in 06-21..06-26, which is the cost of having them.

`portfolio/networth.py` gains `fx_row_for` — the FX freeze rule ("newest `fx_rate` on or before
this date"), previously held as raw SQL in `rate_for` and again as an ORM query in the script.
`rate_for` is now its wrapper. One definition, two callers.

## Verified against the deployed store

| Acceptance criterion | How |
|---|---|
| 5 snapshots, 2026-06-21 → 2026-08-05 | `--expect-count 5 --expect-span 2026-06-21..2026-08-05` |
| June pair carries every item, frozen FX + `value_sgd` unchanged | `frozen_money_diff` readback vs local: CLEAN |
| Frozen `portfolio_value_sgd` captured at the time | 1,029,006.95 / 1,117,722.25 identical to local |
| No existing snapshot modified, renumbered or deleted | kept ids 2/3/4; promoted took 5/6 |
| Catalogue unchanged | `catalogue_diff`: identical |
| Both integrity checks pass on the merged series | no BR2 omission, no FX carry-back |

`metrics()` reproduces the map's figures to the cent: 1,763,368.11 → 1,885,507.10, deltas
+128,227.86 / -763.96 / -4,824.82 / -500.09, top-edge range 128,227.86 = 6.41% of domain.

## Review follow-ups (commits 2 and 3)

A two-axis review (standards + spec) ran against commit 1; both later commits are its findings.

- **AC1 was prose, not a check.** `plan` promotes whatever dates the target lacks, so a source
  missing a snapshot merges cleanly into a series that is sound but not the one asked for.
  `series_expectation` now asserts count and span. No defaults — those belong to the ticket, not
  the tool.
- **AC4 was unverifiable after the fact.** `frozen_money_diff` compares only dates *both* stores
  hold, so the target's pre-existing snapshots sat in no comparison at all. `write_snapshots` now
  fingerprints the series (ids included — renumbering is what a money comparison misses), re-reads
  after the flush, and rolls back on drift instead of committing damage. Fails closed.
- `created_at` joins `SNAPSHOT_FIELDS`; it was the one carried field nothing checked.
- A comment claimed `created_at` "is nullable"; `models.py:355` declares `Mapped[dt.datetime]`.
  Corrected — the guard stays, for the right reason.
- `_only_in` / `_field_diffs` hold the diff shape once across three call sites; `_readback`
  replaces a try/finally block duplicated in both `main` branches; `apply` → `write_snapshots`.

## Testing

`tests/test_promote_networth.py` (44 tests) + additions to `tests/test_networth.py`. Two in-memory
SQLite sessions stand in for the two stores, seeded on **different id sequences** so a by-id copy
is visibly wrong, and `tiger_usd`'s frozen `value_sgd` is deliberately not `native x rate` so
every test runs against a row a recompute cannot reproduce.

**379 pass, ruff clean.** Against Neon: `--verify --expect-count 5 --expect-span
2026-06-21..2026-08-05` reports integrity, series and readback all clean, exit 0; a deliberately
wrong count exits 1.

## Known gaps

- The `fx_rate` writes are outside the ticket's stated scope (argued above).
- The promotion tool is more general than the one operation needed — multi-snapshot planning,
  re-run idempotence and an 8-field catalogue guard are past "a data operation with a
  verification". The spec review flagged this and I have left it; it is the shape that made the
  checks re-runnable.
- `_fx_rows` copies the fx *row*, which can differ from the value's frozen rate where a day's rate
  was refreshed after the snapshot took it. A promoted snapshot is editable, but `update_snapshot`
  would re-derive `value_sgd` at a rate that never froze it.
