### PR TITLE
feat(networth): the band rule, and a write path that admits what it made up (#95)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -122,4 +122,14 @@ _Avoid_: balance, statement
 
 **Catalogue**:
 The single source of truth for which net-worth line items exist and whether each is auto-pulled
-from statements or entered manually.
+from statements or entered manually. Its flags reach **line items only** — the frozen portfolio
+value is not a catalogue row — so every flag-excluding metric excludes only the catalogue side of
+what its name implies.
+
+**Band**:
+The partition of the catalogue the composition chart stacks — derived from the item flags by
+precedence (`is_housing` → `is_cpf` → `is_liquid` → else), never stored. A stored band column
+would be a fourth grouping free to disagree with the three that exist. Four values — `housing`,
+`cpf`, `cash`, `srs` — plus a synthetic `portfolio` that is not a catalogue item at all and is
+synthesised from the snapshot's frozen portfolio value.
+_Avoid_: group (frontend form furniture, deleted), category (that is spending's)

--- a/migrations/versions/b3c4d5e6f7a8_nw_value_source_portfolio_buckets.py
+++ b/migrations/versions/b3c4d5e6f7a8_nw_value_source_portfolio_buckets.py
@@ -1,0 +1,47 @@
+"""net worth write-path provenance: nw_value.source + nw_snapshot.portfolio_*_sgd
+
+Both additions are nullable with no server_default and **nothing is backfilled**. That is the
+point of them, not a shortcut:
+
+  * `nw_value.source` records what the write path *knew* about where a figure came from. Every
+    row written before this column existed was written by a path that recorded nothing, so NULL
+    is the true answer for all of them. Stamping the existing rows `carried` or `statement` would
+    be asserting a provenance nobody can now establish.
+  * `nw_snapshot.portfolio_{cash,cpf,srs}_sgd` are the frozen portfolio's funding-bucket split.
+    A split can only be captured live, against the positions as they stood on the day. For a
+    snapshot already taken, there is no split to recover — only one to invent.
+
+Revision ID: b3c4d5e6f7a8
+Revises: a2b3c4d5e6f7
+Create Date: 2026-08-15 10:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'b3c4d5e6f7a8'
+down_revision: Union[str, Sequence[str], None] = 'a2b3c4d5e6f7'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+MONEY = sa.Numeric(20, 4)
+
+PORTFOLIO_BUCKET_COLUMNS = ("portfolio_cash_sgd", "portfolio_cpf_sgd", "portfolio_srs_sgd")
+
+
+def upgrade() -> None:
+    # No CHECK on the allowed values: the set lives in portfolio.networth.VALUE_SOURCES and is
+    # enforced there, on a column that must stay nullable for every pre-existing row anyway.
+    op.add_column("nw_value", sa.Column("source", sa.String(12), nullable=True))
+    for col in PORTFOLIO_BUCKET_COLUMNS:
+        op.add_column("nw_snapshot", sa.Column(col, MONEY, nullable=True))
+
+
+def downgrade() -> None:
+    for col in PORTFOLIO_BUCKET_COLUMNS:
+        op.drop_column("nw_snapshot", col)
+    op.drop_column("nw_value", "source")

--- a/portfolio/models.py
+++ b/portfolio/models.py
@@ -352,6 +352,12 @@ class NwSnapshot(Base):
     date: Mapped[dt.date] = mapped_column(Date, unique=True, index=True)
     note: Mapped[str | None] = mapped_column(String(256))
     portfolio_value_sgd: Mapped[Decimal] = mapped_column(MONEY, default=0)
+    # The frozen portfolio's funding-bucket split, stamped at capture beside the total. NULL for
+    # every snapshot taken before the columns existed and never backfilled — a bucket split can
+    # only be recorded live, so inventing one for an old snapshot would be fabricated history.
+    portfolio_cash_sgd: Mapped[Decimal | None] = mapped_column(MONEY)
+    portfolio_cpf_sgd: Mapped[Decimal | None] = mapped_column(MONEY)
+    portfolio_srs_sgd: Mapped[Decimal | None] = mapped_column(MONEY)
     created_at: Mapped[dt.datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
 
     values: Mapped[list[NwValue]] = relationship(back_populates="snapshot", cascade="all, delete-orphan")
@@ -367,6 +373,10 @@ class NwValue(Base):
     currency: Mapped[str] = mapped_column(String(3), default="SGD")
     rate_to_sgd: Mapped[Decimal] = mapped_column(RATE, default=1)
     value_sgd: Mapped[Decimal] = mapped_column(MONEY, default=0)
+    # What the write path knew about where this figure came from: statement | carried |
+    # default_zero, or NULL when the caller asserted nothing (the form and the API always do).
+    # See portfolio.networth.VALUE_SOURCES. Nullable and never backfilled.
+    source: Mapped[str | None] = mapped_column(String(12))
 
     snapshot: Mapped[NwSnapshot] = relationship(back_populates="values")
     item: Mapped[NwItem] = relationship()

--- a/portfolio/networth.py
+++ b/portfolio/networth.py
@@ -8,7 +8,11 @@ Metrics (all SGD), with A = sum asset items, L = sum liability items, P = frozen
     net_worth_excl_housing   = net_worth - housing_assets + housing_liabilities
     net_worth_excl_hou_cpf   = net_worth_excl_housing - cpf_assets
 
-fx + value_sgd + portfolio_value_sgd are frozen at capture so history stays stable.
+fx + value_sgd + portfolio_value_sgd are frozen at capture so history stays stable, as is the
+portfolio's funding-bucket split (portfolio_{cash,cpf,srs}_sgd) — nothing draws that yet, but a
+split can only ever be recorded live, so a snapshot taken without one can never grow one.
+
+Bands (`band()`) are the other half: derived from the catalogue flags on every read, never stored.
 """
 from __future__ import annotations
 
@@ -26,14 +30,78 @@ from .models import FxRate, NwItem, NwSnapshot, NwValue
 # can flag which fields still need manual input and the ingest script stays in sync.
 AUTO_CODES = {"tiger_usd", "tiger_sgd", "tiger_hkd", "tiger_vault", "dbs_multiplier", "srs"}
 
+# The four bands a catalogue item can fall into. NOT a stacking order — the composition chart's
+# bottom→top order is the chart's, and it also carries a fifth, `portfolio`, which is no catalogue
+# item at all (it is read off the snapshot's frozen portfolio scalar). This is only the set
+# `band()` may return, so a caller can assert coverage without restating the precedence.
+BANDS = ("housing", "cpf", "cash", "srs")
 
-def live_portfolio_sgd(s: Session) -> Decimal:
-    """Current live investment-portfolio market value in SGD (open positions),
-    the same figure /api/overview reports as market_value_sgd."""
+# The funding buckets a portfolio position can be pooled under (account.funding_bucket). Named
+# here because a snapshot freezes one portfolio_*_sgd column per bucket — add a bucket and the
+# snapshot needs a column, so the two lists have to be changed together.
+FUNDING_BUCKETS = ("cash", "cpf", "srs")
+
+# What `nw_value.source` may say — what the *write path* knew, never what it inferred:
+#   statement    — a statement reported this figure
+#   carried      — no statement covered it, so the prior snapshot's figure was carried forward
+#   default_zero — nobody supplied it, so BR2's zeroing rule fabricated the $0
+# NULL is the fourth and commonest state and is not a gap: it means the caller asserted nothing.
+# The snapshot form deliberately writes NULL rather than deriving `carried`, because a user who
+# reads the HDB valuation, confirms it has not moved and leaves the field alone has *measured*
+# it — a column that said `carried` there would be worse than no column.
+VALUE_SOURCES = ("statement", "carried", "default_zero")
+
+
+def band(it: NwItem) -> str:
+    """Which band of the composition a catalogue item belongs to, by precedence:
+    `is_housing` → housing, `is_cpf` → cpf, `is_liquid` → cash, else srs.
+
+    Derived, never stored. A `band` column would be a fourth grouping free to disagree with the
+    three flags it is derived from, and this is deliberately not a SQL `CASE` ladder or a
+    frontend switch either: the catalogue endpoint is active-only while the composition walks
+    every value unfiltered, so a second copy would silently drop a deactivated item's history
+    out of whichever edge it belonged to.
+
+    Raises on a **non-housing liability**. Three of the composition's cumulative edges equal a
+    summary tile to the cent only because every liability in the catalogue is a housing
+    liability — netted into the Housing band, they cancel there and nowhere else. A car loan or
+    a carried card balance would sit in an asset band as a negative and break that identity
+    without changing a single number's sign, so it fails here instead of drawing wrong."""
+    if it.kind == "liability" and not it.is_housing:
+        raise ValueError(
+            f"non-housing liability in the net-worth catalogue: {it.code!r} ({it.label!r}). "
+            "The composition chart's band edges assume every liability is a housing liability "
+            "(netted into Housing). Give it is_housing, or extend the banding first.")
+    if it.is_housing:
+        return "housing"
+    if it.is_cpf:
+        return "cpf"
+    if it.is_liquid:
+        return "cash"
+    return "srs"
+
+
+def live_portfolio_by_bucket(s: Session) -> dict[str, Decimal]:
+    """Current live investment-portfolio market value in SGD (open positions), split by the
+    funding bucket each position is pooled under. Summed, it is the same figure /api/overview
+    reports as market_value_sgd.
+
+    The split is the primitive and the total is derived from it, rather than the two being
+    computed side by side: `compute()` is a fold over the whole securities ledger, so this walks
+    it once, and a snapshot's three frozen buckets can never fail to add up to the total frozen
+    beside them."""
     from .performance import compute
-    rows = compute(s)
-    total = sum((r["mv_sgd"] for r in rows if r["units"] > 1e-6), 0.0)
-    return Decimal(str(round(total, 4)))
+    out = {b: 0.0 for b in FUNDING_BUCKETS}
+    for r in compute(s):
+        if r["units"] <= 1e-6:
+            continue
+        if r["bucket"] not in out:
+            # Silently dropping it would understate the portfolio by exactly that bucket, and
+            # the total is the number every net-worth metric is built on.
+            raise ValueError(f"position {r['ticker']} is in unknown funding bucket "
+                             f"{r['bucket']!r}; expected one of {FUNDING_BUCKETS}")
+        out[r["bucket"]] += r["mv_sgd"]
+    return {b: Decimal(str(round(v, 4))) for b, v in out.items()}
 
 
 def fx_row_for(s: Session, ccy: str, on_date: dt.date) -> FxRate | None:
@@ -80,16 +148,34 @@ def _frozen_value(s: Session, it: NwItem, v: dict, on_date: dt.date) -> tuple:
     return native, ccy, rate_for(s, ccy, on_date)
 
 
-def _write_value(s: Session, snap_id: int, it: NwItem, native, ccy, rate, existing=None) -> None:
+def _check_source(source: str | None) -> str | None:
+    """A source is a claim about provenance, so an unrecognised one is a caller bug, not a
+    free-text note. Checked in Python rather than by a CHECK constraint because the column must
+    stay nullable for every row written before this existed."""
+    if source is not None and source not in VALUE_SOURCES:
+        raise ValueError(f"unknown nw_value.source {source!r}; expected one of {VALUE_SOURCES} "
+                         "or None")
+    return source
+
+
+def _write_value(s: Session, snap_id: int, it: NwItem, native, ccy, rate, existing=None,
+                 source: str | None = None) -> None:
     """Insert a NwValue for `it` (value_sgd = native*rate), or update its existing row in place.
-    `existing` is an item_id -> NwValue index; None means always insert."""
+    `existing` is an item_id -> NwValue index; None means always insert.
+
+    `source` is assigned on both paths, never merged: re-writing a value replaces what the write
+    path knows about it. That is what clears a stale `default_zero` when a dropped item is
+    finally filled in — leave the old stamp and the item stays in the composition's `dropped`
+    list forever, long after someone supplied the number."""
+    source = _check_source(source)
     row = existing.get(it.id) if existing else None
     if row is None:
         s.add(NwValue(snapshot_id=snap_id, item_id=it.id, native_value=native,
-                      currency=ccy, rate_to_sgd=rate, value_sgd=native * rate))
+                      currency=ccy, rate_to_sgd=rate, value_sgd=native * rate, source=source))
     else:
         row.native_value, row.currency = native, ccy
         row.rate_to_sgd, row.value_sgd = rate, native * rate
+        row.source = source
 
 
 def catalogue(s: Session | None = None) -> list[dict]:
@@ -102,8 +188,8 @@ def _item_dict(i: NwItem) -> dict:
     return {
         "id": i.id, "code": i.code, "label": i.label, "kind": i.kind,
         "currency_default": i.currency_default, "is_liquid": i.is_liquid,
-        "is_housing": i.is_housing, "is_cpf": i.is_cpf, "sort_order": i.sort_order,
-        "is_manual": i.code not in AUTO_CODES,
+        "is_housing": i.is_housing, "is_cpf": i.is_cpf, "band": band(i),
+        "sort_order": i.sort_order, "is_manual": i.code not in AUTO_CODES,
     }
 
 
@@ -193,12 +279,27 @@ def create_snapshot(date: dt.date, values: list[dict], note: str | None = None,
             raise ValueError("net-worth catalogue is empty — run scripts/seed_networth.py")
         supplied = {_resolve_item(items, by_id, v).code: v for v in values}
 
-        snap = NwSnapshot(date=date, note=note, portfolio_value_sgd=live_portfolio_sgd(s))
+        # Frozen beside the total, not instead of it: nothing draws the buckets yet — the
+        # Portfolio band stays one opaque band until they have history — but a bucket split can
+        # only ever be recorded live, so a snapshot captured before they existed can never be
+        # reconstructed. Existing snapshots keep NULL rather than being backfilled with a guess.
+        buckets = live_portfolio_by_bucket(s)
+        snap = NwSnapshot(date=date, note=note,
+                          portfolio_value_sgd=sum(buckets.values(), Decimal(0)),
+                          portfolio_cash_sgd=buckets["cash"],
+                          portfolio_cpf_sgd=buckets["cpf"],
+                          portfolio_srs_sgd=buckets["srs"])
         s.add(snap)
         s.flush()
         for code, it in items.items():
-            native, ccy, rate = _frozen_value(s, it, supplied.get(code, {}), date)
-            _write_value(s, snap.id, it, native, ccy, rate)
+            v = supplied.get(code)
+            native, ccy, rate = _frozen_value(s, it, v or {}, date)
+            # An omitted item is BR2's zeroing rule fabricating the $0 itself, so the row says
+            # so — that stamp is describing what this line just did, not asserting a provenance
+            # it cannot know. A *supplied* value carries only what its caller claims (the
+            # statement ingest names one; the form and the API name nothing).
+            _write_value(s, snap.id, it, native, ccy, rate,
+                         source="default_zero" if v is None else v.get("source"))
         s.commit()
         s.refresh(snap)
         return snapshot_detail(snap)
@@ -221,7 +322,8 @@ def update_snapshot(snap_id: int, values: list[dict], note: str | None = None,
         for v in values:
             it = _resolve_item(items, by_id, v)
             native, ccy, rate = _frozen_value(s, it, v, snap.date)
-            _write_value(s, snap.id, it, native, ccy, rate, existing)   # insert if added after snapshot
+            _write_value(s, snap.id, it, native, ccy, rate, existing,   # insert if added after snapshot
+                         source=v.get("source"))
         if note is not None:
             snap.note = note
         s.commit()

--- a/scripts/promote_networth_snapshots.py
+++ b/scripts/promote_networth_snapshots.py
@@ -8,11 +8,13 @@ neither environment has ever shown the whole series. This copies the missing sna
 one store holds all five.
 
 **Copy, never recompute.** `networth.create_snapshot` cannot do this job: it stamps *today's*
-`live_portfolio_sgd()` and derives `value_sgd` from native x rate at the target's FX. Both are
-frozen money captured at the snapshot date, and the target store has neither the prices nor the
+`live_portfolio_by_bucket()` and derives `value_sgd` from native x rate at the target's FX. Both
+are frozen money captured at the snapshot date, and the target store has neither the prices nor the
 rates that produced them — recomputing would rewrite history to the value of the day it ran. So
-every one of `native_value`, `currency`, `rate_to_sgd`, `value_sgd`, `portfolio_value_sgd`,
-`note` and `created_at` is carried over verbatim.
+every one of `native_value`, `currency`, `rate_to_sgd`, `value_sgd`, `source`,
+`portfolio_value_sgd`, `portfolio_{cash,cpf,srs}_sgd`, `note` and `created_at` is carried over
+verbatim — including where that value is NULL, which is what the two newest columns hold for
+every snapshot taken before they existed.
 
 Items are matched by **code**, never by id: the two stores keep their own `nw_item` id sequences,
 and a copied `item_id` would land a value on the wrong band or on nothing at all. The catalogues
@@ -169,9 +171,12 @@ def plan(src: Session, tgt: Session) -> list[dict]:
             "note": snap.note,
             "created_at": snap.created_at,
             "portfolio_value_sgd": snap.portfolio_value_sgd,
+            "portfolio_cash_sgd": snap.portfolio_cash_sgd,
+            "portfolio_cpf_sgd": snap.portfolio_cpf_sgd,
+            "portfolio_srs_sgd": snap.portfolio_srs_sgd,
             "values": [{"code": v.item.code, "native_value": v.native_value,
                         "currency": v.currency, "rate_to_sgd": v.rate_to_sgd,
-                        "value_sgd": v.value_sgd}
+                        "value_sgd": v.value_sgd, "source": v.source}
                        for v in sorted(snap.values, key=lambda v: v.item.sort_order)],
             "fx": _fx_rows(src, snap),
         })
@@ -182,10 +187,14 @@ def series_fingerprint(s: Session) -> dict:
     """Every snapshot in a store reduced to a comparable tuple, keyed by date: its id, the frozen
     snapshot fields, and every value row. The `id` is in there deliberately — "renumbered" is one
     of the three things the promotion promises not to do, and it is the one a field-by-field money
-    comparison would miss entirely."""
+    comparison would miss entirely.
+
+    `v.source or ""` only so the tuples stay sortable — Python will not order None against a str.
+    Nothing is lost: "" is not a source any writer produces, so it collides with no real value."""
     return {sn.date: (sn.id, sn.note, sn.portfolio_value_sgd, sn.created_at,
+                      sn.portfolio_cash_sgd, sn.portfolio_cpf_sgd, sn.portfolio_srs_sgd,
                       tuple(sorted((v.item.code, v.native_value, v.currency, v.rate_to_sgd,
-                                    v.value_sgd) for v in sn.values)))
+                                    v.value_sgd, v.source or "") for v in sn.values)))
             for sn in s.scalars(select(NwSnapshot))}
 
 
