### PR TITLE
feat(spending): the window rule, as data, before either chart draws (#94)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ web/dist/
 
 # playwright run artifacts (the suite itself and its fixtures ARE tracked)
 web/test-results/
+test-results/
 web/playwright-report/
 web/blob-report/
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -90,6 +90,28 @@ are the series keys the chart reads); `summary()` leaves the NULL as a value and
 names it at render. One word, two places, because only one of them can hold a null.
 _Avoid_: uncategorised (the app spells it with a z), missing, unknown
 
+**Date window**:
+The `frm`/`to` range a caller passes to `summary()`, `trends()` or `transactions()` — a filter
+the reader chooses, and the only thing "window" meant before the spend-trend window existed.
+_Avoid_: window, unqualified (see below — the two are not interchangeable)
+
+**Spend-trend window**:
+The months the spend-trend chart may draw, derived by `window()` from source coverage rather
+than chosen: `[start, last drawable month]`, where **start** is the first month beginning after
+the latest first-transaction among *material* sources and a month is **drawable** when it is at
+or after start, is not the month holding `MAX(txn_date)`, and every material source reported in
+it. Non-drawable months inside it are **gaps**. It is a rule, not a control — the grounds are
+data defects, so there is deliberately no UI to widen it.
+_Avoid_: window, unqualified; date range; the chart window
+
+**Material source**:
+A statement source whose dated counted spend is at least 1% of all dated counted spend. Decides
+which sources a month must have heard from before it is drawable. **First-appearance only** —
+a source that stops reporting never shortens the window, because the rule exists to exclude
+months a source had not started yet, not months it had finished. Immaterial sources are carried
+in the payload and flagged, never filtered out.
+_Avoid_: primary source, main account, significant source
+
 ### Net worth
 
 **Net-worth snapshot**:

--- a/portfolio/spending.py
+++ b/portfolio/spending.py
@@ -69,7 +69,7 @@ DATED = "txn_date IS NOT NULL"
 
 
 def summary(frm=None, to=None, s=None):
-    """Totals + category / subcategory / month breakdowns for the spend window.
+    """Totals + category / subcategory / month breakdowns for the `frm`/`to` date window.
 
     total_sgd is every counted line in the window; by_month covers only the dated ones (see
     DATED). Unwindowed, the two therefore differ by exactly undated()'s magnitude — the gap
@@ -215,11 +215,16 @@ def categories(s=None):
             f"FROM cash_txn WHERE {where} GROUP BY category, subcategory ORDER BY category, v DESC", p)
 
 
-# ---------------- the spend window ----------------
+# ---------------- the spend-trend window ----------------
 # Which months the spend-trend chart may draw, and everything its disclosure prose is
 # derived from. The chart itself slices the array trends() already returns; this shape only
 # says where to cut it, so trends() is untouched and one payload feeds two charts that
 # cannot disagree about a shared month.
+#
+# "Spend-trend window" in full, every time, because "window" alone is already spoken for in
+# this module: summary() and transactions() take a `frm`/`to` *date window*, which is a
+# filter the caller chooses. This one is a rule the data decides, and the two are not
+# interchangeable — see CONTEXT.md's Spending glossary, which pins both.
 
 #: A source is *material* when its lifetime counted spend is at least this share of all
 #: counted spend. Not a knife-edge on the live ledger: the gap between the last material
@@ -235,10 +240,14 @@ def _iso(d):
 
 
 def _month(d):
+    """The `YYYY-MM` bucket a date falls in — the same key `to_char(txn_date,'YYYY-MM')`
+    produces, taken by slice so the two cannot drift."""
     return None if d is None else _iso(d)[:7]
 
 
 def _next_month(ym):
+    """The month after `ym`, rolling the year. December is the whole of the arithmetic:
+    `12 // 12` carries the 1 into the year and `12 % 12 + 1` wraps the month back to 01."""
     y, m = int(ym[:4]), int(ym[5:7])
     return f"{y + m // 12:04d}-{m % 12 + 1:02d}"
 
@@ -259,7 +268,9 @@ def _bucket(months, keys):
     how much money."""
     return {"months": len(keys),
             "n": sum(months[k]["n"] for k in keys),
-            "total_sgd": round(sum(months[k]["v"] for k in keys), 2)}
+            # float() before round(), or an empty bucket serializes as `0` where every other
+            # bucket says `0.0` — the same money field with two JSON types across one payload.
+            "total_sgd": round(float(sum(months[k]["v"] for k in keys)), 2)}
 
 
 def _window_shape(coverage, presence):
@@ -305,6 +316,26 @@ def _window_shape(coverage, presence):
     undated rows (see DATED) — subtracting it naively would absorb undated spend into the
     outside-the-window figure, and undated spend is undated()'s to report, not this one's.
 
+    IT SPLITS THREE WAYS, NOT TWO. The spec names `before` and `after`; a gap month is a
+    third kind of off-chart money, and the two-way split has no room for it. That matters
+    because the only subtraction available to a caller is
+    `dated_total - before - after`, which counts every gap month's spend as *drawn* — so a
+    payload carrying `gaps` but not their money makes the disclosure prose wrong on the day
+    the list first fires, and this endpoint exists precisely so that prose is derived rather
+    than typed. Empty today, for the same reason `gaps` is. What the chart does with a
+    non-empty `gaps` is still out of scope; having the number is not the same as drawing it.
+
+    So: drawn = dated_total - before - after - gaps, and off-chart = before + after + gaps.
+
+    A SECOND DEVIATION, deliberate: the gate's denominator is the *dated* counted total, not
+    "all counted spend". The two differ only by undated rows, and undated rows cannot make a
+    source present in any month — so a source material on undated money alone would be
+    required in every month and no month would ever be drawable, which empties the chart
+    permanently rather than protecting it. The share on the wire is the same dated figure the
+    gate compared, so a reader can check the verdict against the number beside it. Both halves
+    are moot on today's ledger (undated is n=0/$0) and neither would stay moot silently:
+    undated() reports the count this rule is blind to.
+
     With no material source, or no drawable month, there is no window: `start` and `end` are
     both null and every dated month falls in `before`, because with no window there is no
     tail for `after` to mean.
@@ -335,7 +366,8 @@ def _window_shape(coverage, presence):
     material = {x["source"] for x in sources if x["material"]}
     empty = {"start": None, "end": None, "gaps": [], "sources": sources,
              "excluded": {"before": _bucket(months, sorted(months)),
-                          "after": _bucket(months, [])}}
+                          "after": _bucket(months, []),
+                          "gaps": _bucket(months, [])}}
     if not material:
         return empty
 
@@ -349,13 +381,15 @@ def _window_shape(coverage, presence):
         return empty
 
     end = max(drawable)
+    gaps = [m for m in _month_range(start, end) if m not in drawable]
     return {
         "start": start,
         "end": end,
-        "gaps": [m for m in _month_range(start, end) if m not in drawable],
+        "gaps": gaps,
         "sources": sources,
         "excluded": {"before": _bucket(months, [m for m in months if m < start]),
-                     "after": _bucket(months, [m for m in months if m > end])},
+                     "after": _bucket(months, [m for m in months if m > end]),
+                     "gaps": _bucket(months, [m for m in gaps if m in months])},
     }
 
 

--- a/portfolio/spending.py
+++ b/portfolio/spending.py
@@ -6,7 +6,7 @@ every spend metric but remain inspectable via transactions(include_excluded=True
 
 Every public function accepts an optional Session (`s`) and routes through
 db.session_scope, so it composes inside a larger unit of work or opens its own connection.
-The six read shapes share a single WHERE builder (`_where`) rather than each re-deriving
+The seven read shapes share a single WHERE builder (`_where`) rather than each re-deriving
 the same is_spend / date / category filters.
 
 Note: summary() and trends() bucket by month with Postgres `to_char`, so their SQL is
@@ -15,6 +15,14 @@ is a testing split too — tests/test_spending.py runs the portable shapes on SQ
 `_where` and `_trend_shape` (trends()' payload fold, where unclassified spend gets its name
 and where it used to raise) directly, and tests/test_spending_pg.py runs these two functions'
 actual SELECT against a real Postgres, skipping when there is none.
+
+window() straddles that split rather than sitting on one side of it, which is why it is two
+queries and a fold instead of one query: its per-source coverage query (MIN/MAX/SUM) is
+portable, its per-source-per-month presence query buckets with `to_char` and is Postgres-only,
+and the window rule itself is `_window_shape`, a pure function over those two result sets.
+So the rule — every clause of it — is tested on any machine with no database at all, and
+only the month bucketing needs a server: tests/test_spending.py::TestWindowShape holds the
+rule, tests/test_spending_pg.py::TestPresenceQuery holds the bucketing.
 
 Run: PYTHONPATH=. .venv/bin/python -m pytest tests/test_spending.py tests/test_spending_pg.py -q
 """
