### PR TITLE
feat(web): one palette, keyed by name, before either chart draws (#96)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@
 #
 # Grouping is the whole point of the config below. Ungrouped, this repo opens ~10 PRs a week
 # (react + react-dom, sqlalchemy + psycopg, every @playwright/* in lockstep) and each one runs
-# the full 1345-assertion viewport suite. Grouped, related bumps arrive as one PR that either
+# the full 1367-assertion viewport suite. Grouped, related bumps arrive as one PR that either
 # passes together or fails together, which is also how they would be deployed.
 version: 2
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@
 # the only ones that arrive with nobody having run anything locally — but it gates every PR.
 #
 # Two jobs, split by what they can tell you and how fast: `python` answers in ~2 minutes,
-# `web` runs the 1345-assertion viewport suite and takes ~10. Neither needs a secret; the
+# `web` runs the 1367-assertion viewport suite and takes ~10. Neither needs a secret; the
 # suite serves every API call from web/tests/fixtures and the Python tests build their own
 # throwaway database.
 name: CI

--- a/web/TESTING.md
+++ b/web/TESTING.md
@@ -142,11 +142,23 @@ would otherwise pass for the wrong reason. The stacked bar chart used to be the 
 not reach — its fixture was a 500 — so its key was source-grepped in `inventory.spec.js` instead.
 #35 fixed the endpoint, and the key is asserted here now, against the fixture's own `groups` rather
 than a literal: those strings are `<Bar dataKey>`s, so a group that renders under a different name is
-a group whose bar drew nothing. The grep stays for the charts no fixture happens to mount.
+a group whose bar drew nothing. The grep stays for the charts no fixture happens to mount. It also
+carries the **one-palette** gate, which is the key-versus-fill assertion's strict sibling: that one
+compares two surfaces against *each other*, and both used to index one array at the same `i`, so it
+passed by construction while the donut two cards up — indexing a differently sorted payload — coloured
+Personal a different colour in the same viewport. The palette gate compares every spending surface
+against the map declared in `src/palette.js`, which it **imports rather than restates**: a table of
+hexes in the suite is a second palette, and the drift it would be blind to is the one it exists to
+catch.
 
 `tests/inventory.spec.js` — the checks that read files rather than pixels: the table count, the
 single donut implementation, that no chart renders a `<Legend>` and that both multi-series charts
-carry a `<ChartKey>`, that `640` is a literal in exactly four files **and that the two JavaScript
+carry a `<ChartKey>`, that **no spending surface mentions the `POSITIONAL_COLOURS` array** — only
+`palette.js`, which declares it, and `charts.jsx`, whose portfolio donut slices by market and by
+account and so has no taxonomy to key a map on — and that **the two colour maps agree about
+Housing**, which is a deliberate coupling (spend Housing is the running cost of the same HDB whose
+equity is the net-worth Housing band) that nothing renders side by side, so no viewport would look
+wrong if one map drifted, that `640` is a literal in exactly four files **and that the two JavaScript
 media queries say character for character what the stylesheet says** — counting the sites is not
 checking they agree, and `(max-width: 640px)` would keep the count at four while moving the tier into
 a 1px dead zone — that **no `vh` unit** survives under `web/src` — widened from `100vh` when the rule modal's `6vh`/`84vh` became `svh`, since `\dvh` does not match `100svh` and so does not catch the unit that is correct — the viewport meta's `viewport-fit=cover`,

--- a/web/src/charts.jsx
+++ b/web/src/charts.jsx
@@ -2,20 +2,23 @@ import React from "react";
 import { PieChart, Pie, Cell, ResponsiveContainer, Tooltip } from "recharts";
 import { sgd, fmt } from "./api.js";
 import { usePhone } from "./cards.jsx";
+import { POSITIONAL_COLOURS } from "./palette.js";
 
 /**
- * The one donut in the app, and the palette behind it.
+ * The one donut in the app.
  *
  * It lives beside `api.js` rather than under a module because both sections draw it:
  * `portfolio/Overview` carried a hand-copied duplicate with its own 7-colour palette, so
- * every chart change had to land twice across four call sites. The 8-entry palette is the
- * one kept — the two only differ once a donut has 8+ slices, where the 7-entry one wraps
- * back to blue. The palette also colours the spending Overview stacked bars and the By
- * Category row markers, so every chart in the app stays on one colour order.
+ * every chart change had to land twice across four call sites.
+ *
+ * `colourOf` IS HOW THE TWO KINDS OF CALLER DIFFER, and it is the whole of what this donut
+ * knows about colour. The spending call sites pass `categoryColour` and get a name-keyed
+ * map; the portfolio ones pass nothing and fall back to `POSITIONAL_COLOURS` by slice
+ * position, which is all a slicing by market or by account can do — those are not a
+ * taxonomy. See `palette.js`: the fallback is the *only* surviving positional read, and one
+ * that no spending surface may reach.
  */
-export const COLORS = ["#388bfd", "#2ea043", "#d29922", "#8957e5", "#f85149", "#39c5cf", "#db61a2", "#6e7681"];
-
-export function Donut({ title, data }) {
+export function Donut({ title, data, colourOf }) {
   // Descending, internally, with no `sort` prop: `portfolio/spending.py:58` is
   // `ORDER BY v DESC`, so the spending call sites already arrive sorted and both depend on
   // it (`groups[0]` is their "Top Category" tile) — sorting again is a no-op there and
@@ -43,6 +46,11 @@ export function Donut({ title, data }) {
    * four sites.
    */
   const phone = usePhone();
+  // Named once, read twice — the ring and the list beneath it are one chart at every width
+  // and the same slice cannot take two colours. Below 640 the list IS the chart, so this is
+  // the only one of the two that always runs.
+  const colour = (row, i) =>
+    (colourOf ? colourOf(row.name) : POSITIONAL_COLOURS[i % POSITIONAL_COLOURS.length]);
   return (
     <div className="card">
       <h3>{title}</h3>
@@ -50,7 +58,7 @@ export function Donut({ title, data }) {
         <ResponsiveContainer width="100%" height={240}>
           <PieChart>
             <Pie data={rows} dataKey="value" nameKey="name" innerRadius={55} outerRadius={90} paddingAngle={2}>
-              {rows.map((_, i) => <Cell key={i} fill={COLORS[i % COLORS.length]} />)}
+              {rows.map((row, i) => <Cell key={i} fill={colour(row, i)} />)}
             </Pie>
             <Tooltip formatter={(v) => sgd(v)} contentStyle={{ background: "#161b22", border: "1px solid #2b333d" }} itemStyle={{ color: "#d7dde4" }} labelStyle={{ color: "#d7dde4" }} />
           </PieChart>
@@ -66,13 +74,13 @@ export function Donut({ title, data }) {
       <div className="donutlist">
         {rows.map((x, i) => {
           const share = total ? (x.value / total) * 100 : 0;
-          const colour = COLORS[i % COLORS.length];
+          const fill = colour(x, i);
           return (
             <div className="barrow" key={x.name}>
               {/* The track is the row: a percentage width behind the text, so it stays
                   proportional at any card width. The 220px constant it replaces did not. */}
-              <span className="barfill" style={{ width: share + "%", background: colour }} />
-              <span className="chip" style={{ background: colour }} />
+              <span className="barfill" style={{ width: share + "%", background: fill }} />
+              <span className="chip" style={{ background: fill }} />
               <span className="nm">{x.name}</span>
               <span className="val">{sgd(x.value)} · {fmt(share, 0)}%</span>
             </div>

--- a/web/src/modules/spending/ByCategory.jsx
+++ b/web/src/modules/spending/ByCategory.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useRef, useState } from "react";
 import { get, sgd, fmt, catName } from "../../api.js";
-import { COLORS, Donut } from "../../charts.jsx";
+import { Donut } from "../../charts.jsx";
+import { categoryColour } from "../../palette.js";
 import { CardGroup, Cards, RowCard, usePhone } from "../../cards.jsx";
 
 // Expenses for a single calendar year, broken down by category. The year selector loads that
@@ -153,7 +154,7 @@ export default function SpendByCategory() {
             <Tile lbl="Transactions" val={count} />
           </div>
           <div className="grid2">
-            <Donut title={`By Category · ${year}`} data={groups} />
+            <Donut title={`By Category · ${year}`} data={groups} colourOf={categoryColour} />
             <div className="card">
               <h3>Categories</h3>
               {/* Levels one and two, read through the pinned pattern below 1024px: the name
@@ -164,7 +165,7 @@ export default function SpendByCategory() {
                 <table>
                   <thead><tr><th className="l">Category</th><th>Spend</th><th>%</th><th>Txns</th></tr></thead>
                   <tbody>
-                    {groups.map((g, i) => (
+                    {groups.map((g) => (
                       <React.Fragment key={g.name}>
                         {/* `rowtap`, not `rowlink`. Both take the same `:active` flash, and
                             only `rowlink` grows the persistent `›` in the pinned cell — which
@@ -174,7 +175,12 @@ export default function SpendByCategory() {
                         <tr className={g.cat ? "rowtap" : undefined}
                             onClick={() => g.cat && toggle(g.cat)} style={{ cursor: g.cat ? "pointer" : "default" }}>
                           <td className="l">
-                            <span style={{ color: COLORS[i % COLORS.length] }}>{g.cat ? (open === g.cat ? "▾" : "▸") : "·"}</span> {g.name}
+                            {/* Keyed on `g.name` and not on the row's index. This table's
+                                order is this *year's* spend descending — a third order
+                                again, different from the donut beside it in a year where
+                                two categories swap rank, and different from the stacked
+                                bar's alphabetical one on the other view. */}
+                            <span style={{ color: categoryColour(g.name) }}>{g.cat ? (open === g.cat ? "▾" : "▸") : "·"}</span> {g.name}
                           </td>
                           <td>{sgd(g.value)}</td>
                           <td className="mut">{fmt((g.value / total) * 100, 1)}%</td>

--- a/web/src/modules/spending/Overview.jsx
+++ b/web/src/modules/spending/Overview.jsx
@@ -4,7 +4,8 @@ import {
   BarChart, Bar, XAxis, YAxis, CartesianGrid,
 } from "recharts";
 import { get, sgd, fmt, catName } from "../../api.js";
-import { COLORS, ChartKey, Donut } from "../../charts.jsx";
+import { ChartKey, Donut } from "../../charts.jsx";
+import { categoryColour } from "../../palette.js";
 import { Cards, RowCard, usePhone } from "../../cards.jsx";
 
 export default function SpendOverview() {
@@ -35,7 +36,11 @@ export default function SpendOverview() {
         <Tile lbl="Months Tracked" val={sum.months} />
       </div>
       <div className="grid2">
-        <Donut title="Spending by Category" data={groups} />
+        {/* THE TWO CHARTS ON THIS PAGE ARE THE REASON THE MAP EXISTS. This donut's data is
+            `by_group`, sorted by spend descending; the stacked bar's series are `groups`,
+            sorted alphabetically. Both used to index one array by their own position, so
+            Personal was blue here and green ~600px further down, in one viewport. */}
+        <Donut title="Spending by Category" data={groups} colourOf={categoryColour} />
         <div className="card">
           {/* The count is in the title because the card list below 640 has no header to
               carry it — see `cards.jsx`. It is the number of rows rendered, which is the
@@ -104,15 +109,17 @@ export default function SpendOverview() {
               <Tooltip formatter={(v) => sgd(v)}
                        contentStyle={{ background: "#161b22", border: "1px solid #2b333d" }}
                        itemStyle={{ color: "#d7dde4" }} labelStyle={{ color: "#d7dde4" }} />
-              {trend.groups.map((g, i) => (
-                <Bar key={g} dataKey={g} stackId="s" fill={COLORS[i % COLORS.length]} />
+              {trend.groups.map((g) => (
+                <Bar key={g} dataKey={g} stackId="s" fill={categoryColour(g)} />
               ))}
             </BarChart>
           </ResponsiveContainer>
           {/* The `<Legend>` this replaces was inside the chart, so its ~75px came out of the
-              300px plot. Same colours, same order — both read `COLORS[i % COLORS.length]`
-              off the same index, which is what keeps the key honest. */}
-          <ChartKey items={trend.groups.map((g, i) => ({ name: g, colour: COLORS[i % COLORS.length] }))} />
+              300px plot. The key and the bars now agree because both ask the map for the
+              same *name* — they used to agree because both indexed one array at the same
+              `i`, which is a weaker guarantee than it looks: it held between these two and
+              said nothing at all about the donut above, which indexed a different order. */}
+          <ChartKey items={trend.groups.map((g) => ({ name: g, colour: categoryColour(g) }))} />
         </div>
       )}
     </div>

--- a/web/src/palette.js
+++ b/web/src/palette.js
@@ -1,0 +1,204 @@
+/**
+ * ONE PALETTE FOR SERIES COLOUR: two name-keyed maps, and the one positional array left.
+ *
+ * SCOPE, because the file name overclaims if left alone. This is the colour a *series* is
+ * drawn in — a spending category, a net-worth band, a donut slice. It is not the app's
+ * colour: `styles.css` owns the surface and text tokens, and the amber `#d29922` on
+ * Recurring's "due soon" pill, Classify's error card and the breakdown's "unsaved" pill is a
+ * status colour, which is a different job that happens to share a hex. `NetWorth.jsx`'s
+ * two-line chart also still carries its own two hexes; it is deliberately not migrated,
+ * because the composition chart retires that chart rather than recolouring it.
+ *
+ * WHY NAME-KEYED. The app used to colour every series by its *position* in a single 8-entry
+ * array. That is fine for one chart and wrong for four, because two surfaces index the same
+ * array with two different `i`: `/api/spending/summary` returns `by_group` sorted by spend
+ * descending and `/api/spending/trends` returns `groups` sorted alphabetically, so Personal
+ * was slot 0 in the donut and slot 1 in the stacked bar — blue in one card and green in the
+ * next one down, in one viewport. A third surface, the by-category row markers, indexed a
+ * *third* order again, because that view's summary is a different window.
+ *
+ * The three colour-by-position sites are gone. `inventory.spec.js` holds that, and
+ * `charts.spec.js` compares every rendered spending surface against the map declared here
+ * rather than against its neighbour — two surfaces reading the same wrong index agree with
+ * each other perfectly, which is exactly how the old key-versus-fill gate stayed green.
+ *
+ * Plain data with no React and no recharts import, deliberately: that is what lets the test
+ * suite import the map instead of restating it, and a restated palette is a second palette.
+ *
+ * -- Validator ---------------------------------------------------------------------------
+ *
+ * Both maps were run through the dataviz palette validator (Machado-Oliveira-Fernandes
+ * severity-1.0 CVD simulation, OKLab ΔE×100), `--mode dark --surface #161b22` — `--panel`,
+ * the card these charts are drawn on. Recorded rather than summarised, because both maps
+ * carry an accepted FAIL and an undocumented FAIL reads as an oversight.
+ *
+ *   BAND MAP, raw hexes:      lightness FAIL (#39c5cf L .755, #d29922 L .72) · chroma PASS
+ *                             CVD PASS (worst adjacent #db61a2↔#d29922 ΔE 16.9 deutan)
+ *                             normal-vision PASS (19.0) · contrast PASS
+ *
+ *   BAND MAP, composited:     the number that matters, because the composition chart ships
+ *                             reduced-opacity fills over the card and a full-opacity stroke,
+ *                             and opacity over `--panel` is what the eye actually receives.
+ *                             At BAND_FILL_OPACITY over #161b22 the fills are
+ *                             #34acb5 #337adc #b68622 #bd578f:
+ *                             lightness FAIL (#34acb5 L .684, ceiling .67) · chroma PASS
+ *                             CVD PASS (worst adjacent #bd578f↔#b68622 ΔE 15.2 deutan)
+ *                             normal-vision PASS (16.7) · contrast PASS
+ *
+ *   CATEGORY MAP:             not composited — every spending surface (donut cells, chips,
+ *                             bar fills, row markers) is opaque, so the raw hex is what is
+ *                             received. lightness FAIL (#d29922 L .72)
+ *                             chroma FAIL (#6e7681 C .02 — "reads gray")
+ *                             CVD PASS (worst adjacent #db61a2↔#388bfd ΔE 13.8 protan)
+ *                             normal-vision PASS (22.4) · contrast PASS
+ *
+ * THE TWO HARD GATES PASS ON BOTH MAPS; the failures above are accepted, for two different
+ * reasons. The lightness band is a glare budget — a colour brighter than the band is
+ * tiring on a dark surface — where a CVD or normal-vision failure is an *identity* problem:
+ * two series a reader cannot tell apart. A chart that is slightly bright is a worse chart;
+ * a chart whose series are indistinguishable is not a chart. And the chroma failure on
+ * `#6e7681` is the point of that entry rather than a defect in it: Uncategorized is grey
+ * *because* it must not read as a category anyone chose, and it carries CATEGORY_DASH as
+ * the secondary encoding the validator asks for wherever a stroke can hold it.
+ *
+ * These are the only four-colour sets from the app's palette that clear both hard gates.
+ */
+
+/**
+ * The positional palette, and the last thing that reads it: the portfolio donut.
+ *
+ * It slices by market and by account — an unbounded set with no fixed taxonomy, so there is
+ * nothing to key a map on and position is the only thing left. Every spending surface has
+ * moved off it and none may move back; `inventory.spec.js` names the two files allowed to
+ * mention it.
+ *
+ * NAMED FOR THE CONSTRAINT rather than for the contents, since it now sits beside two maps
+ * that are also palettes and are also colours: what distinguishes it is that reading it is
+ * reading a *position*. The 8-entry order is unchanged from when it was the whole app's
+ * palette — it is still the one kept over `portfolio/Overview`'s hand-copied 7-entry
+ * duplicate, which wrapped back to blue at 8+ slices.
+ */
+export const POSITIONAL_COLOURS = ["#388bfd", "#2ea043", "#d29922", "#8957e5", "#f85149", "#39c5cf", "#db61a2", "#6e7681"];
+
+/**
+ * Spending categories → colour, keyed by the name the payload uses.
+ *
+ * The keys are the taxonomy's three categories plus `Uncategorized`, which is what the
+ * compute layer calls a NULL category where the name has to be a JSON key (`trends()`) and
+ * what `catName()` calls it at render (`summary()`). One name, so one entry.
+ *
+ * HOUSING IS PINK IN BOTH MAPS, DELIBERATELY — see BAND_COLOURS. A recolour of either map
+ * must check the other; `inventory.spec.js` fails if they drift.
+ */
+export const CATEGORY_COLOURS = {
+  Personal: "#388bfd",
+  Housing: "#db61a2",
+  Transport: "#d29922",
+  Uncategorized: "#6e7681",
+};
+
+/**
+ * Net-worth bands → colour, keyed by the band identifier on the wire.
+ *
+ * NEVER POSITIONAL, and not merely as a matter of taste: the band count is scheduled to
+ * change the day the frozen portfolio's funding-bucket split has enough history to draw, so
+ * a positional palette here would silently recolour three bands the moment a fourth was
+ * inserted below them. The keys are `/api/networth/composition`'s `bands`, which is the
+ * literal bottom→top stacking order — this map does not encode that order and must not be
+ * read for it.
+ *
+ * FOUR ENTRIES AGAINST THE CATALOGUE'S FIVE BAND VALUES, and the gap is deliberate rather
+ * than an omission: `srs` is a band server-side (CONTEXT.md's Band entry) and the chart
+ * folds it into `cash` at render, which is why the chip reads "Cash & SRS". The day SRS
+ * promotes to a band of its own it needs an entry here, and that is the same edit as
+ * unfolding it. Until then this map is keyed on what the *chart* stacks, not on what the
+ * catalogue partitions into — so read it with the fold, or it is missing a key.
+ *
+ * HOUSING IS PINK IN BOTH MAPS, DELIBERATELY. It is not a homonym: spend Housing holds
+ * Mortgage, Property Taxes and Utilities — the running cost of the same HDB whose equity is
+ * this band — so the two maps are naming one thing and share its colour on purpose. This
+ * couples the maps on one series, which means A RECOLOUR OF EITHER MUST CHECK THE OTHER.
+ * `inventory.spec.js` asserts the two entries are equal, because nothing renders them side
+ * by side and no viewport would look wrong if one drifted.
+ */
+export const BAND_COLOURS = {
+  cash: "#39c5cf",      // Cash & SRS — `cash` and `srs` folded, see above
+  portfolio: "#388bfd",
+  cpf: "#d29922",       // CPF cash
+  housing: "#db61a2",   // Housing, net of loan — the spend map's Housing, deliberately
+};
+
+/**
+ * The fill opacity the composition chart's stacked areas are drawn at, and therefore the
+ * opacity the validator record above was measured at. Strokes are full opacity.
+ *
+ * IT IS HERE BECAUSE THE MEASUREMENT NEEDS IT. "Re-run the validator on the composited
+ * fill" has no answer without a number, so the number cannot wait for the chart — and a
+ * chart that then picked its own would invalidate the record above rather than inherit it.
+ * Read it as the measured value the chart consumes; a chart ticket that wants a different
+ * one is re-running the validator, not overriding a constant.
+ *
+ * 0.85 is where the scan lands. Raw hexes fail the lightness band on two slots; compositing
+ * darkens them, and by 0.85 only one remains 0.014 over the ceiling. Below that it gets
+ * worse rather than better in the checks that matter — at 0.80 `cash` drops under the chroma
+ * floor (C .099) and starts reading grey, and at 0.75 the hard normal-vision gate breaks
+ * (#306fc6↔#309ba4, printed as ΔE 15.0 and failing on the unrounded value against a floor
+ * of 15). So the band is not a preference: it is 0.85.
+ */
+export const BAND_FILL_OPACITY = 0.85;
+
+/**
+ * The dash pattern for a category that must not read as a category anyone chose.
+ *
+ * Grey alone is the weaker half of that claim — `#6e7681` fails the validator's chroma floor
+ * precisely because grey is what a colour looks like when it carries no identity, and a
+ * reader who cannot see it as a hue cannot see it as *residue* either. The dash is the
+ * secondary encoding that says so, and it is what makes the accepted chroma failure legal
+ * rather than merely tolerated.
+ *
+ * NO SPENDING SURFACE DRAWS A STROKE TODAY — the donut cells, the chips, the bar fills and
+ * the row markers are all fills and glyphs — so this is declared and not yet applied. Its
+ * first consumer is the spend-trend chart, whose four panels are lines. Declared with the
+ * map rather than in that chart because "grey and dashed" is one decision about one
+ * category, and splitting it across two files is how the halves drift.
+ *
+ * A map rather than a bare constant so the reader can see the claim is about `Uncategorized`
+ * and not about dashes in general.
+ */
+export const CATEGORY_DASH = {
+  Uncategorized: "6 4",
+};
+
+/**
+ * The reserve, for a category name that is in no map.
+ *
+ * The taxonomy is locked at three categories, so this cannot fire today — but "locked" is a
+ * decision rather than a constraint, and what happens if it is unlocked matters. Returning
+ * `undefined` hands recharts a series with no fill; falling back to grey makes a new
+ * category indistinguishable from unclassified spend; falling back by index puts position
+ * back. So the fallback is keyed on the name too, and drawn from the entries no map has
+ * claimed — an unmapped category can be an unfamiliar colour, but it can never impersonate a
+ * mapped one, and two of them can never collide into one.
+ *
+ * IT IS A FLOOR, NOT A PALETTE, and the difference is recorded because the validator record
+ * above would otherwise read as covering it. It does not: the four mapped colours plus these
+ * three, checked all-pairs, fail both hard gates (#2ea043↔#d29922 ΔE 4.4 protan,
+ * #f85149↔#db61a2 ΔE 12.5 normal). That is the correct result and not a defect to fix here —
+ * a fifth spending category is a decision that has to choose a colour and re-run the
+ * validator on the whole set. What this guarantees until then is only that the chart draws
+ * something legible against the card and distinct from the four, rather than nothing.
+ */
+const RESERVE = ["#2ea043", "#8957e5", "#f85149"];
+
+/**
+ * The category's colour, by name. Every spending surface goes through here.
+ *
+ * The hash is only reached by the reserve above; for the four real names this is a lookup.
+ */
+export function categoryColour(name) {
+  const mapped = CATEGORY_COLOURS[name];
+  if (mapped) return mapped;
+  let h = 0;
+  for (let i = 0; i < name.length; i++) h = (h * 31 + name.charCodeAt(i)) >>> 0;
+  return RESERVE[h % RESERVE.length];
+}

--- a/web/tests/charts.spec.js
+++ b/web/tests/charts.spec.js
@@ -31,6 +31,10 @@ import { expect, test } from "@playwright/test";
 import { PHONE_TIER_BELOW, VIEWPORTS } from "./viewports.js";
 import { openView } from "./support/app.js";
 import { readFixture } from "./fixtures/index.js";
+// The declared map itself, not a copy of it — see the `one palette` describe below for why
+// a table of hexes in this file would be the defect rather than the gate. `palette.js` is
+// plain data with no React or recharts import, which is what makes it importable here.
+import { categoryColour } from "../src/palette.js";
 
 const viewportOf = (projectName) => VIEWPORTS.find((v) => v.name === projectName);
 
@@ -192,6 +196,110 @@ test.describe("every chart", () => {
         return rect ? getComputedStyle(rect).fill : null;
       }));
     expect.soft(stackedChips, "the key's chips do not match the bars they name").toEqual(perSeries);
+  });
+});
+
+test.describe("one palette", () => {
+  /**
+   * A category keeps one colour on every spending surface.
+   *
+   * The gate above this one is weaker than it reads: it compares the key against the bars,
+   * and both of those used to read `COLORS[i % COLORS.length]` off the *same* index, so it
+   * passed by construction and would have gone on passing while the donut two cards up
+   * coloured Personal blue and the bar chart coloured it green — which is what shipped. What
+   * makes a positional palette wrong is that two surfaces index it with two different `i`:
+   * `by_group` arrives sorted by spend and `groups` arrives sorted alphabetically, so the
+   * same four names take two different orders in one viewport.
+   *
+   * So this compares every surface against the **declared map** rather than against each
+   * other. Imported from the source rather than restated here: a literal table of four hexes
+   * in the suite is a second palette, and the failure it would then be blind to is precisely
+   * the one it exists to catch.
+   */
+  const rgb = (hex) => `rgb(${[1, 3, 5].map((i) => parseInt(hex.slice(i, i + 2), 16)).join(", ")})`;
+
+  test("Spending › Overview colours its three surfaces by name", async ({ page, baseURL }) => {
+    await openView(page, baseURL, "Spending › Overview");
+    await barsSettled(page);
+
+    // The donut's list, which below 640 *is* the donut. Read as name→colour pairs rather
+    // than as an ordered array, because the order here is the payload's (descending spend)
+    // and the order in the key below is the payload's too — a different one.
+    const listed = await page.locator(".main .donutlist .barrow").evaluateAll((rows) =>
+      rows.map((row) => ({
+        name: row.querySelector(".nm").textContent,
+        chip: getComputedStyle(row.querySelector(".chip")).backgroundColor,
+        // The percentage track behind the text is the same fact about the row, so it is the
+        // same colour or the row states one category two ways.
+        fill: getComputedStyle(row.querySelector(".barfill")).backgroundColor,
+      })));
+    expect.soft(listed.length, "the donut's list drew no rows").toBeGreaterThan(0);
+    for (const row of listed) {
+      expect.soft(row.chip, `${row.name}: the donut list's chip is off the map`)
+        .toBe(rgb(categoryColour(row.name)));
+      expect.soft(row.fill, `${row.name}: the donut list's track is off the map`)
+        .toBe(rgb(categoryColour(row.name)));
+    }
+
+    // The stacked bar's key and its bars, each against the map — not against each other.
+    //
+    // COUNTED AGAINST THE FIXTURE FIRST, and that guard is not ceremony: the whole chart is
+    // behind `trend && trend.series.length > 0`, and the fetch's `.catch` sets `groups: []`,
+    // so a trends call that failed the way it failed for the whole of #35 would leave both
+    // loops below iterating nothing and reporting green. The count comes from the payload's
+    // own `groups` for the same reason the key's text does one test up — those strings are
+    // the `<Bar dataKey>`s.
+    const key = page.locator(".main .chartkey");
+    const named = await key.locator(".ck-item").evaluateAll((items) =>
+      items.map((el) => ({
+        name: el.textContent,
+        chip: getComputedStyle(el.querySelector(".chip")).backgroundColor,
+      })));
+    expect.soft(named.length, "the stacked bar's key drew nothing — did its fixture 500?")
+      .toBe(readFixture("spending-trends.json").groups.length);
+    for (const item of named) {
+      expect.soft(item.chip, `${item.name}: the key's chip is off the map`)
+        .toBe(rgb(categoryColour(item.name)));
+    }
+    const fills = await page.locator(".main .recharts-bar").evaluateAll((series) =>
+      series.map((el) => {
+        const rect = el.querySelector(".recharts-bar-rectangle path");
+        return rect ? getComputedStyle(rect).fill : null;
+      }));
+    expect.soft(fills, "one bar series per key item").toHaveLength(named.length);
+    for (const [i, fill] of fills.entries()) {
+      expect.soft(fill, `${named[i].name}: the bar fill is off the map`)
+        .toBe(rgb(categoryColour(named[i].name)));
+    }
+  });
+
+  test("Spending › By Category colours its row markers by name", async ({ page, baseURL }) => {
+    // The third spending surface, and the one that was hardest to see going wrong: the
+    // marker is a 9px glyph in a table cell, on a different view from the two above, so no
+    // viewport ever showed it disagreeing with them. It indexed the shared array by row
+    // position, which is a *third* order again — this view's summary is a different window.
+    await openView(page, baseURL, "Spending › By Category");
+    const marked = await page.locator(".main .pinned tbody tr td.l:first-child")
+      .evaluateAll((cells) => cells.map((cell) => ({
+        name: cell.textContent.replace(/^[▸▾·]\s*/, ""),
+        colour: getComputedStyle(cell.querySelector("span")).color,
+      })));
+    expect.soft(marked.length, "the category table drew no rows").toBeGreaterThan(0);
+    for (const row of marked) {
+      expect.soft(row.colour, `${row.name}: the row marker is off the map`)
+        .toBe(rgb(categoryColour(row.name)));
+    }
+
+    // Same view, same names, the other surface on it.
+    const listed = await page.locator(".main .donutlist .barrow").evaluateAll((rows) =>
+      rows.map((row) => ({
+        name: row.querySelector(".nm").textContent,
+        chip: getComputedStyle(row.querySelector(".chip")).backgroundColor,
+      })));
+    for (const row of listed) {
+      expect.soft(row.chip, `${row.name}: the donut list's chip is off the map`)
+        .toBe(rgb(categoryColour(row.name)));
+    }
   });
 });
 

--- a/web/tests/inventory.spec.js
+++ b/web/tests/inventory.spec.js
@@ -101,6 +101,44 @@ test("both multi-series charts carry a DOM key", () => {
   expect(keyed, "a multi-series chart with no key is anonymous on touch").toEqual(wanted);
 });
 
+test("no spending surface indexes the positional palette", () => {
+  // `POSITIONAL_COLOURS` is an ordered array, so reading it is reading a *position*. The
+  // donut's list, the monthly stacked bar and the by-category row markers each indexed it
+  // with their own `i` — and those three orders are three different sorts of the same four
+  // names (spend descending, alphabetical, and this-year's spend descending), which is how
+  // Personal came out blue in one card and green in the next one down.
+  //
+  // The array itself stays: the portfolio donut slices by market and by account, which is
+  // not a taxonomy anything can key a map on. What is forbidden is a *second* consumer, and
+  // the file that owns the donut is the only one allowed to be it.
+  //
+  // Comments stripped, like its siblings above — `charts.jsx` and both spending views
+  // explain at length what they used to index and why they no longer do.
+  const importers = sourceFiles(path.join(WEB, "src"))
+    .filter((f) => /\bPOSITIONAL_COLOURS\b/.test(stripComments(fs.readFileSync(f, "utf8"))))
+    .map((f) => path.relative(WEB, f))
+    .sort();
+  expect(importers, "colour by name — `categoryColour` / `BAND_COLOURS` in `palette.js`")
+    .toEqual(["src/charts.jsx", "src/palette.js"]);
+});
+
+test("the two colour maps agree about Housing", async () => {
+  // THE COUPLING IS DELIBERATE AND THIS IS WHERE IT IS ENFORCED. Spend Housing holds
+  // Mortgage, Property Taxes and Utilities — the running cost of the same HDB whose equity
+  // is the net-worth Housing band — so the two maps name one thing and share its colour.
+  // Not a homonym, and so not something to break apart when one map is recoloured.
+  //
+  // A test rather than only a comment because the two maps are read by different views and
+  // nothing renders them side by side: recolour one and no viewport in this suite would
+  // look wrong. If a future decision genuinely decouples them, this is the file that has to
+  // be edited to say so — which is the whole point, since editing it means having looked at
+  // the other map.
+  const { CATEGORY_COLOURS, BAND_COLOURS } = await import("../src/palette.js");
+  expect(CATEGORY_COLOURS.Housing,
+    "a recolour of either map must check the other — see `palette.js`")
+    .toBe(BAND_COLOURS.housing);
+});
+
 test("`640` is written in exactly four places", () => {
   // The stylesheet, the suite, `Holdings.jsx`'s read-at-mount and `cards.jsx`'s `usePhone` —
   // no build step makes a single source of truth possible, so what is left is counting them


### PR DESCRIPTION
Closes #96. Spec: #92 (map #74) — §D (band colours), §E (category colours), §G.4 (colour maps
land before or with the charts).

## What this is

The prefactor the two new charts stand on. It draws nothing new and touches more surface than
they do — the donut, the monthly stacked bar and the By Category row markers all coloured by
*position* in one shared 8-entry array.

**Position is the defect.** `summary()` returns `by_group` sorted by spend descending and
`trends()` returns `groups` sorted alphabetically, so the same four names take two different
orders: Personal was slot 0 in the donut and slot 1 in the bar chart — blue in one card and
green ~600px further down, in one viewport. The By Category row markers indexed a third order
again, because that view's summary is a different window.

`web/src/palette.js` is now the one place *series* colour is declared. Not the app's colour:
the surface and text tokens stay in `styles.css`, the amber on the three status pills is a
different job that happens to share a hex, and `NetWorth.jsx`'s two-line chart keeps its own
two — deliberately, because the composition chart retires that chart rather than recolouring
it.

- **Spending** is a name-keyed category map: Personal `#388bfd` · Housing `#db61a2` ·
  Transport `#d29922` · Uncategorized `#6e7681`.
- **Net worth** is a name-keyed band map: Cash & SRS `#39c5cf` · Portfolio `#388bfd` ·
  CPF cash `#d29922` · Housing `#db61a2`, keyed on the wire identifiers
  `/api/networth/composition` will send. Never positional — the band count is scheduled to
  change.

Plain data, no React and no recharts import, which is what lets the suite import the map
instead of restating it: a table of hexes in a spec file is a second palette, blind to the
exact drift it exists to catch.

## Reviewer notes

**Three exports ship with no consumer, and that is the ticket rather than dead code.**
§G.4 orders the colour maps to land *before* the charts, because they touch more surface than
the charts do. `BAND_COLOURS` and `BAND_FILL_OPACITY` are what the net-worth composition chart
will read; `CATEGORY_DASH` is what the spend-trend chart's four lines will read. Each names its
first consumer at its declaration.

**`CATEGORY_DASH` is declared and not applied.** The issue asks for Uncategorized to be dashed
"wherever a stroke can carry it", and today that is nowhere — every spending surface is a fill
or a glyph. Declared with the map rather than in the chart because "grey and dashed" is one
decision about one category, and splitting it across two files is how the halves drift.

**Housing is pink in both maps, deliberately.** Not a homonym: spend Housing holds Mortgage,
Property Taxes and Utilities, the running cost of the same HDB whose equity is the net-worth
Housing band. It is commented at both declarations, and `inventory.spec.js` asserts the two
entries are equal — nothing renders the two maps side by side, so a drift would look wrong on
no viewport. If a future decision genuinely decouples them, that test is the file that has to
be edited to say so, which is the point: editing it means having looked at the other map.

## Validator

Re-run and recorded at the declaration, `--mode dark --surface #161b22` (`--panel`, the card
these charts are drawn on). The number that matters is the **composited** fill, not the hex —
the composition chart ships reduced-opacity fills over the card with full-opacity strokes, and
opacity over the card surface is what the eye receives.

At `BAND_FILL_OPACITY` (0.85) over `#161b22` the band fills are `#34acb5 #337adc #b68622
#bd578f`:

| check | result |
| --- | --- |
| Lightness band | **FAIL** — `#34acb5` L .684 against a .670 ceiling (accepted) |
| Chroma floor | PASS |
| CVD separation | PASS — worst adjacent `#bd578f`↔`#b68622` ΔE 15.2 deutan |
| Normal-vision floor | PASS — worst adjacent 16.7 |
| Contrast vs surface | PASS |

Both hard gates pass. The lightness failure is accepted because it is a glare problem, where a
CVD or normal-vision failure is an *identity* problem: a chart that is slightly bright is a
worse chart, a chart whose series are indistinguishable is not a chart.

**0.85 is not a preference.** Raw hexes fail lightness on two slots; compositing darkens them
and by 0.85 only one remains 0.014 over the ceiling. Below that it gets worse in the checks
that matter — at 0.80 `cash` drops under the chroma floor (C .099) and starts reading grey, and
at 0.75 the hard normal-vision gate breaks. The opacity is exported beside the map for that
reason: "re-run the validator on the composited fill" has no answer without a number, so the
number cannot wait for the chart, and a chart that picked its own would invalidate the record
rather than inherit it.

The category map carries a second accepted FAIL and it is the point of the entry rather than a
defect in it: `#6e7681` fails the chroma floor because grey is what a colour looks like when it
carries no identity, which is exactly how Uncategorized must read. `CATEGORY_DASH` is the
secondary encoding that makes it legal.

The reserve behind `categoryColour`'s fallback is recorded as a **floor, not a palette** — the
one place the validator record does not reach. The four mapped colours plus the three reserve
entries fail both hard gates all-pairs. That is the correct result, not a defect to fix here: a
fifth spending category is a decision that has to pick a colour and re-run the validator on the
whole set. What the fallback guarantees until then is only that an unmapped name draws
something legible and distinct from the four, and never impersonates one of them.

## Tests

`charts.spec.js` gains the gate the existing key-versus-fill assertion could not be. That one
compares two surfaces against *each other*, and both read the same array at the same `i` — so
it passed by construction and would have gone on passing while the donut two cards up
disagreed with them. The new one compares every spending surface against the declared map: the
donut's chips and tracks, the key's chips, the bar fills, and the row markers on the other
view. It imports the map rather than restating it. Mutation-checked — putting the row marker
back on a positional read fails it.

The key/bar half counts against the fixture's own `groups` first, since the chart is behind
`series.length > 0` and a failed fetch would otherwise leave both loops iterating nothing and
reporting green.

`inventory.spec.js` gains two gates: no file outside `palette.js` and `charts.jsx` may mention
`POSITIONAL_COLOURS` (so a fourth positional consumer cannot arrive by paste), and the two maps
must agree about Housing.

**1367 frontend assertions (up from 1345), green at all ten viewports.** No Python in this
diff. The two `.github` comments that quoted the old suite size are updated in the same commit,
since this change is what made them stale.

## Acceptance criteria

- [x] A single name-keyed spending category → colour map exists, and the donut, the monthly
      stacked bar and the By Category row markers all read it; no spending surface indexes a
      palette by position.
- [x] A single name-keyed band → colour map exists for the net-worth chart to consume.
- [x] Personal, Housing, Transport and Uncategorized each render the same colour on every
      spending surface in one viewport.
- [x] The validator has been re-run on the **composited** fill and the result recorded,
      including the accepted lightness-band failure.
- [x] The declaration comments the deliberate Housing coupling between the two maps.
- [x] Existing key-versus-fill Playwright assertions still pass — untouched, and the chips and
      the bar fills now read from the same map.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added consistent, category-based colour mapping across spending charts, donut charts, bars, table markers, and legend chips.
  * Added reliable fallback colours for previously unmapped categories.
  * Added visual treatment for uncategorized spending.

* **Documentation**
  * Expanded testing guidance for chart palette validation and colour consistency.

* **Tests**
  * Added coverage ensuring chart surfaces use the declared palette consistently.
  * Added checks for colour usage rules and Housing colour alignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->