@@ -217,7 +226,10 @@ def write_snapshots(tgt: Session, rows: list[dict]) -> None:
             tgt.add(FxRate(date=f["date"], currency=f["currency"],
                            rate_to_sgd=f["rate_to_sgd"]))
         snap = NwSnapshot(date=r["date"], note=r["note"],
-                          portfolio_value_sgd=r["portfolio_value_sgd"])
+                          portfolio_value_sgd=r["portfolio_value_sgd"],
+                          portfolio_cash_sgd=r["portfolio_cash_sgd"],
+                          portfolio_cpf_sgd=r["portfolio_cpf_sgd"],
+                          portfolio_srs_sgd=r["portfolio_srs_sgd"])
         if r.get("created_at") is not None:
             # When it was captured, not when it was copied. Guarded rather than assigned blind:
             # the column is NOT NULL with only a server_default, so passing a source NULL
@@ -229,7 +241,8 @@ def write_snapshots(tgt: Session, rows: list[dict]) -> None:
         for v in r["values"]:
             tgt.add(NwValue(snapshot_id=snap.id, item_id=items[v["code"]].id,
                             native_value=v["native_value"], currency=v["currency"],
-                            rate_to_sgd=v["rate_to_sgd"], value_sgd=v["value_sgd"]))
+                            rate_to_sgd=v["rate_to_sgd"], value_sgd=v["value_sgd"],
+                            source=v["source"]))
     tgt.flush()
     drift = fingerprint_drift(before, series_fingerprint(tgt))
     if drift:
@@ -274,11 +287,17 @@ def series_expectation(s: Session, count: int | None = None,
 
 # What must survive the copy untouched, per row. `native_value` and `currency` are here as much
 # as the money is: a rate that round-trips against a rewritten native is still a rewritten value.
-VALUE_FIELDS = ("native_value", "currency", "rate_to_sgd", "value_sgd")
+# `source` is here because it is the one field a copy is *tempted* to recompute: the promoted
+# snapshot's items were all supplied, so re-deriving would stamp them all NULL and lose exactly
+# the `default_zero` marks the composition endpoint reads to find a dropped payload.
+VALUE_FIELDS = ("native_value", "currency", "rate_to_sgd", "value_sgd", "source")
 # `created_at` is here because `apply` carries it deliberately — when the snapshot was captured,
 # not when it was copied. Left out, a snapshot that arrived stamped with the copy time would read
-# back clean and the promotion's "verbatim" claim would go unchecked.
-SNAPSHOT_FIELDS = ("note", "portfolio_value_sgd", "created_at")
+# back clean and the promotion's "verbatim" claim would go unchecked. The portfolio buckets are
+# frozen money like the total, and NULL on every snapshot taken before they existed — carrying
+# the NULL is as much the point as carrying a figure, since the alternative is inventing a split.
+SNAPSHOT_FIELDS = ("note", "portfolio_value_sgd", "created_at",
+                   "portfolio_cash_sgd", "portfolio_cpf_sgd", "portfolio_srs_sgd")
 
 
 def frozen_money_diff(src: Session, tgt: Session) -> list[str]:

--- a/scripts/snapshot_from_statements.py
+++ b/scripts/snapshot_from_statements.py
@@ -11,6 +11,11 @@ Sources (authoritative for the listed nw_item codes):
 All other catalogue items (posb, ibkr_sgd, cpf_*, hdb, home_loan*) are carried
 forward unchanged from the most recent existing snapshot.
 
+Provenance: every written value carries its `nw_value.source` — `statement`, `carried` or
+`default_zero`. This script is the only writer that names one, because it is the only writer
+that *knows*: it decided between the three itself. The snapshot form and the API write NULL,
+because a user leaving an unchanged field alone has confirmed the figure, not carried it.
+
 FX: create_snapshot freezes rate_to_sgd via networth.rate_for(date), which needs an
 fx_rate row dated <= the snapshot date. If none exists for a needed currency, we
 backfill one from the nearest later fx_rate (source='carry-back') so history stays usable.
@@ -137,6 +142,29 @@ def ensure_fx(s, currencies: set[str], on_date: dt.date) -> list[str]:
     return notes
 
 
+def plan_values(items: dict, statement_vals: dict, carry: dict) -> list[dict]:
+    """One entry per active catalogue item: the figure to write and where it came from.
+
+    `source` is a `nw_value.source` value, not display text (networth.VALUE_SOURCES). The script
+    has computed this decision since it was written and used to print it into the dry-run table
+    and drop it — so a committed snapshot could not say which of its numbers a bank had actually
+    reported and which were last month's carried forward untouched. `statement` outranks `carry`
+    for the same item: the statement is the fresher measurement, and recording it as carried
+    would understate what is confirmed."""
+    out = []
+    for code, it in items.items():
+        if code in statement_vals:
+            source, d = "statement", statement_vals[code]
+        elif code in carry:
+            source, d = "carried", carry[code]
+        else:
+            source, d = "default_zero", {"native_value": Decimal(0),
+                                         "currency": it.currency_default or "SGD"}
+        out.append({"code": code, "native_value": d["native_value"],
+                    "currency": d["currency"], "source": source})
+    return out
+
+
 def month_end(yyyymm: str) -> dt.date:
     y, m = int(yyyymm[:4]), int(yyyymm[4:6])
     return dt.date(y, m, calendar.monthrange(y, m)[1])
@@ -178,17 +206,7 @@ def build_snapshot(s, snap_date: dt.date, dbs_path: str, tiger_path: str, commit
                 carry[v.item.code] = {"native_value": v.native_value, "currency": v.currency}
 
     items = {i.code: i for i in s.scalars(select(NwItem).where(NwItem.active)).all()}
-    values = []
-    for code in items:
-        if code in statement_vals:
-            src, d = "statement", statement_vals[code]
-        elif code in carry:
-            src, d = f"carry<-{prev.date}", carry[code]
-        else:
-            src, d = "default 0", {"native_value": Decimal(0),
-                                   "currency": items[code].currency_default or "SGD"}
-        values.append({"code": code, "native_value": d["native_value"],
-                       "currency": d["currency"], "_src": src})
+    values = plan_values(items, statement_vals, carry)
 
     fx_notes = ensure_fx(s, {v["currency"] for v in values}, snap_date)
 
@@ -199,10 +217,14 @@ def build_snapshot(s, snap_date: dt.date, dbs_path: str, tiger_path: str, commit
         print(f"carry-forward base: snapshot {prev.date}")
     for n in fx_notes:
         print(f"  ! {n}")
-    print(f"\n{'code':<18}{'native':>16} {'ccy':<4} {'src'}")
+    print(f"\n{'code':<18}{'native':>16} {'ccy':<4} {'source'}")
     print("-" * 60)
     for v in sorted(values, key=lambda v: items[v["code"]].sort_order):
-        print(f"{v['code']:<18}{float(v['native_value']):>16,.2f} {v['currency']:<4} {v['_src']}")
+        # The column records the provenance; the preview also names *which* snapshot a carry came
+        # from — the one thing a dry-run reader wants that the column deliberately omits. `prev`
+        # is never None here: `carry` is only populated when there is one.
+        src = f"carried <- {prev.date}" if v["source"] == "carried" else v["source"]
+        print(f"{v['code']:<18}{float(v['native_value']):>16,.2f} {v['currency']:<4} {src}")
 
     if not commit:
         print("\nDRY-RUN. Re-run with --commit to write.")
@@ -210,11 +232,10 @@ def build_snapshot(s, snap_date: dt.date, dbs_path: str, tiger_path: str, commit
 
     s.commit()  # persist any fx backfill before create_snapshot opens its own work
     note = f"statements: tiger {os.path.basename(tiger_path)} + dbs {os.path.basename(dbs_path)} (as at {dbs_asat})"
-    res = networth.create_snapshot(
-        snap_date,
-        [{"code": v["code"], "native_value": v["native_value"], "currency": v["currency"]}
-         for v in values],
-        note=note, s=s)
+    # `values` is passed straight through rather than re-projected: the projection that used to
+    # sit here existed only to strip a display-only key, and it is exactly the shape that dropped
+    # the provenance on the floor for as long as this script has run.
+    res = networth.create_snapshot(snap_date, values, note=note, s=s)
     print("\nCOMMITTED. Snapshot metrics:")
     for k in ("net_worth", "total_assets", "total_liabilities", "liquid_assets",
               "net_worth_excl_housing", "net_worth_excl_housing_cpf", "portfolio_value_sgd"):

--- a/tests/test_networth.py
+++ b/tests/test_networth.py
@@ -104,7 +104,9 @@ class FxAndCreateTest(unittest.TestCase):
         self.s.execute(text("INSERT INTO fx_rate(date, currency, rate_to_sgd) VALUES "
                             "('2026-05-01','USD',1.33),('2026-06-15','USD',1.36)"))
         self.s.commit()
+        original_live_portfolio_by_bucket = nw.live_portfolio_by_bucket
         nw.live_portfolio_by_bucket = _no_portfolio      # avoid heavy compute()
+        self.addCleanup(setattr, nw, 'live_portfolio_by_bucket', original_live_portfolio_by_bucket)
 
     def test_rate_sgd_is_one(self):
         self.assertEqual(nw.rate_for(self.s, "SGD", dt.date(2026, 6, 1)), Decimal(1))
@@ -265,7 +267,9 @@ class TestEmptyCatalogue(unittest.TestCase):
 
     def setUp(self):
         self.s = make_session()          # schema only: nw_item deliberately left empty
+        original_live_portfolio_by_bucket = nw.live_portfolio_by_bucket
         nw.live_portfolio_by_bucket = _no_portfolio
+        self.addCleanup(setattr, nw, 'live_portfolio_by_bucket', original_live_portfolio_by_bucket)
 
     def tearDown(self):
         self.s.close()
@@ -297,7 +301,9 @@ class SourceTest(unittest.TestCase):
         self.s.execute(text("INSERT INTO fx_rate(date, currency, rate_to_sgd) VALUES "
                             "('2026-06-01','USD',1.30)"))
         self.s.commit()
+        original_live_portfolio_by_bucket = nw.live_portfolio_by_bucket
         nw.live_portfolio_by_bucket = _no_portfolio
+        self.addCleanup(setattr, nw, 'live_portfolio_by_bucket', original_live_portfolio_by_bucket)
 
     def tearDown(self):
         self.s.close()
@@ -384,7 +390,9 @@ class PortfolioBucketsTest(unittest.TestCase):
         self.s.commit()
         self.split = {"cash": Decimal("700000"), "cpf": Decimal("200000"),
                       "srs": Decimal("129006.95")}
+        original_live_portfolio_by_bucket = nw.live_portfolio_by_bucket
         nw.live_portfolio_by_bucket = lambda s: dict(self.split)
+        self.addCleanup(setattr, nw, 'live_portfolio_by_bucket', original_live_portfolio_by_bucket)
 
     def tearDown(self):
         self.s.close()
@@ -420,7 +428,9 @@ class TestSeededCatalogueStillWorks(unittest.TestCase):
         self.s.execute(text("INSERT INTO fx_rate(date, currency, rate_to_sgd) VALUES "
                             "('2026-07-01','USD',1.28)"))     # tiger_usd is a USD item
         self.s.commit()
+        original_live_portfolio_by_bucket = nw.live_portfolio_by_bucket
         nw.live_portfolio_by_bucket = _no_portfolio
+        self.addCleanup(setattr, nw, 'live_portfolio_by_bucket', original_live_portfolio_by_bucket)
 
     def tearDown(self):
         self.s.close()

--- a/tests/test_networth.py
+++ b/tests/test_networth.py
@@ -22,13 +22,24 @@ def make_session():
     return sessionmaker(bind=eng, future=True)()
 
 
+def _no_portfolio(s):
+    """Stands in for `live_portfolio_by_bucket`, which folds the whole securities ledger.
+    Patched in wherever a test only needs create_snapshot to get *a* portfolio figure; the
+    split, not the total, because the total is derived from the split."""
+    return {b: Decimal("0") for b in nw.FUNDING_BUCKETS}
+
+
 def seed_items(s):
+    # One item in each of the four bands, deliberately: `srs` is the band no flag selects (it is
+    # the else-arm of the precedence), so a catalogue without an unflagged asset covers 3 of 4 and
+    # every test downstream of the banding inherits the hole.
     cat = [
-        ("posb", "asset", "SGD", True, False, False),
-        ("tiger_usd", "asset", "USD", True, False, False),
-        ("cpf_oa", "asset", "SGD", False, False, True),
-        ("hdb", "asset", "SGD", False, True, False),
-        ("home_loan", "liability", "SGD", False, True, False),
+        ("posb", "asset", "SGD", True, False, False),           # cash
+        ("tiger_usd", "asset", "USD", True, False, False),      # cash
+        ("srs", "asset", "SGD", False, False, False),           # srs — no flag set
+        ("cpf_oa", "asset", "SGD", False, False, True),         # cpf
+        ("hdb", "asset", "SGD", False, True, False),            # housing
+        ("home_loan", "liability", "SGD", False, True, False),  # housing
         ("home_loan_accrued", "liability", "SGD", False, True, False),
     ]
     for i, (code, kind, ccy, liq, hou, cpf) in enumerate(cat):
@@ -93,7 +104,7 @@ class FxAndCreateTest(unittest.TestCase):
         self.s.execute(text("INSERT INTO fx_rate(date, currency, rate_to_sgd) VALUES "
                             "('2026-05-01','USD',1.33),('2026-06-15','USD',1.36)"))
         self.s.commit()
-        nw.live_portfolio_sgd = lambda s: Decimal("0")   # avoid heavy compute()
+        nw.live_portfolio_by_bucket = _no_portfolio      # avoid heavy compute()
 
     def test_rate_sgd_is_one(self):
         self.assertEqual(nw.rate_for(self.s, "SGD", dt.date(2026, 6, 1)), Decimal(1))
@@ -127,8 +138,8 @@ class FxAndCreateTest(unittest.TestCase):
                                 {"code": "tiger_usd", "native_value": 100, "currency": "USD"}],
                                s=self.s)
         self.assertAlmostEqual(d["total_assets"], 5000 + 100 * 1.36, 2)
-        # the other 4 catalogue items defaulted to 0 -> still present
-        self.assertEqual(len(d["values"]), 6)
+        # the other 5 catalogue items defaulted to 0 -> still present
+        self.assertEqual(len(d["values"]), 7)
 
     def test_duplicate_date_rejected(self):
         nw.create_snapshot(dt.date(2026, 6, 20), [], s=self.s)
@@ -178,8 +189,72 @@ class ManualFlagTest(unittest.TestCase):
         self.assertFalse(by["tiger_usd"]["is_manual"])  # in AUTO_CODES
 
 
-if __name__ == "__main__":
-    unittest.main(verbosity=2)
+class BandTest(unittest.TestCase):
+    """The one place that decides which band a catalogue item belongs to. Precedence, not a set
+    of independent tests: an item can carry several flags, and only the first arm may win."""
+
+    def setUp(self):
+        self.s = make_session()
+        seed_items(self.s)
+
+    def item(self, **flags):
+        return NwItem(code="x", label="x", kind=flags.pop("kind", "asset"),
+                      currency_default="SGD", is_liquid=flags.get("liquid", False),
+                      is_housing=flags.get("housing", False), is_cpf=flags.get("cpf", False))
+
+    def test_each_flag_selects_its_band(self):
+        self.assertEqual(nw.band(self.item(housing=True)), "housing")
+        self.assertEqual(nw.band(self.item(cpf=True)), "cpf")
+        self.assertEqual(nw.band(self.item(liquid=True)), "cash")
+
+    def test_no_flag_falls_through_to_srs(self):
+        self.assertEqual(nw.band(self.item()), "srs")
+
+    def test_housing_outranks_cpf_and_liquid(self):
+        self.assertEqual(nw.band(self.item(housing=True, cpf=True, liquid=True)), "housing")
+
+    def test_cpf_outranks_liquid(self):
+        # CPF OA is spendable on a flat, so a catalogue that ever flags it liquid must still
+        # band it cpf — otherwise the housing edge and the CPF edge both move.
+        self.assertEqual(nw.band(self.item(cpf=True, liquid=True)), "cpf")
+
+    def test_bands_declares_exactly_the_four_values_band_can_return(self):
+        produced = {nw.band(self.item(**f)) for f in
+                    ({}, {"liquid": True}, {"cpf": True}, {"housing": True})}
+        self.assertEqual(produced, set(nw.BANDS))
+
+    def test_non_housing_liability_raises(self):
+        """A car loan or a carried card balance. Every cumulative edge the composition chart
+        draws holds only because the catalogue's liabilities are all housing liabilities; a
+        non-housing one breaks the identity silently, so band() refuses to answer at all."""
+        with self.assertRaises(ValueError) as cm:
+            nw.band(self.item(kind="liability"))
+        self.assertIn("liability", str(cm.exception))
+
+    def test_a_non_housing_liability_in_the_catalogue_raises(self):
+        self.s.add(NwItem(code="car_loan", label="Car Loan", kind="liability",
+                          currency_default="SGD", sort_order=99, active=True))
+        self.s.commit()
+        with self.assertRaises(ValueError) as cm:
+            nw.catalogue(self.s)
+        self.assertIn("car_loan", str(cm.exception))
+
+    def test_catalogue_carries_band_on_every_item(self):
+        items = nw.catalogue(self.s)
+        self.assertTrue(all("band" in i for i in items))
+        by = {i["code"]: i["band"] for i in items}
+        self.assertEqual(by, {"posb": "cash", "tiger_usd": "cash", "srs": "srs",
+                              "cpf_oa": "cpf", "hdb": "housing", "home_loan": "housing",
+                              "home_loan_accrued": "housing"})
+
+    def test_the_seed_catalogue_covers_all_four_bands(self):
+        """scripts/seed_networth.py is the real catalogue; the fixture above mirrors it. Neither
+        may lose a band — a band with no item draws as a flat zero rather than as absent."""
+        from scripts.seed_networth import CATALOGUE
+        produced = {nw.band(NwItem(code=code, label=label, kind=kind, currency_default=ccy,
+                                   is_liquid=liq, is_housing=hou, is_cpf=cpf))
+                    for (code, label, kind, ccy, liq, hou, cpf) in CATALOGUE}
+        self.assertEqual(produced, set(nw.BANDS))
 
 
 class TestEmptyCatalogue(unittest.TestCase):
@@ -190,7 +265,7 @@ class TestEmptyCatalogue(unittest.TestCase):
 
     def setUp(self):
         self.s = make_session()          # schema only: nw_item deliberately left empty
-        nw.live_portfolio_sgd = lambda s: Decimal("0")
+        nw.live_portfolio_by_bucket = _no_portfolio
 
     def tearDown(self):
         self.s.close()
@@ -208,6 +283,136 @@ class TestEmptyCatalogue(unittest.TestCase):
         self.assertEqual(self.s.query(NwSnapshot).count(), 0)
 
 
+class SourceTest(unittest.TestCase):
+    """`nw_value.source` — what the write path knew about where a number came from.
+
+    Only ever what the code can *assert*, never what it can guess. The statement ingest names
+    all three because it computed them; the form and the API name nothing, because a user who
+    looks at the HDB valuation, sees it has not moved and leaves the field alone has measured
+    it — stamping that `carried` would be worse than leaving it null."""
+
+    def setUp(self):
+        self.s = make_session()
+        seed_items(self.s)
+        self.s.execute(text("INSERT INTO fx_rate(date, currency, rate_to_sgd) VALUES "
+                            "('2026-06-01','USD',1.30)"))
+        self.s.commit()
+        nw.live_portfolio_by_bucket = _no_portfolio
+
+    def tearDown(self):
+        self.s.close()
+
+    def sources(self, snap_id):
+        return {v.item.code: v.source for v in
+                self.s.query(NwValue).filter(NwValue.snapshot_id == snap_id).all()}
+
+    def test_an_omitted_item_is_stamped_default_zero(self):
+        """Not a reversal of the form's silence: an omitted item is BR2's zeroing rule
+        fabricating the $0 itself, so the stamp describes what this code just did."""
+        d = nw.create_snapshot(dt.date(2026, 6, 1),
+                               [{"code": "posb", "native_value": 5000}], s=self.s)
+        src = self.sources(d["id"])
+        self.assertEqual(src["cpf_oa"], "default_zero")
+        self.assertEqual(src["hdb"], "default_zero")
+
+    def test_a_supplied_value_is_stamped_null(self):
+        d = nw.create_snapshot(dt.date(2026, 6, 1),
+                               [{"code": "posb", "native_value": 5000}], s=self.s)
+        self.assertIsNone(self.sources(d["id"])["posb"])
+
+    def test_a_supplied_zero_is_not_default_zero(self):
+        """The distinction the column exists for: a real $0 the user typed, versus a $0 nobody
+        supplied. Indistinguishable in `value_sgd`, opposite in meaning."""
+        d = nw.create_snapshot(dt.date(2026, 6, 1),
+                               [{"code": "posb", "native_value": 0}], s=self.s)
+        src = self.sources(d["id"])
+        self.assertIsNone(src["posb"])                     # measured as zero
+        self.assertEqual(src["cpf_oa"], "default_zero")    # fabricated as zero
+
+    def test_a_caller_supplied_source_is_written_through(self):
+        """The statement ingest's path: it computed statement / carried / default_zero for every
+        item and used to print them and throw them away."""
+        d = nw.create_snapshot(dt.date(2026, 6, 1), [
+            {"code": "posb", "native_value": 100, "source": "carried"},
+            {"code": "tiger_usd", "native_value": 200, "currency": "USD", "source": "statement"},
+            {"code": "hdb", "native_value": 0, "source": "default_zero"},
+        ], s=self.s)
+        src = self.sources(d["id"])
+        self.assertEqual(src["posb"], "carried")
+        self.assertEqual(src["tiger_usd"], "statement")
+        self.assertEqual(src["hdb"], "default_zero")
+
+    def test_the_api_request_model_carries_no_source_field(self):
+        """The API is a form, not a statement reader — it has nothing it can claim about where a
+        figure came from, so `source` is not on its wire shape at all. A client that sends one
+        has it dropped rather than honoured, which is what makes "the API writes null" a property
+        of the boundary rather than of the handler remembering to."""
+        from server.main import NwValueIn          # local: this file is otherwise DB-only
+        v = NwValueIn(**{"code": "posb", "native_value": 1, "source": "statement"})
+        self.assertNotIn("source", v.model_dump())
+
+    def test_an_unknown_source_is_refused(self):
+        with self.assertRaises(ValueError) as cm:
+            nw.create_snapshot(dt.date(2026, 6, 1),
+                               [{"code": "posb", "native_value": 1, "source": "guessed"}],
+                               s=self.s)
+        self.assertIn("guessed", str(cm.exception))
+
+    def test_updating_a_value_clears_a_stale_default_zero(self):
+        """Filling a dropped item in is exactly how it stops being dropped. Leaving the stamp
+        would keep it in the composition endpoint's `dropped` list forever."""
+        d = nw.create_snapshot(dt.date(2026, 6, 1), [], s=self.s)
+        self.assertEqual(self.sources(d["id"])["cpf_oa"], "default_zero")
+        nw.update_snapshot(d["id"], [{"code": "cpf_oa", "native_value": 50000}], s=self.s)
+        self.assertIsNone(self.sources(d["id"])["cpf_oa"])
+
+    def test_update_does_not_stamp_items_it_left_alone(self):
+        d = nw.create_snapshot(dt.date(2026, 6, 1), [], s=self.s)
+        nw.update_snapshot(d["id"], [{"code": "cpf_oa", "native_value": 50000}], s=self.s)
+        self.assertEqual(self.sources(d["id"])["hdb"], "default_zero")   # untouched
+
+
+class PortfolioBucketsTest(unittest.TestCase):
+    """The Portfolio band stays one opaque band until these have history. Recording them at
+    capture is what lets it be split later without anyone fabricating the earlier points."""
+
+    def setUp(self):
+        self.s = make_session()
+        seed_items(self.s)
+        self.s.execute(text("INSERT INTO fx_rate(date, currency, rate_to_sgd) VALUES "
+                            "('2026-06-01','USD',1.30)"))   # tiger_usd needs a frozen rate at 0
+        self.s.commit()
+        self.split = {"cash": Decimal("700000"), "cpf": Decimal("200000"),
+                      "srs": Decimal("129006.95")}
+        nw.live_portfolio_by_bucket = lambda s: dict(self.split)
+
+    def tearDown(self):
+        self.s.close()
+
+    def test_the_three_buckets_are_stamped_at_capture(self):
+        d = nw.create_snapshot(dt.date(2026, 6, 1), [], s=self.s)
+        snap = self.s.get(NwSnapshot, d["id"])
+        self.assertEqual(snap.portfolio_cash_sgd, Decimal("700000"))
+        self.assertEqual(snap.portfolio_cpf_sgd, Decimal("200000"))
+        self.assertEqual(snap.portfolio_srs_sgd, Decimal("129006.95"))
+
+    def test_the_buckets_sum_to_the_frozen_total(self):
+        """Not a coincidence to be checked per-snapshot later: the total is derived from the
+        split, so a bucket that goes missing shows up in the total too."""
+        d = nw.create_snapshot(dt.date(2026, 6, 1), [], s=self.s)
+        snap = self.s.get(NwSnapshot, d["id"])
+        self.assertEqual(snap.portfolio_cash_sgd + snap.portfolio_cpf_sgd
+                         + snap.portfolio_srs_sgd, snap.portfolio_value_sgd)
+        self.assertAlmostEqual(d["portfolio_value_sgd"], 1029006.95, 2)
+
+    def test_update_leaves_the_frozen_buckets_alone(self):
+        d = nw.create_snapshot(dt.date(2026, 6, 1), [], s=self.s)
+        self.split = {"cash": Decimal("1"), "cpf": Decimal("1"), "srs": Decimal("1")}
+        nw.update_snapshot(d["id"], [{"code": "posb", "native_value": 10}], s=self.s)
+        snap = self.s.get(NwSnapshot, d["id"])
+        self.assertEqual(snap.portfolio_cash_sgd, Decimal("700000"))
+
+
 class TestSeededCatalogueStillWorks(unittest.TestCase):
     def setUp(self):
         self.s = make_session()
@@ -215,7 +420,7 @@ class TestSeededCatalogueStillWorks(unittest.TestCase):
         self.s.execute(text("INSERT INTO fx_rate(date, currency, rate_to_sgd) VALUES "
                             "('2026-07-01','USD',1.28)"))     # tiger_usd is a USD item
         self.s.commit()
-        nw.live_portfolio_sgd = lambda s: Decimal("0")
+        nw.live_portfolio_by_bucket = _no_portfolio
 
     def tearDown(self):
         self.s.close()
@@ -226,3 +431,7 @@ class TestSeededCatalogueStillWorks(unittest.TestCase):
                                s=self.s)
         self.assertEqual(len(d["values"]), n_items)
         self.assertGreater(n_items, 0)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/test_networth_pg.py
+++ b/tests/test_networth_pg.py
@@ -7,9 +7,11 @@ is repeated here. What it cannot cover is the trade-off underneath it — the sa
 issue #53 raised for spending, which is why this file exists beside tests/test_spending_pg.py
 and shares its harness. Unlike spending, networth has no Postgres-only SQL; it has
 Postgres-only *types*. SQLite has no numeric — `Numeric(20,4)` round-trips through a float —
-and its `Date` is text. So three things go untested there, and only three are here:
+and its `Date` is text. So four things go untested there, and only four are here:
 
   * frozen money keeps four decimal places through the column, exactly;
+  * the same, for the snapshot's frozen portfolio bucket split, which additionally has to still
+    add up to the total beside it after the round trip;
   * `rate_for`'s raw `date <= :d ORDER BY date DESC` compares dates as dates;
   * one-snapshot-per-date is enforced by the schema, not only by create_snapshot's SELECT.
 
@@ -44,21 +46,24 @@ class PgCase(pgtest.Case):
         # compute() over the whole securities ledger is not what any of this is about, and the
         # catalogue below has no positions to price. Restored in tearDown — patching the module
         # global permanently would hand the stub to every later test in the same process.
-        self._live = nw.live_portfolio_sgd
-        nw.live_portfolio_sgd = lambda s: Decimal("0")
+        self._live = nw.live_portfolio_by_bucket
+        nw.live_portfolio_by_bucket = lambda s: {b: Decimal("0") for b in nw.FUNDING_BUCKETS}
         self.seed_items()
         # create_snapshot writes a row for EVERY catalogue item, and an item defaulting to USD
         # needs a frozen rate even when its value is 0 — BR4 raises rather than assume 1.
         self.add_rate(dt.date(2026, 1, 1), "USD", Decimal("1.3456"))
 
     def tearDown(self):
-        nw.live_portfolio_sgd = self._live
+        nw.live_portfolio_by_bucket = self._live
         super().tearDown()
 
     def seed_items(self):
+        # `srs` is here for the band it covers, not for its value: it is the only item no flag
+        # selects, so a catalogue without one exercises 3 of the 4 bands.
         for i, (code, kind, ccy, liq, hou, cpf) in enumerate([
                 ("posb", "asset", "SGD", True, False, False),
                 ("tiger_usd", "asset", "USD", True, False, False),
+                ("srs", "asset", "SGD", False, False, False),
                 ("cpf_oa", "asset", "SGD", False, False, True),
                 ("hdb", "asset", "SGD", False, True, False),
                 ("home_loan", "liability", "SGD", False, True, False)]):
@@ -86,6 +91,23 @@ class TestFrozenMoney(PgCase):
             "WHERE i.code = 'tiger_usd'")).scalar()
         self.assertEqual(v, Decimal("1346.2728"))
         self.assertIsInstance(v, Decimal)          # numeric, not the float SQLite hands back