@@ -205,3 +213,173 @@ def categories(s=None):
         return _rows(s,
             f"SELECT category, subcategory, ROUND(SUM(-amount_sgd),2) v, COUNT(*) n "
             f"FROM cash_txn WHERE {where} GROUP BY category, subcategory ORDER BY category, v DESC", p)
+
+
+# ---------------- the spend window ----------------
+# Which months the spend-trend chart may draw, and everything its disclosure prose is
+# derived from. The chart itself slices the array trends() already returns; this shape only
+# says where to cut it, so trends() is untouched and one payload feeds two charts that
+# cannot disagree about a shared month.
+
+#: A source is *material* when its lifetime counted spend is at least this share of all
+#: counted spend. Not a knife-edge on the live ledger: the gap between the last material
+#: source and the first immaterial one is 18x (6.60% vs 0.36%).
+MATERIAL_SHARE = 0.01
+
+
+def _iso(d):
+    """A date column as the `YYYY-MM-DD` string that goes on the wire. Postgres hands back
+    `datetime.date`, SQLite hands back a string already, and an all-undated source hands
+    back None from MIN/MAX — all three have to survive the same call."""
+    return d if d is None or isinstance(d, str) else d.isoformat()
+
+
+def _month(d):
+    return None if d is None else _iso(d)[:7]
+
+
+def _next_month(ym):
+    y, m = int(ym[:4]), int(ym[5:7])
+    return f"{y + m // 12:04d}-{m % 12 + 1:02d}"
+
+
+def _month_range(start, end):
+    """Every calendar month in `[start, end]`, including the ones no row landed in — which
+    is the point: a month with no transactions at all is a gap, and it cannot be found by
+    walking rows that do not exist."""
+    out, m = [], start
+    while m <= end:
+        out.append(m)
+        m = _next_month(m)
+    return out
+
+
+def _bucket(months, keys):
+    """Fold a set of month keys into one `excluded` bucket: how many months, how many lines,
+    how much money."""
+    return {"months": len(keys),
+            "n": sum(months[k]["n"] for k in keys),
+            "total_sgd": round(sum(months[k]["v"] for k in keys), 2)}
+
+
+def _window_shape(coverage, presence):
+    """The window rule, as a pure function over the two result sets `window()` runs.
+
+    Split out for the same reason `_trend_shape` is: one of the two queries is Postgres-only
+    (`to_char`) and this is not, so the rule is testable with no database at all — see
+    tests/test_spending.py::TestWindowShape, which is where every clause below is pinned.
+
+    `coverage` is one row per source: `first_txn`, `last_txn`, `total_sgd` (the *dated* sum).
+    `presence` is one row per (month, source): `ym`, `source`, `n`, `v`. The rule:
+
+      * **Material source** — lifetime counted spend >= MATERIAL_SHARE of all counted spend.
+      * **Start** — the first calendar month beginning *after* the latest first-transaction
+        among material sources. Unconditionally the next month: a source whose first line is
+        the 1st still only gets counted from the month after, because materiality here is
+        about when a source *appeared*, not how much of that month it saw.
+      * **Drawable** — a month at or after `start`, that is not the month containing
+        MAX(txn_date), and in which *every* material source has at least one counted line.
+      * **Window** — `[start, last drawable month]`.
+
+    Materiality is FIRST-APPEARANCE ONLY, never ongoing presence. The two are different
+    rules and only the first one is right: a discontinued small source would otherwise
+    truncate the window at the month it stopped reporting, and the window exists to exclude
+    months a source had not started yet, not months it had finished.
+
+    IMMATERIAL SOURCES ARE FLAGGED, NOT FILTERED. A source silently absent from a payload is
+    how the fourth source stayed invisible in the first place, so `sources` carries every
+    one of them with its share and its verdict, and the prose derives "two of three sources"
+    from the flags rather than having it typed (typed, it is wrong at three of four).
+
+    `gaps` is every non-drawable month *inside* the window, which is a hair wider than the
+    spec's "strictly inside": `end` is drawable by construction, but `start` need not be —
+    every material source has a first line before `start` begins, and none of that promises
+    each one also has a line *in* `start`. Reading "strictly" literally would leave an
+    undrawable start month inside the window and unlisted anywhere, which is the silent hole
+    this whole endpoint exists to close. The closed interval agrees with the spec everywhere
+    the spec's assumption holds.
+
+    `excluded` is SPLIT, NOT TOTALLED, and computed from the *dated* total. Split because
+    98.6% of the off-chart money on the live ledger is the leading months and one figure
+    would misread it as a rounding tail. Dated because summary()'s total_sgd includes
+    undated rows (see DATED) — subtracting it naively would absorb undated spend into the
+    outside-the-window figure, and undated spend is undated()'s to report, not this one's.
+
+    With no material source, or no drawable month, there is no window: `start` and `end` are
+    both null and every dated month falls in `before`, because with no window there is no
+    tail for `after` to mean.
+    """
+    dated_total = sum(float(c["total_sgd"] or 0) for c in coverage)
+    sources = []
+    for c in sorted(coverage, key=lambda c: -float(c["total_sgd"] or 0)):
+        total, first = float(c["total_sgd"] or 0), _iso(c["first_txn"])
+        share = total / dated_total if dated_total else 0.0
+        sources.append({
+            "source": c["source"],
+            "first_txn": first,
+            "last_txn": _iso(c["last_txn"]),
+            "total_sgd": round(total, 2),
+            # Rounded for the wire, compared raw: a 0.996% share rounds to 0.0100 and would
+            # otherwise be admitted by the very digits that are there to display it.
+            "share": round(share, 4),
+            "material": first is not None and share >= MATERIAL_SHARE,
+        })
+
+    months: dict[str, dict] = {}
+    for r in presence:
+        m = months.setdefault(r["ym"], {"n": 0, "v": 0.0, "sources": set()})
+        m["n"] += int(r["n"])
+        m["v"] += float(r["v"])
+        m["sources"].add(r["source"])
+
+    material = {x["source"] for x in sources if x["material"]}
+    empty = {"start": None, "end": None, "gaps": [], "sources": sources,
+             "excluded": {"before": _bucket(months, sorted(months)),
+                          "after": _bucket(months, [])}}
+    if not material:
+        return empty
+
+    start = _next_month(max(_month(x["first_txn"]) for x in sources if x["material"]))
+    # MAX(txn_date) over *every* counted line, immaterial sources included: the partial month
+    # is the month the ledger currently ends in, whoever reported into it.
+    latest = max(_month(c["last_txn"]) for c in coverage if c["last_txn"] is not None)
+    drawable = {m for m, d in months.items()
+                if m >= start and m != latest and material <= d["sources"]}
+    if not drawable:
+        return empty
+
+    end = max(drawable)
+    return {
+        "start": start,
+        "end": end,
+        "gaps": [m for m in _month_range(start, end) if m not in drawable],
+        "sources": sources,
+        "excluded": {"before": _bucket(months, [m for m in months if m < start]),
+                     "after": _bucket(months, [m for m in months if m > end])},
+    }
+
+
+def window(s=None):
+    """Which months the spend-trend chart may draw, plus the material-source coverage its
+    disclosure prose is derived from. See `_window_shape` for the rule.
+
+    Two result sets, because they split on portability: the coverage query is per-source
+    MIN/MAX/SUM and runs anywhere; the presence query buckets by month with `to_char` and is
+    Postgres-only. Both are one pass over cash_txn, so the endpoint costs two queries whatever
+    the ledger holds.
+
+    The coverage sum is over dated rows only (`CASE WHEN txn_date IS NOT NULL` rather than a
+    `FILTER` clause, which SQLite only learned in 3.30) while the GROUP BY is over all of
+    them — so an all-undated source still appears in `sources`, with no coverage and no
+    share, instead of vanishing from the payload."""
+    where, p = _where()
+    with session_scope(s) as s:
+        coverage = _rows(s,
+            f"SELECT source, MIN(txn_date) first_txn, MAX(txn_date) last_txn, "
+            f"COALESCE(SUM(CASE WHEN {DATED} THEN -amount_sgd ELSE 0 END),0) total_sgd "
+            f"FROM cash_txn WHERE {where} GROUP BY source", p)
+        presence = _rows(s,
+            f"SELECT to_char(txn_date,'YYYY-MM') ym, source, COUNT(*) n, "
+            f"ROUND(SUM(-amount_sgd),2) v FROM cash_txn "
+            f"WHERE {where} AND {DATED} GROUP BY ym, source ORDER BY ym, source", p)
+    return _window_shape(coverage, presence)