+
+    def test_the_portfolio_buckets_keep_four_decimals_and_still_sum_to_the_total(self):
+        """The buckets are frozen money like every other figure on the snapshot, and they exist
+        so the Portfolio band can be split later without anyone fabricating history — which only
+        works if what comes back out of the columns still adds up to the total beside them.
+        SQLite's `Numeric` round-trips through a float and would hide a quantize either way."""
+        nw.live_portfolio_by_bucket = lambda s: {"cash": Decimal("700000.1234"),
+                                                 "cpf": Decimal("200000.5678"),
+                                                 "srs": Decimal("129006.9500")}
+        nw.create_snapshot(dt.date(2026, 6, 1), [], s=self.s)
+        row = self.s.execute(text(
+            "SELECT portfolio_cash_sgd, portfolio_cpf_sgd, portfolio_srs_sgd, "
+            "portfolio_value_sgd FROM nw_snapshot")).one()
+        self.assertEqual(row[0], Decimal("700000.1234"))
+        self.assertEqual(row[1], Decimal("200000.5678"))
+        self.assertEqual(row[2], Decimal("129006.9500"))
+        self.assertEqual(row[0] + row[1] + row[2], row[3])
 
     def test_metrics_reconcile_after_a_round_trip(self):
         # Read back in a session that never saw the write: every figure comes off the column,