--- a/portfolio/spending.py
+++ b/portfolio/spending.py
@@ -226,9 +226,10 @@ def categories(s=None):
 # filter the caller chooses. This one is a rule the data decides, and the two are not
 # interchangeable — see CONTEXT.md's Spending glossary, which pins both.
 
-#: A source is *material* when its lifetime counted spend is at least this share of all
-#: counted spend. Not a knife-edge on the live ledger: the gap between the last material
-#: source and the first immaterial one is 18x (6.60% vs 0.36%).
+#: A source is *material* when its lifetime *dated* counted spend is at least this share of
+#: all dated counted spend (see `_window_shape` for why the denominator excludes undated
+#: rows). Not a knife-edge on the live ledger: the gap between the last material source and
+#: the first immaterial one is 18x (6.60% vs 0.36%).
 MATERIAL_SHARE = 0.01
 
 

--- a/scripts/capture_web_fixtures.py
+++ b/scripts/capture_web_fixtures.py
@@ -124,6 +124,10 @@ ENDPOINTS: list[tuple[str, str]] = [
     # --- spending ---
     ("spending-summary", "/api/spending/summary"),
     ("spending-trends", "/api/spending/trends"),
+    # The spend-trend chart's window rule. Its own path rather than a parameter on
+    # `/api/spending/trends` partly for this table: the route key would carry a date, and a
+    # dated key goes stale the moment the ledger gains a month.
+    ("spending-window", "/api/spending/window"),
     ("spending-years", "/api/spending/years"),
     ("spending-undated", "/api/spending/undated"),
     ("spending-categories", "/api/spending/categories"),

--- a/server/main.py
+++ b/server/main.py
@@ -515,6 +515,14 @@ def spending_trends(frm: str | None = Query(None, alias="from"),
     return spending.trends(frm, to)
 
 
+@app.get("/api/spending/window")
+def spending_window():
+    """Which months the spend-trend chart may draw, and the coverage its footnote is derived
+    from. Deliberately its own path rather than a parameter on /api/spending/trends: that
+    payload stays byte-identical, and a fixture key that carried a date would go stale."""
+    return spending.window()
+
+
 @app.get("/api/spending/transactions")
 def spending_transactions(frm: str | None = Query(None, alias="from"),
                           to: str | None = Query(None, alias="to"),

--- a/server/main.py
+++ b/server/main.py
@@ -517,9 +517,6 @@ def spending_trends(frm: str | None = Query(None, alias="from"),
 
 @app.get("/api/spending/window")
 def spending_window():
-    """Which months the spend-trend chart may draw, and the coverage its footnote is derived
-    from. Deliberately its own path rather than a parameter on /api/spending/trends: that
-    payload stays byte-identical, and a fixture key that carried a date would go stale."""
     return spending.window()
 
 

--- a/tests/test_spending.py
+++ b/tests/test_spending.py
@@ -205,5 +205,272 @@ class TestTrendShape(unittest.TestCase):
         self.assertEqual(spending._trend_shape([]), {"groups": [], "series": []})
 
 
+# ---------------- the window rule (pure) ----------------
+
+class TestWindowShape(unittest.TestCase):
+    """The spend-trend window, exercised through `_window_shape` rather than the endpoint.
+
+    The rule is the whole of this endpoint — the two queries around it are a MIN/MAX/SUM and
+    a GROUP BY, and neither decides anything. So the rule is a pure function over their two
+    result sets and every clause of it is pinned here, with no database: the 1% gate, where
+    the start lands, what does and does not move the end, and what falls in `gaps` rather
+    than truncating the history around it.
+
+    The one thing this file cannot claim is that the presence query buckets months the way
+    summary() and trends() do, because `to_char` is Postgres-only —
+    tests/test_spending_pg.py::TestPresenceQuery is that assertion.
+    """
+
+    def cover(self, *rows):
+        """coverage rows: (source, first_txn, last_txn, total_sgd)."""
+        return [{"source": s, "first_txn": f, "last_txn": l, "total_sgd": v}
+                for s, f, l, v in rows]
+
+    def seen(self, *rows):
+        """presence rows: (ym, source, n, v)."""
+        return [{"ym": ym, "source": s, "n": n, "v": v} for ym, s, n, v in rows]
+
+    def months(self, source, first, last, per_month, n=1):
+        """Every month in [first, last] for one source, `per_month` dollars each — the
+        shorthand most cases below want, since what they vary is which months exist."""
+        return [(m, source, n, per_month)
+                for m in spending._month_range(first[:7], last[:7])]
+
+    def by(self, got, source):
+        return next(x for x in got["sources"] if x["source"] == source)
+
+    # --- the 1% gate ---
+
+    def test_the_gate_rejects_a_source_under_one_percent(self):
+        # 99.5 / 100.0 and 0.5 / 100.0. The small source appears in `sources` — flagged, not
+        # filtered — and its months are not required for a month to be drawable, so the
+        # window is not shortened to the two months it happens to have reported in.
+        coverage = self.cover(("dbs", "2024-01-05", "2024-04-20", 99.5),
+                              ("tiny", "2024-01-06", "2024-02-20", 0.5))
+        presence = self.seen(*self.months("dbs", "2024-01", "2024-04", 24.875),
+                             ("2024-01", "tiny", 1, 0.25), ("2024-02", "tiny", 1, 0.25))
+        got = spending._window_shape(coverage, presence)
+        self.assertEqual(self.by(got, "tiny")["material"], False)
+        self.assertEqual(self.by(got, "tiny")["share"], 0.005)
+        self.assertEqual((got["start"], got["end"]), ("2024-02", "2024-03"))
+
+    def test_the_gate_admits_a_source_at_exactly_one_percent(self):
+        # 1.00 / 100.00 is admitted: the rule is ">= 1%", and a source that sits exactly on
+        # the line is a source that exists.
+        coverage = self.cover(("dbs", "2024-01-05", "2024-04-20", 99.0),
+                              ("small", "2024-02-06", "2024-04-20", 1.0))
+        got = spending._window_shape(coverage, self.seen(("2024-01", "dbs", 1, 99.0)))
+        self.assertEqual(self.by(got, "small")["material"], True)
+        self.assertEqual(self.by(got, "small")["share"], 0.01)
+
+    def test_the_gate_compares_the_raw_share_not_the_displayed_one(self):
+        # 0.996% displays as 0.0100 because `share` is rounded for the wire. Comparing the
+        # rounded number would let the digits that exist to *show* the verdict decide it.
+        coverage = self.cover(("dbs", "2024-01-05", "2024-04-20", 99.004),
+                              ("tiny", "2024-02-06", "2024-04-20", 0.996))
+        got = spending._window_shape(coverage, self.seen(("2024-01", "dbs", 1, 99.004)))
+        self.assertEqual(self.by(got, "tiny")["share"], 0.01)
+        self.assertEqual(self.by(got, "tiny")["material"], False)
+
+    # --- where the start lands ---
+
+    def test_a_source_starting_mid_month_pushes_the_start_to_the_next_month(self):
+        # The whole reason the start is the month *after*: February is a partial month for
+        # `cc`, and drawing it would show a category rising out of nothing when it was
+        # simply not being captured for the first three weeks.
+        coverage = self.cover(("dbs", "2024-01-02", "2024-05-30", 900.0),
+                              ("cc", "2024-02-21", "2024-05-30", 100.0))
+        presence = self.seen(*self.months("dbs", "2024-01", "2024-05", 180.0),
+                             *self.months("cc", "2024-02", "2024-05", 25.0))
+        got = spending._window_shape(coverage, presence)
+        self.assertEqual((got["start"], got["end"]), ("2024-03", "2024-04"))
+
+    def test_a_source_starting_on_the_first_still_pushes_the_start(self):
+        # No day-of-month special case. The month a source first appears in is never drawn,
+        # even when it appeared on day one — the rule is about appearance, not coverage, and
+        # a special case would be a second rule to keep true.
+        coverage = self.cover(("dbs", "2024-01-02", "2024-05-30", 900.0),
+                              ("cc", "2024-02-01", "2024-05-30", 100.0))
+        presence = self.seen(*self.months("dbs", "2024-01", "2024-05", 180.0),
+                             *self.months("cc", "2024-02", "2024-05", 25.0))
+        got = spending._window_shape(coverage, presence)
+        self.assertEqual(got["start"], "2024-03")
+
+    def test_the_latest_first_appearance_wins_not_the_first(self):
+        coverage = self.cover(("dbs", "2024-01-02", "2024-06-30", 800.0),
+                              ("cc", "2024-02-11", "2024-06-30", 100.0),
+                              ("trust", "2024-04-09", "2024-06-30", 100.0))
+        presence = self.seen(*self.months("dbs", "2024-01", "2024-06", 133.0),
+                             *self.months("cc", "2024-02", "2024-06", 20.0),
+                             *self.months("trust", "2024-04", "2024-06", 33.0))
+        got = spending._window_shape(coverage, presence)
+        self.assertEqual((got["start"], got["end"]), ("2024-05", "2024-05"))
+
+    # --- what moves the end, and what must not ---
+
+    def test_the_partial_month_is_always_dropped(self):
+        # The month containing MAX(txn_date) is never drawable, however complete it looks:
+        # it is the month the ledger currently ends in, so the newest point would be a
+        # fabricated collapse — and it is the reading entry point.
+        coverage = self.cover(("dbs", "2024-01-02", "2024-04-14", 400.0))
+        got = spending._window_shape(
+            coverage, self.seen(*self.months("dbs", "2024-01", "2024-04", 100.0)))
+        self.assertEqual((got["start"], got["end"]), ("2024-02", "2024-03"))
+
+    def test_a_discontinued_immaterial_source_does_not_move_the_end(self):
+        # Materiality is first-appearance only, never ongoing presence. A 0.4% source that
+        # stopped reporting in February must not truncate four months of history: the window
+        # exists to exclude months a source had not started yet, not months it had finished.
+        coverage = self.cover(("dbs", "2024-01-02", "2024-06-28", 996.0),
+                              ("gone", "2024-01-06", "2024-02-20", 4.0))
+        presence = self.seen(*self.months("dbs", "2024-01", "2024-06", 166.0),
+                             ("2024-01", "gone", 1, 2.0), ("2024-02", "gone", 1, 2.0))
+        got = spending._window_shape(coverage, presence)
+        self.assertEqual((got["start"], got["end"]), ("2024-02", "2024-05"))
+        self.assertEqual(got["gaps"], [])
+
+    def test_a_material_source_absent_from_the_tail_does_move_the_end(self):
+        # The complement, and the one the chart is protected by: `cc` is 25% of spend and
+        # stopped reporting after March, so April and May are ingestion gaps rather than
+        # months where spending fell. They are dropped, and their money lands in `after`.
+        coverage = self.cover(("dbs", "2024-01-02", "2024-06-28", 750.0),
+                              ("cc", "2024-01-06", "2024-03-20", 250.0))
+        presence = self.seen(*self.months("dbs", "2024-01", "2024-06", 125.0),
+                             *self.months("cc", "2024-01", "2024-03", 83.33))
+        got = spending._window_shape(coverage, presence)
+        self.assertEqual((got["start"], got["end"]), ("2024-02", "2024-03"))
+        self.assertEqual(got["excluded"]["after"]["months"], 3)   # April, May, June
+
+    # --- gaps ---
+
+    def test_an_interior_absence_lands_in_gaps_rather_than_truncating(self):
+        # April has no `cc` line at all. The alternative — ending the window at March — would
+        # throw away May and June because one month in the middle was short, so the history
+        # is kept and the hole is *named*.
+        coverage = self.cover(("dbs", "2024-01-02", "2024-07-28", 700.0),
+                              ("cc", "2024-01-06", "2024-07-20", 300.0))
+        presence = self.seen(*self.months("dbs", "2024-01", "2024-07", 100.0),
+                             *[r for r in self.months("cc", "2024-01", "2024-07", 42.85)
+                               if r[0] != "2024-04"])
+        got = spending._window_shape(coverage, presence)
+        self.assertEqual((got["start"], got["end"], got["gaps"]),
+                         ("2024-02", "2024-06", ["2024-04"]))
+
+    def test_a_month_with_no_rows_at_all_is_a_gap(self):
+        # Nothing reported in April, from anyone. It cannot be found by walking presence rows
+        # — there are none — so the gap list is built by walking the calendar instead.
+        coverage = self.cover(("dbs", "2024-01-02", "2024-06-28", 600.0))
+        presence = self.seen(*[r for r in self.months("dbs", "2024-01", "2024-06", 100.0)
+                               if r[0] != "2024-04"])
+        got = spending._window_shape(coverage, presence)
+        self.assertEqual((got["start"], got["end"], got["gaps"]),
+                         ("2024-02", "2024-05", ["2024-04"]))
+
+    def test_an_undrawable_start_month_is_listed_rather_than_left_silent(self):
+        # `start` is derived from first-appearance, which promises every material source has
+        # a line *before* the month begins — not one *inside* it. So the window's own first
+        # month can be undrawable, and the spec's "strictly inside" would leave it inside the
+        # window and named nowhere. It is a gap.
+        coverage = self.cover(("dbs", "2024-01-02", "2024-06-28", 800.0),
+                              ("cc", "2024-01-06", "2024-06-20", 200.0))
+        presence = self.seen(*self.months("dbs", "2024-01", "2024-06", 133.0),
+                             *[r for r in self.months("cc", "2024-01", "2024-06", 40.0)
+                               if r[0] != "2024-02"])
+        got = spending._window_shape(coverage, presence)
+        self.assertEqual((got["start"], got["end"], got["gaps"]),
+                         ("2024-02", "2024-05", ["2024-02"]))
+
+    # --- the degenerate ledgers ---
+
+    def test_a_single_source_windows_on_its_own_coverage(self):
+        coverage = self.cover(("dbs", "2024-01-02", "2024-05-30", 500.0))
+        got = spending._window_shape(
+            coverage, self.seen(*self.months("dbs", "2024-01", "2024-05", 100.0)))
+        self.assertEqual((got["start"], got["end"], got["gaps"]),
+                         ("2024-02", "2024-04", []))
+        self.assertEqual(self.by(got, "dbs"), {
+            "source": "dbs", "first_txn": "2024-01-02", "last_txn": "2024-05-30",
+            "total_sgd": 500.0, "share": 1.0, "material": True})
+
+    def test_an_empty_ledger_is_a_null_window_not_an_error(self):
+        self.assertEqual(spending._window_shape([], []), {
+            "start": None, "end": None, "gaps": [], "sources": [],
+            "excluded": {"before": {"months": 0, "n": 0, "total_sgd": 0.0},
+                         "after": {"months": 0, "n": 0, "total_sgd": 0.0}}})
+
+    def test_a_ledger_with_no_drawable_month_reports_no_window(self):
+        # One source, one month, and that month is the partial one. There is nothing to draw,
+        # and with no window there is no tail — all of it is `before`.
+        coverage = self.cover(("dbs", "2024-01-02", "2024-01-30", 50.0))
+        got = spending._window_shape(coverage, self.seen(("2024-01", "dbs", 3, 50.0)))
+        self.assertEqual((got["start"], got["end"], got["gaps"]), (None, None, []))
+        self.assertEqual(got["excluded"]["before"], {"months": 1, "n": 3, "total_sgd": 50.0})
+        self.assertEqual(got["excluded"]["after"], {"months": 0, "n": 0, "total_sgd": 0.0})
+
+    def test_an_all_undated_source_is_flagged_rather_than_missing(self):
+        # MIN/MAX over rows that all carry a NULL date is NULL, and its dated sum is zero. It
+        # is still a source, so it is still in the payload — with no coverage, no share, and
+        # no vote on any month. A payload that dropped it is the exact failure this list of
+        # flags exists to prevent.
+        coverage = self.cover(("dbs", "2024-01-02", "2024-04-30", 400.0),
+                              ("orphan", None, None, 0.0))
+        got = spending._window_shape(
+            coverage, self.seen(*self.months("dbs", "2024-01", "2024-04", 100.0)))
+        self.assertEqual(self.by(got, "orphan"),
+                         {"source": "orphan", "first_txn": None, "last_txn": None,
+                          "total_sgd": 0.0, "share": 0.0, "material": False})
+        self.assertEqual((got["start"], got["end"]), ("2024-02", "2024-03"))
+
+    # --- the footnote arithmetic ---
+
+    def test_outside_the_window_is_computed_from_the_dated_total(self):
+        """The disclosure's "$X sits outside the window", and the trap in computing it.
+
+        summary()'s total_sgd includes undated rows (see DATED) — it is 1,000 here while the
+        dated ledger is 900 — so `total - inside` would report 400 outside when 300 is
+        outside and 100 carries no date at all. undated() reports that 100 separately and
+        always has; this shape's job is to make the other subtraction come out right, which
+        it does by summing the *dated* coverage rather than being handed a total.
+        """
+        coverage = self.cover(("dbs", "2024-01-02", "2024-06-28", 600.0),
+                              ("cc", "2024-02-11", "2024-06-20", 300.0))
+        presence = self.seen(*self.months("dbs", "2024-01", "2024-06", 100.0, n=10),
+                             *self.months("cc", "2024-02", "2024-06", 60.0, n=6))
+        got = spending._window_shape(coverage, presence)
+        self.assertEqual((got["start"], got["end"]), ("2024-03", "2024-05"))
+
+        dated_total = sum(x["total_sgd"] for x in got["sources"])
+        before, after = got["excluded"]["before"], got["excluded"]["after"]
+        self.assertEqual(dated_total, 900.0)
+        # Jan (dbs only) + Feb (both) = 100 + 160; June = 160.
+        self.assertEqual(before, {"months": 2, "n": 26, "total_sgd": 260.0})
+        self.assertEqual(after, {"months": 1, "n": 16, "total_sgd": 160.0})
+        inside = round(dated_total - before["total_sgd"] - after["total_sgd"], 2)
+        self.assertEqual(inside, 480.0)                       # 3 drawn months x 160
+        # And the undated 100 is nowhere in any of it — not in the dated total, not in
+        # either bucket, and so not silently absorbed into "outside the window".
+        self.assertEqual(before["total_sgd"] + after["total_sgd"] + inside, dated_total)
+
+
+class TestMonthArithmetic(unittest.TestCase):
+    """`_next_month` / `_month_range`, which every boundary in the rule above is built from.
+
+    Worth their own class because both roll the year, and both are string arithmetic on
+    `YYYY-MM` rather than date arithmetic — the format is what `to_char` produces and what
+    `<Bar dataKey>` consumes, so it never becomes a date on the way through."""
+
+    def test_next_month_rolls_the_year(self):
+        self.assertEqual(spending._next_month("2024-12"), "2025-01")
+        self.assertEqual(spending._next_month("2024-01"), "2024-02")
+        self.assertEqual(spending._next_month("2024-09"), "2024-10")   # zero-padded
+
+    def test_month_range_is_inclusive_and_crosses_a_year(self):
+        self.assertEqual(spending._month_range("2024-11", "2025-02"),
+                         ["2024-11", "2024-12", "2025-01", "2025-02"])
+
+    def test_a_single_month_range_is_that_month(self):
+        self.assertEqual(spending._month_range("2024-03", "2024-03"), ["2024-03"])
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_spending.py
+++ b/tests/test_spending.py
@@ -396,7 +396,8 @@ class TestWindowShape(unittest.TestCase):
         self.assertEqual(spending._window_shape([], []), {
             "start": None, "end": None, "gaps": [], "sources": [],
             "excluded": {"before": {"months": 0, "n": 0, "total_sgd": 0.0},
-                         "after": {"months": 0, "n": 0, "total_sgd": 0.0}}})
+                         "after": {"months": 0, "n": 0, "total_sgd": 0.0},
+                         "gaps": {"months": 0, "n": 0, "total_sgd": 0.0}}})
 
     def test_a_ledger_with_no_drawable_month_reports_no_window(self):
         # One source, one month, and that month is the partial one. There is nothing to draw,
@@ -404,8 +405,9 @@ class TestWindowShape(unittest.TestCase):
         coverage = self.cover(("dbs", "2024-01-02", "2024-01-30", 50.0))
         got = spending._window_shape(coverage, self.seen(("2024-01", "dbs", 3, 50.0)))
         self.assertEqual((got["start"], got["end"], got["gaps"]), (None, None, []))
-        self.assertEqual(got["excluded"]["before"], {"months": 1, "n": 3, "total_sgd": 50.0})
-        self.assertEqual(got["excluded"]["after"], {"months": 0, "n": 0, "total_sgd": 0.0})
+        self.assertEqual(got["excluded"], {"before": {"months": 1, "n": 3, "total_sgd": 50.0},
+                                           "after": {"months": 0, "n": 0, "total_sgd": 0.0},
+                                           "gaps": {"months": 0, "n": 0, "total_sgd": 0.0}})
 
     def test_an_all_undated_source_is_flagged_rather_than_missing(self):
         # MIN/MAX over rows that all carry a NULL date is NULL, and its dated sum is zero. It
@@ -440,17 +442,51 @@ class TestWindowShape(unittest.TestCase):
         self.assertEqual((got["start"], got["end"]), ("2024-03", "2024-05"))
 
         dated_total = sum(x["total_sgd"] for x in got["sources"])
-        before, after = got["excluded"]["before"], got["excluded"]["after"]
+        ex = got["excluded"]
         self.assertEqual(dated_total, 900.0)
         # Jan (dbs only) + Feb (both) = 100 + 160; June = 160.
-        self.assertEqual(before, {"months": 2, "n": 26, "total_sgd": 260.0})
-        self.assertEqual(after, {"months": 1, "n": 16, "total_sgd": 160.0})
-        inside = round(dated_total - before["total_sgd"] - after["total_sgd"], 2)
-        self.assertEqual(inside, 480.0)                       # 3 drawn months x 160
-        # And the undated 100 is nowhere in any of it — not in the dated total, not in
-        # either bucket, and so not silently absorbed into "outside the window".
-        self.assertEqual(before["total_sgd"] + after["total_sgd"] + inside, dated_total)
+        self.assertEqual(ex["before"], {"months": 2, "n": 26, "total_sgd": 260.0})
+        self.assertEqual(ex["after"], {"months": 1, "n": 16, "total_sgd": 160.0})
+        self.assertEqual(ex["gaps"], {"months": 0, "n": 0, "total_sgd": 0.0})
+        off_chart = sum(b["total_sgd"] for b in ex.values())
+        drawn = round(dated_total - off_chart, 2)
+        self.assertEqual(drawn, 480.0)                        # 3 drawn months x 160
+        # And the undated 100 is nowhere in any of it — not in the dated total, not in any
+        # bucket, and so not silently absorbed into "outside the window".
+        self.assertEqual(off_chart + drawn, dated_total)
 
+    def test_gap_months_are_their_own_bucket_not_silently_drawn(self):
+        """The subtraction a caller has to make, and what a two-way split does to it.
+
+        April is a gap — inside the window, drawn by nothing. It is in neither `before` nor
+        `after`, so `dated_total - before - after` reports it as money the chart shows, and
+        the disclosure prose understates the off-chart total by exactly one month. The third
+        bucket is what makes the sum close.
+        """
+        # dbs 100/month across Jan-Jul = 700; cc 50/month across the same span minus April
+        # = 300. Coverage and presence agree, so the subtraction below is checkable by hand.
+        coverage = self.cover(("dbs", "2024-01-02", "2024-07-28", 700.0),
+                              ("cc", "2024-01-06", "2024-07-20", 300.0))
+        presence = self.seen(*self.months("dbs", "2024-01", "2024-07", 100.0, n=4),
+                             *[r for r in self.months("cc", "2024-01", "2024-07", 50.0, n=2)
+                               if r[0] != "2024-04"])
+        got = spending._window_shape(coverage, presence)
+        self.assertEqual((got["start"], got["end"], got["gaps"]),
+                         ("2024-02", "2024-06", ["2024-04"]))
+        # April: dbs alone, 4 lines, $100 — inside the window and on no chart.
+        self.assertEqual(got["excluded"]["gaps"], {"months": 1, "n": 4, "total_sgd": 100.0})
+
+        dated_total = sum(x["total_sgd"] for x in got["sources"])
+        ex = got["excluded"]
+        self.assertEqual(dated_total, 1000.0)
+        naive = round(dated_total - ex["before"]["total_sgd"] - ex["after"]["total_sgd"], 2)
+        drawn = round(naive - ex["gaps"]["total_sgd"], 2)
+        self.assertEqual(naive - drawn, 100.0)   # the month a two-way split would have lost
+        self.assertEqual(drawn, 600.0)           # Feb, Mar, May, Jun at 150 each
+        self.assertEqual(sum(b["total_sgd"] for b in ex.values()) + drawn, dated_total)
+
+
+# ---------------- month arithmetic (pure) ----------------
 
 class TestMonthArithmetic(unittest.TestCase):
     """`_next_month` / `_month_range`, which every boundary in the rule above is built from.

--- a/tests/test_spending.py
+++ b/tests/test_spending.py
@@ -223,8 +223,8 @@ class TestWindowShape(unittest.TestCase):
 
     def cover(self, *rows):
         """coverage rows: (source, first_txn, last_txn, total_sgd)."""
-        return [{"source": s, "first_txn": f, "last_txn": l, "total_sgd": v}
-                for s, f, l, v in rows]
+        return [{"source": src, "first_txn": first, "last_txn": last, "total_sgd": v}
+                for src, first, last, v in rows]
 
     def seen(self, *rows):
         """presence rows: (ym, source, n, v)."""

--- a/tests/test_spending_pg.py
+++ b/tests/test_spending_pg.py
@@ -283,5 +283,117 @@ class TestWindow(PgCase):
         self.assertEqual(spending.trends(s=self.s)["series"], [{"ym": "2024-01", "Food": 10.0}])
 
 
+# ---------------- window(): the one query the rule cannot be tested without ----------------
+
+class TestPresenceQuery(PgCase):
+    """`window()`'s per-source-per-month presence query, against a real Postgres.
+
+    The window *rule* is `_window_shape`, a pure function, and every clause of it is pinned
+    in tests/test_spending.py with no database. What cannot be pinned there is the one thing
+    this query is made of: `to_char(txn_date,'YYYY-MM')`, which SQLite does not have. So the
+    claim here is narrow and specific — the presence query buckets months **the same way**
+    summary() and trends() do.
+
+    It has to be the same bucketing or the endpoint is worse than useless: the chart takes
+    the months from `window()` and the money from `trends()`, so a month that the two
+    queries disagree about is a slice taken at the wrong index — silently, because both
+    payloads are individually well-formed. The three queries share `_where` and `DATED` but
+    not their GROUP BY, and that is exactly the seam a shared helper does not cover.
+    """
+
+    def presence_rows(self):
+        """The presence query's own rows, caught at the seam it hands them over at — the
+        same spy shape TestGroupByCardinality uses, and for the same reason: `_window_shape`
+        folds months into verdicts, so the rows themselves are invisible downstream."""
+        caught = []
+        rule = spending._window_shape
+
+        def spy(coverage, presence):
+            caught.extend(dict(r) for r in presence)
+            return rule(coverage, presence)
+
+        with mock.patch.object(spending, "_window_shape", spy):
+            spending.window(s=self.s)
+        return caught
+
+    def test_presence_months_are_the_months_summary_and_trends_bucket(self):
+        # Two sources, overlapping but not identical months, and a month-boundary pair
+        # (Jan 31 / Feb 1) so an off-by-one bucketing would show up as a shifted month
+        # rather than a missing one.
+        self.add(D(2024, 1, 31), -10, source="dbs")
+        self.add(D(2024, 2, 1), -20, source="dbs")
+        self.add(D(2024, 2, 15), -5, source="cc")
+        self.add(D(2024, 3, 4), -30, source="dbs")
+        rows = self.presence_rows()
+        summary_months = [r["ym"] for r in spending.summary(s=self.s)["by_month"]]
+        trend_months = [m["ym"] for m in spending.trends(s=self.s)["series"]]
+        self.assertEqual(sorted({r["ym"] for r in rows}), summary_months)
+        self.assertEqual(summary_months, trend_months)
+        self.assertEqual(summary_months, ["2024-01", "2024-02", "2024-03"])
+
+    def test_presence_money_per_month_equals_summarys(self):
+        # Same rows, split by source instead of by category, so the per-month sums must
+        # reconcile line for line. They are what `excluded` is totalled from, and `excluded`
+        # is what the disclosure prose subtracts from the dated total.
+        self.add(D(2024, 1, 31), -10, source="dbs")
+        self.add(D(2024, 2, 1), -20, source="dbs")
+        self.add(D(2024, 2, 15), -5, source="cc")
+        per_month: dict[str, float] = {}
+        for r in self.presence_rows():
+            per_month[r["ym"]] = per_month.get(r["ym"], 0) + float(r["v"])
+        self.assertEqual(per_month, {"2024-01": 10.0, "2024-02": 25.0})
+        self.assertEqual({r["ym"]: float(r["v"]) for r in spending.summary(s=self.s)["by_month"]},
+                         per_month)
+
+    def test_presence_is_one_row_per_month_and_source(self):
+        # The property `_window_shape`'s `sources.add` and `n +=` are written against: two
+        # lines from one source in one month arrive as one row, not two.
+        self.add(D(2024, 1, 5), -10, source="dbs")
+        self.add(D(2024, 1, 6), -10, source="dbs")
+        self.add(D(2024, 1, 7), -5, source="cc")
+        rows = self.presence_rows()
+        self.assertEqual([(r["ym"], r["source"], int(r["n"]), float(r["v"])) for r in rows],
+                         [("2024-01", "cc", 1, 5.0), ("2024-01", "dbs", 2, 20.0)])
+
+    def test_undated_spend_is_in_no_month_and_in_no_coverage_sum(self):
+        # The footnote arithmetic, at the SQL end of it. `to_char(NULL,'YYYY-MM')` is NULL,
+        # so an undated row must be dropped by the presence query the way it is everywhere
+        # else — and dropped from the coverage sum too, or the dated total the disclosure
+        # subtracts from would carry money that belongs to no month.
+        self.add(D(2024, 1, 5), -10, source="dbs")
+        self.add(None, -15, source="dbs")
+        self.assertEqual([r["ym"] for r in self.presence_rows()], ["2024-01"])
+        got = spending.window(s=self.s)
+        self.assertEqual([s["total_sgd"] for s in got["sources"]], [10.0])
+        self.assertEqual(spending.summary(s=self.s)["total_sgd"], 25.0)   # includes the 15
+        self.assertEqual(spending.undated(s=self.s), {"n": 1, "total_sgd": 15.0})
+
+    def test_excluded_rows_are_out_of_the_window_too(self):
+        # `_where`'s is_spend default, composing into this query like every other one: a
+        # card-bill payment must not make a month look covered, or an ingestion gap would be
+        # papered over by the transfer that repaid it.
+        self.add(D(2024, 1, 5), -10, source="dbs")
+        self.add(D(2024, 2, 5), -999, source="cc", is_spend=False, exclude_reason="cc_payment")
+        self.assertEqual([(r["ym"], r["source"]) for r in self.presence_rows()],
+                         [("2024-01", "dbs")])
+
+    def test_window_end_to_end_on_a_real_ledger(self):
+        # The two queries and the rule joined up, once: dbs from January, cc appearing on
+        # Feb 11, and March as the partial month. Start is the month after cc appeared, the
+        # partial month is dropped, and the immaterial nothing-source is flagged not filtered.
+        for day in (D(2024, 1, 4), D(2024, 2, 4), D(2024, 3, 4), D(2024, 4, 4)):
+            self.add(day, -250, source="dbs")
+        for day in (D(2024, 2, 11), D(2024, 3, 11), D(2024, 4, 11)):
+            self.add(day, -100, source="cc")
+        self.add(D(2024, 3, 12), -1, source="hsbc")
+        got = spending.window(s=self.s)
+        self.assertEqual((got["start"], got["end"], got["gaps"]), ("2024-03", "2024-03", []))
+        self.assertEqual([(s["source"], s["material"]) for s in got["sources"]],
+                         [("dbs", True), ("cc", True), ("hsbc", False)])
+        self.assertEqual(got["excluded"],
+                         {"before": {"months": 2, "n": 3, "total_sgd": 600.0},
+                          "after": {"months": 1, "n": 2, "total_sgd": 350.0}})
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_spending_pg.py
+++ b/tests/test_spending_pg.py
@@ -12,7 +12,7 @@ that left uncovered, and every item is a class below:
     old `m[category] = v` assignment relied on without saying so — TestGroupByCardinality;
   * `ROUND(SUM(-amount_sgd),2)` really arrives as something `float()` accepts — TestNumerics;
   * `_where` really composes into valid Postgres, rather than into the string
-    TestWhere asserts on — TestWindow.
+    TestWhere asserts on — TestDateWindow.
 
 `tests/pgtest.py` owns the connection: a throwaway `portfolio_test` database, never the app's,
 and a skip when no server is up. Marked `pg` — `-m "not pg"` deselects the file.
@@ -253,7 +253,11 @@ class TestNumerics(PgCase):
 
 # ---------------- _where composing into valid Postgres ----------------
 
-class TestWindow(PgCase):
+class TestDateWindow(PgCase):
+    """The `frm`/`to` date window — the filter a caller chooses, NOT window()'s spend-trend
+    window, which is a rule the data decides and lives in TestPresenceQuery below. One word,
+    two things; CONTEXT.md's Spending glossary pins both."""
+
     def test_date_window_filters_both_functions(self):
         self.add(D(2023, 12, 31), -10)
         self.add(D(2024, 1, 15), -20)
@@ -392,7 +396,8 @@ class TestPresenceQuery(PgCase):
                          [("dbs", True), ("cc", True), ("hsbc", False)])
         self.assertEqual(got["excluded"],
                          {"before": {"months": 2, "n": 3, "total_sgd": 600.0},
-                          "after": {"months": 1, "n": 2, "total_sgd": 350.0}})
+                          "after": {"months": 1, "n": 2, "total_sgd": 350.0},
+                          "gaps": {"months": 0, "n": 0, "total_sgd": 0.0}})
 
 
 if __name__ == "__main__":