--- a/tests/test_promote_networth.py
+++ b/tests/test_promote_networth.py
@@ -227,6 +227,54 @@ class ApplyTest(Stores):
         self.assertEqual(self.promoted("2026-06-21").portfolio_value_sgd, Decimal("1029006.9500"))
         self.assertEqual(self.promoted("2026-06-30").portfolio_value_sgd, Decimal("1117722.2500"))
 
+    def test_write_path_provenance_is_carried_rather_than_re_derived(self):
+        """`nw_value.source` is the field a copy is most tempted to recompute: every value
+        promotion writes was supplied to it, so re-deriving would stamp them all NULL and lose
+        exactly the `default_zero` marks that say a payload was dropped."""
+        snap = self.src.scalar(select(NwSnapshot).where(NwSnapshot.date == dt.date(2026, 6, 21)))
+        for v in snap.values:
+            v.source = {"tiger_usd": "statement", "cpf_oa": "default_zero"}.get(v.item.code)
+        self.src.commit()
+        self.apply()
+        got = {v.item.code: v.source for v in self.promoted("2026-06-21").values}
+        self.assertEqual(got["tiger_usd"], "statement")
+        self.assertEqual(got["cpf_oa"], "default_zero")
+        self.assertIsNone(got["posb"])            # NULL is a value too, and it travels as one
+
+    def test_the_portfolio_bucket_split_is_carried_including_its_nulls(self):
+        """The buckets are frozen money like the total. Carrying the NULL matters as much as
+        carrying a figure: a snapshot captured before the columns existed has no split to
+        recover, and a target that filled one in would be inventing history."""
+        snap = self.src.scalar(select(NwSnapshot).where(NwSnapshot.date == dt.date(2026, 6, 21)))
+        snap.portfolio_cash_sgd = Decimal("700000.1234")
+        snap.portfolio_cpf_sgd = Decimal("200000.5678")
+        snap.portfolio_srs_sgd = Decimal("129006.2588")
+        self.src.commit()
+        self.apply()
+        got = self.promoted("2026-06-21")
+        self.assertEqual(got.portfolio_cash_sgd, Decimal("700000.1234"))
+        self.assertEqual(got.portfolio_cpf_sgd, Decimal("200000.5678"))
+        self.assertEqual(got.portfolio_srs_sgd, Decimal("129006.2588"))
+        # 06-30 was captured with no split at all; it must arrive with none.
+        older = self.promoted("2026-06-30")
+        self.assertIsNone(older.portfolio_cash_sgd)
+        self.assertIsNone(older.portfolio_cpf_sgd)
+        self.assertIsNone(older.portfolio_srs_sgd)
+
+    def test_a_readback_catches_a_dropped_source_or_bucket(self):
+        """The check that would have failed before the copy carried them: `frozen_money_diff`
+        compares every field in VALUE_FIELDS / SNAPSHOT_FIELDS, so a promotion that stopped
+        carrying either one is a reported problem rather than a silent loss."""
+        self.apply()
+        self.assertEqual(promote.frozen_money_diff(self.src, self.tgt), [])
+        got = [v for v in self.promoted("2026-06-21").values if v.item.code == "tiger_usd"][0]
+        got.source = "carried"                    # as if the copy had re-derived it
+        self.promoted("2026-06-21").portfolio_cash_sgd = Decimal("1")
+        self.tgt.commit()
+        problems = promote.frozen_money_diff(self.src, self.tgt)
+        self.assertTrue(any("source" in p for p in problems), problems)
+        self.assertTrue(any("portfolio_cash_sgd" in p for p in problems), problems)
+
     def test_items_are_matched_by_code_not_by_id(self):
         """The two stores are seeded on different id sequences. A copy that carried `item_id`
         across would land every value on the wrong band, or on no item at all."""