--- a/web/tests/fixtures/api/spending-window.json
+++ b/web/tests/fixtures/api/spending-window.json
@@ -46,6 +46,11 @@
    "months": 1,
    "n": 30,
    "total_sgd": 599.58
+  },
+  "gaps": {
+   "months": 0,
+   "n": 0,
+   "total_sgd": 0.0
   }
  }
 }

--- a/web/tests/fixtures/api/spending-window.json
+++ b/web/tests/fixtures/api/spending-window.json
@@ -1,0 +1,51 @@
+{
+ "start": "2025-09",
+ "end": "2026-06",
+ "gaps": [],
+ "sources": [
+  {
+   "source": "dbs",
+   "first_txn": "2025-01-02",
+   "last_txn": "2026-06-30",
+   "total_sgd": 109412.05,
+   "share": 0.783,
+   "material": true
+  },
+  {
+   "source": "dbs-cc",
+   "first_txn": "2025-08-21",
+   "last_txn": "2026-07-23",
+   "total_sgd": 20600.97,
+   "share": 0.1474,
+   "material": true
+  },
+  {
+   "source": "trust",
+   "first_txn": "2025-08-14",
+   "last_txn": "2026-07-14",
+   "total_sgd": 9223.21,
+   "share": 0.066,
+   "material": true
+  },
+  {
+   "source": "hsbc",
+   "first_txn": "2025-08-22",
+   "last_txn": "2025-11-24",
+   "total_sgd": 496.41,
+   "share": 0.0036,
+   "material": false
+  }
+ ],
+ "excluded": {
+  "before": {
+   "months": 8,
+   "n": 285,
+   "total_sgd": 42718.85
+  },
+  "after": {
+   "months": 1,
+   "n": 30,
+   "total_sgd": 599.58
+  }
+ }
+}