--- a/tests/test_snapshot_ingest.py
+++ b/tests/test_snapshot_ingest.py
@@ -86,7 +86,9 @@ class PlanReachesTheColumnTest(unittest.TestCase):
         self.s.execute(text("INSERT INTO fx_rate(date, currency, rate_to_sgd) VALUES "
                             "('2026-06-01','USD',1.30)"))
         self.s.commit()
+        original_live_portfolio_by_bucket = nw.live_portfolio_by_bucket
         nw.live_portfolio_by_bucket = lambda s: {b: Decimal("0") for b in nw.FUNDING_BUCKETS}
+        self.addCleanup(setattr, nw, 'live_portfolio_by_bucket', original_live_portfolio_by_bucket)
 
     def tearDown(self):
         self.s.close()

--- a/tests/test_snapshot_ingest.py
+++ b/tests/test_snapshot_ingest.py
@@ -1,0 +1,109 @@
+"""Where the statement ingest's numbers come from, and that it now says so.
+
+`scripts/snapshot_from_statements.py` has always known which of its three provenances each
+catalogue item's figure had — a statement reported it, the previous snapshot carried it, or
+nobody had it and BR2 zeroed it. It printed all three into the dry-run table and then dropped
+them on the floor, so a committed snapshot could not tell you which of its numbers a bank had
+actually confirmed. This covers the decision itself, which is pure; parsing a tiger CSV and a
+DBS PDF is not what is under test here.
+
+Run: PYTHONPATH=. .venv/bin/python tests/test_snapshot_ingest.py
+"""
+import datetime as dt
+import os
+import sys
+import unittest
+from decimal import Decimal
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+from sqlalchemy import create_engine, text
+from sqlalchemy.orm import sessionmaker
+
+from portfolio import networth as nw
+from portfolio.models import Base, NwItem, NwValue
+from scripts import snapshot_from_statements as ingest
+
+
+def make_session():
+    eng = create_engine("sqlite://")
+    Base.metadata.create_all(eng)
+    return sessionmaker(bind=eng, future=True)()
+
+
+def items(*rows):
+    """rows: (code, ccy) -> the {code: NwItem} index plan_values reads."""
+    return {code: NwItem(code=code, label=code, kind="asset", currency_default=ccy)
+            for code, ccy in rows}
+
+
+class PlanValuesTest(unittest.TestCase):
+    CAT = (("tiger_usd", "USD"), ("posb", "SGD"), ("ibkr_sgd", "SGD"))
+
+    def plan(self, statement_vals, carry):
+        return {v["code"]: v for v in ingest.plan_values(items(*self.CAT), statement_vals, carry)}
+
+    def test_a_statement_figure_is_sourced_statement(self):
+        p = self.plan({"tiger_usd": {"native_value": Decimal("100"), "currency": "USD"}}, {})
+        self.assertEqual(p["tiger_usd"]["source"], "statement")
+        self.assertEqual(p["tiger_usd"]["native_value"], Decimal("100"))
+
+    def test_a_carried_figure_is_sourced_carried(self):
+        p = self.plan({}, {"posb": {"native_value": Decimal("5000"), "currency": "SGD"}})
+        self.assertEqual(p["posb"]["source"], "carried")
+        self.assertEqual(p["posb"]["native_value"], Decimal("5000"))
+
+    def test_an_item_no_source_covers_is_sourced_default_zero(self):
+        p = self.plan({}, {})
+        self.assertEqual(p["ibkr_sgd"]["source"], "default_zero")
+        self.assertEqual(p["ibkr_sgd"]["native_value"], Decimal(0))
+        self.assertEqual(p["ibkr_sgd"]["currency"], "SGD")   # the item's own default
+
+    def test_a_statement_beats_a_carry_for_the_same_item(self):
+        """Precedence, not a merge: the statement is the fresher measurement, and an item that
+        appears in both must not be recorded as carried."""
+        p = self.plan({"posb": {"native_value": Decimal("7"), "currency": "SGD"}},
+                      {"posb": {"native_value": Decimal("5000"), "currency": "SGD"}})
+        self.assertEqual(p["posb"]["source"], "statement")
+        self.assertEqual(p["posb"]["native_value"], Decimal("7"))
+
+    def test_every_item_is_planned_and_every_source_is_a_known_one(self):
+        p = self.plan({"tiger_usd": {"native_value": Decimal("1"), "currency": "USD"}},
+                      {"posb": {"native_value": Decimal("2"), "currency": "SGD"}})
+        self.assertEqual(set(p), {"tiger_usd", "posb", "ibkr_sgd"})
+        self.assertTrue(all(v["source"] in nw.VALUE_SOURCES for v in p.values()))
+
+
+class PlanReachesTheColumnTest(unittest.TestCase):
+    """The half that the plan alone cannot show: the source the script computed survives
+    `create_snapshot` and lands in `nw_value.source`."""
+
+    def setUp(self):
+        self.s = make_session()
+        for i, (code, ccy) in enumerate((("tiger_usd", "USD"), ("posb", "SGD"),
+                                         ("ibkr_sgd", "SGD"))):
+            self.s.add(NwItem(code=code, label=code, kind="asset", currency_default=ccy,
+                              sort_order=i, active=True))
+        self.s.execute(text("INSERT INTO fx_rate(date, currency, rate_to_sgd) VALUES "
+                            "('2026-06-01','USD',1.30)"))
+        self.s.commit()
+        nw.live_portfolio_by_bucket = lambda s: {b: Decimal("0") for b in nw.FUNDING_BUCKETS}
+
+    def tearDown(self):
+        self.s.close()
+
+    def test_the_three_sources_land_in_the_column(self):
+        cat = {i.code: i for i in self.s.query(NwItem).all()}
+        plan = ingest.plan_values(cat,
+                                  {"tiger_usd": {"native_value": Decimal("100"),
+                                                 "currency": "USD"}},
+                                  {"posb": {"native_value": Decimal("5000"),
+                                            "currency": "SGD"}})
+        d = nw.create_snapshot(dt.date(2026, 6, 1), plan, s=self.s)
+        got = {v.item.code: v.source for v in
+               self.s.query(NwValue).filter(NwValue.snapshot_id == d["id"]).all()}
+        self.assertEqual(got, {"tiger_usd": "statement", "posb": "carried",
+                               "ibkr_sgd": "default_zero"})
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/web/tests/fixtures/api/networth-items.json
+++ b/web/tests/fixtures/api/networth-items.json
@@ -8,6 +8,7 @@
   "is_liquid": true,
   "is_housing": false,
   "is_cpf": false,
+  "band": "cash",
   "sort_order": 0,
   "is_manual": true
  },
@@ -20,6 +21,7 @@
   "is_liquid": true,
   "is_housing": false,
   "is_cpf": false,
+  "band": "cash",
   "sort_order": 1,
   "is_manual": false
  },
@@ -32,6 +34,7 @@
   "is_liquid": false,
   "is_housing": false,
   "is_cpf": false,
+  "band": "srs",
   "sort_order": 2,
   "is_manual": false
  },
@@ -44,6 +47,7 @@
   "is_liquid": true,
   "is_housing": false,
   "is_cpf": false,
+  "band": "cash",
   "sort_order": 3,
   "is_manual": false
  },
@@ -56,6 +60,7 @@
   "is_liquid": true,
   "is_housing": false,
   "is_cpf": false,
+  "band": "cash",
   "sort_order": 4,
   "is_manual": false
  },
@@ -68,6 +73,7 @@
   "is_liquid": true,
   "is_housing": false,
   "is_cpf": false,
+  "band": "cash",
   "sort_order": 5,
   "is_manual": false
  },
@@ -80,6 +86,7 @@
   "is_liquid": true,
   "is_housing": false,
   "is_cpf": false,
+  "band": "cash",
   "sort_order": 6,
   "is_manual": false
  },