--- a/web/tests/fixtures/manifest.json
+++ b/web/tests/fixtures/manifest.json
@@ -79,6 +79,10 @@
   "file": "spending-trends.json",
   "status": 200
  },
+ "/api/spending/window": {
+  "file": "spending-window.json",
+  "status": 200
+ },
  "/api/spending/years": {
   "file": "spending-years.json",
   "status": 200


### PR DESCRIPTION
Closes #94. Spec: #92 §B (map #74).

`GET /api/spending/window` states, as data, which months the spend-trend chart may draw and
everything its disclosure prose is derived from. It lands before either chart because the
trend's footnote reads off it.

## Against the live ledger

| | |
|---|---|
| Window | **2025-09 → 2026-06**, 10 drawable months, `gaps: []` |
| Inside | **$96,414.21** |
| Excluded — before | 8 months, n=285, $42,718.85 |
| Excluded — after | 1 month (2026-07), n=30, $599.58 |
| Sources | dbs 78.30% · dbs-cc 14.74% · trust 6.60% — all material; hsbc 0.36%, flagged not filtered |

Every figure re-derived from Postgres independently of the code, not read back out of it.

## Shape

Two result sets and a fold, split on portability exactly as §B asks:

- a **portable** per-source coverage query (MIN/MAX/SUM),
- a **Postgres-only** per-source-per-month presence query (`to_char`),
- the rule itself as **`_window_shape`, a pure function** over those two result sets.

So every clause of the rule — the 1% gate, where `start` lands, what makes a month drawable,
what truncates the end and what must not — is tested with no database at all. Only the month
bucketing needs a server. The split is recorded in the module docstring beside the existing one.

`sources` carries immaterial sources **flagged rather than filtered**: a source silently absent
from a payload is how the fourth source stayed invisible in the first place.

## The trends payload is untouched

No new parameter, no change to its fold, no change to the shared WHERE builder. Verified
**byte-identical** against its committed fixture rather than assumed — the only deletion in the
whole diff is a docstring's "six"→"seven".

Its own path rather than a query-string on trends, for the reason #94 gives: a fixture key that
carried a date would go stale the moment the ledger gained a month.

## Three departures from the letter of the spec

Each is commented at the seam it lives on and has its own test.

**1. `gaps` is the closed interval, not "strictly inside".** `end` is drawable by construction
but `start` need not be — first-appearance guarantees every material source has a line *before*
`start` begins, not one *inside* it. Read strictly, an undrawable start month would sit inside
the window and be named nowhere.

**2. The materiality denominator is the dated counted total**, not "all counted spend". Undated
rows cannot make a source present in any month, so a source material on undated money alone
would be required in every month and *no* month would ever be drawable — that empties the chart
permanently rather than protecting it. Moot today (undated is n=0/$0) and it cannot go moot
silently, because `undated()` reports the count this rule is blind to.

**3. `excluded` splits three ways, not two** — `before`, `after`, **`gaps`**. This one exceeds
the spec's verbatim payload block, so #92 §B's shape is now a bucket behind. The reason: the
only subtraction a caller can make is `dated_total - before - after`, which counts every gap
month's spend as money the chart *shows*. A payload carrying `gaps` but not their money makes
the prose wrong the day the list first fires, and this endpoint exists precisely so that prose
is derived rather than typed. Zeros today, for the same reason `gaps` is. What the chart *does*
with a non-empty `gaps` is still out of scope — having the number is not the same as drawing it.

So: `drawn = dated_total - before - after - gaps`, and `off-chart = before + after + gaps`.

## Naming

"Window" was already taken in this module — `summary()` and `transactions()` take a `frm`/`to`
**date window**, a filter the caller chooses, where this is a rule the data decides. Both terms
and `Material source` are now pinned in `CONTEXT.md`'s Spending glossary, the new term is written
out in full at every site, and the pre-existing `TestWindow` in the Postgres suite is
`TestDateWindow` so it stops reading as the test for `window()`.

## Access control

Nothing new — the `/api/spending/` prefix gate already covers the path (401 unauthenticated,
confirmed).

## Testing

| | |
|---|---|
| Python | **406 passed** — 39 in `test_spending.py` (18 new, all pure), 27 in `test_spending_pg.py` (6 new, Postgres-backed) |
| Frontend | **1345 passed, 0 failed**; `baseline.spec.js` unmatched-paths gate green |

The pure suite covers every case #94 enumerates: the 1% gate admitting and rejecting (and
comparing the *raw* share, since 0.996% displays as `0.0100`), a source starting mid-month and
one starting on the 1st, a discontinued source that must not move the end, a material source
absent from the tail that must, an interior absence landing in `gaps` rather than truncating,
single source, and empty ledger — plus the footnote arithmetic computing "outside" from the
**dated** total with undated reported separately.

## Fixture

Captured from the live database via `scripts/capture_web_fixtures.py`, never hand-written, with
the manifest entry and capture-script line added. A full recapture on this machine also churns
`networth-snapshot-*`, prices and dividends — the local DB holds 5 snapshots against the
committed 2 — so that churn was reverted and only the new fixture kept. Every *spending* fixture
came back byte-identical both times, which is independent evidence nothing in the module moved.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added spending-window analytics showing the date range supported by transaction data.
  - Identifies material spending sources and highlights months with missing or incomplete coverage.
  - Reports spending excluded before, after, or within gaps in the analysis window.
  - Added access to spending-window results through the spending data service.

- **Documentation**
  - Added definitions and guidance for date windows, spend-trend windows, material sources, and coverage rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->