@@ -92,6 +99,7 @@
   "is_liquid": true,
   "is_housing": false,
   "is_cpf": false,
+  "band": "cash",
   "sort_order": 7,
   "is_manual": true
  },
@@ -104,6 +112,7 @@
   "is_liquid": false,
   "is_housing": false,
   "is_cpf": true,
+  "band": "cpf",
   "sort_order": 8,
   "is_manual": true
  },
@@ -116,6 +125,7 @@
   "is_liquid": false,
   "is_housing": false,
   "is_cpf": true,
+  "band": "cpf",
   "sort_order": 9,
   "is_manual": true
  },
@@ -128,6 +138,7 @@
   "is_liquid": false,
   "is_housing": false,
   "is_cpf": true,
+  "band": "cpf",
   "sort_order": 10,
   "is_manual": true
  },
@@ -140,6 +151,7 @@
   "is_liquid": false,
   "is_housing": true,
   "is_cpf": false,
+  "band": "housing",
   "sort_order": 11,
   "is_manual": true
  },
@@ -152,6 +164,7 @@
   "is_liquid": false,
   "is_housing": true,
   "is_cpf": false,
+  "band": "housing",
   "sort_order": 12,
   "is_manual": true
  },
@@ -164,6 +177,7 @@
   "is_liquid": false,
   "is_housing": true,
   "is_cpf": false,
+  "band": "housing",
   "sort_order": 13,
   "is_manual": true
  }


### PR DESCRIPTION
Closes #95. Spec: #92 (map #74) — §A (banding), §C (schema and write path), §F (glossary).

The server-side groundwork the composition chart stands on. **Nothing draws any of it yet**; all of it has to exist before #96 can, and two of the three additions can only ever be filled going forward.

## Banding

`networth.band()` is the one place that decides which band a catalogue item is in — `is_housing` → `is_cpf` → `is_liquid` → else — and `/api/networth/items` now carries it.

Not a column: a stored band would be a fourth grouping free to disagree with the three flags it is derived from. Not the frontend: the catalogue endpoint is active-only while the metrics walk every value unfiltered, so a frontend copy would silently drop a deactivated item's history out of whichever edge it belonged to. Not SQL: a `CASE` ladder is a second copy of the precedence. `BANDS` names the four values it may return so a caller can assert coverage without restating the rule.

**It raises on a non-housing liability.** Three of the composition's cumulative edges equal a summary tile to the cent only because every liability in the catalogue is a housing liability, netted into Housing where it cancels. A car loan would sit in an asset band as a negative and break that identity without changing a single number's sign — so the catalogue endpoint refuses to answer at all rather than draw wrong.

## Write-path provenance

`nw_value.source` records what the write path *knew*: `statement` / `carried` / `default_zero`.

The statement ingest is the only writer that names one, because it is the only writer that decided between the three — it has computed that decision since it was written, printed it into the dry-run table and dropped it on the floor. It now writes it, and `plan_values` is that decision pulled out as a pure function so it is testable without a tiger CSV or a DBS PDF.

**The form and the API deliberately write NULL.** Six items are byte-identical across the whole history; a user who reads the HDB valuation, confirms it has not moved and leaves the field alone has *measured* it, and a column that said `carried` there would be worse than no column. The API cannot set one even if a client sends it — `source` is not on `NwValueIn` at all, so pydantic drops it.

**The snapshot creator does stamp `default_zero` on an item nobody supplied.** Not a reversal of the above: an omitted item is BR2's zeroing rule fabricating the $0 itself, which describes what the code just did rather than asserting a provenance it cannot know. This is the live source for the composition endpoint's `dropped` list. Re-writing a value clears the stamp, which is how filling a dropped item in is what stops it being dropped.

## Portfolio funding buckets

`nw_snapshot.portfolio_{cash,cpf,srs}_sgd`, stamped at capture beside the total. Nothing draws them — the Portfolio band stays one opaque band until they have history — but a split can only be recorded live, so a snapshot taken without one can never grow one.

`live_portfolio_sgd` became `live_portfolio_by_bucket`, and the total is now **derived from** the split rather than computed beside it: `compute()` is a fold over the whole securities ledger, so it is walked once, and the three buckets cannot fail to add up to the total frozen next to them.

Verified against the live ledger — total unchanged at `1,123,548.14`, split `857,637.32` / `197,054.89` / `68,855.93`.

## Migration

All four columns nullable, no `server_default`, **nothing backfilled** — the point rather than a shortcut. Every existing row was written by a path that recorded nothing, so NULL is the true answer for all of them; and for the buckets there is no split to recover for an old snapshot, only one to invent. Confirmed on the local store: 70 of 70 value rows and 5 of 5 snapshots still NULL after `upgrade head`. Round-trips through `downgrade`.

## Two things #95 does not ask for

- **Promotion carries the new columns.** `scripts/promote_networth_snapshots.py` would otherwise have dropped `source` and the buckets silently — the one thing that script's docstring promises it does not do. `source` is the field a copy is most tempted to re-derive, and doing so would stamp every promoted row NULL and lose exactly the `default_zero` marks the composition endpoint reads. Both are now in `VALUE_FIELDS` / `SNAPSHOT_FIELDS`, so the readback catches a future regression instead of the loss being invisible. Clean to revert (one file + two tests) if you'd rather it were its own ticket.
- **Moved `if __name__ == "__main__"` to the end of `tests/test_networth.py`.** It sat mid-file, so five test classes defined below it never ran under the file's own documented invocation. Pre-existing; both run modes now agree at 36 tests.

## Fixtures and glossary

The test catalogues gain an `srs` item — `srs` is the band no flag selects, so without one every test downstream of the banding covers 3 of 4. `seed_networth.py` already had one and is now pinned by a test rather than by coincidence.

`CONTEXT.md` gains the **Band** entry and the qualifier that the **Catalogue**'s flags reach line items only.

## Verification

- **436 Python tests** (up from 406), including the 39 `pg`-marked ones against a real Postgres.
- **ruff clean.**
- Migration applied, round-tripped, and the no-backfill claim checked against the real local store.
- `web/tests/fixtures/api/networth-items.json` recaptured — byte-identical to what the endpoint now returns, key order included.

⚠️ **The Playwright suite has not had a trustworthy run.** The host machine suspended repeatedly mid-run — two spec files took 64 minutes of wall clock, one full run 7.1 hours — and every failure was a bare 60s timeout on pages unrelated to net worth, in a different set each attempt. Never an assertion failure. The added key is inert for the SPA (`NetWorth.jsx` reads only `code` and `currency_default` off each item), but **CI's `web` job is the real check here** — worth waiting on it rather than on my local run.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Net-worth catalogue items now include derived bands such as cash, CPF, SRS, and housing.
  - Snapshots now preserve portfolio totals by cash, CPF, and SRS funding buckets.
  - Snapshot values record their provenance: statement, carried forward, or default zero.
  - Catalogue and snapshot data transfers now retain band, source, and portfolio bucket details.

- **Documentation**
  - Expanded the net-worth glossary with clear definitions for catalogues, bands, and their supported values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->