### PR TITLE
feat(networth): three labels move, and the arithmetic stays exactly where it was (#97)

### DIFF
--- a/web/src/modules/networth/NetWorth.jsx
+++ b/web/src/modules/networth/NetWorth.jsx
@@ -66,10 +66,10 @@ export default function NetWorth() {
 const CARDS = [
   ["Total Assets", "total_assets"],
   ["Total Liabilities", "total_liabilities"],
-  ["Liquid Assets", "liquid_assets"],
+  ["Spendable Cash", "liquid_assets"],
   ["Net Worth", "net_worth"],
   ["Net Worth excl. Housing", "net_worth_excl_housing"],
-  ["Net Worth excl. Housing & CPF", "net_worth_excl_housing_cpf"],
+  ["Net Worth excl. Housing & CPF Cash", "net_worth_excl_housing_cpf"],
 ];
 
 function SummaryCards({ m }) {
@@ -308,7 +308,7 @@ function History({ snaps, onSelect, onDelete }) {
             <tr>
               <th style={{ textAlign: "left" }}>Date</th>
               <th>Total Assets</th><th>Total Liab</th><th>Net Worth</th>
-              <th>Excl. Housing</th><th>Excl. Hou+CPF</th><th></th>
+              <th>Excl. Housing</th><th>Excl. Hou+CPF Cash</th><th></th>
             </tr>
           </thead>
           <tbody>


### PR DESCRIPTION
Closes #97. Spec: #92 (map #74) — §F, "Renames (metric arithmetic unchanged)".

## What this is

Three strings on the Net Worth view, and nothing else. +3/−3 in one file.

| | before | after |
| --- | --- | --- |
| tile | Net Worth excl. Housing & CPF | **Net Worth excl. Housing & CPF Cash** |
| tile | Liquid Assets | **Spendable Cash** |
| history `<th>` | Excl. Hou+CPF | **Excl. Hou+CPF Cash** |

**The CPF tile is a genuine defect and this PR does not fix it.** It excludes by catalogue flag,
52% of assets sits behind a scalar no flag can reach, and the tile reads 15.0% over what its name
claims. The fix is arithmetically the *same act* as splitting the Portfolio band, the two share
one blocker — the portfolio bucket columns have no history yet — and doing either alone breaks
the edge identity the composition chart rests on. So the names move now and the metric moves
later, together.

This lands before the composition chart because a **third** surface names the same two metrics —
the chart's key chips and its edge footnote. Rename two of three and the third lies.

## Reviewer notes

**"CPF Cash" over-claims, and that is the word the spec chose.** `excl_housing_cpf` subtracts
`cpf_oa + cpf_sa + cpf_ma`, and SA and MA are not cash. The word is taken from the composition
chart's band, which already made that call, and the tile *is* that band's cumulative edge — so
the alternative here is a fourth name for the same quantity, not a truer one. It is the metric
that is wrong, and the metric moves in its own ticket.

**"Spendable Cash" rather than "Cash & Deposits"**, because the latter lands $4,195 from the
Cash & SRS band on the same page. "Spendable" is the word that explains the gap: the band holds
the locked SRS cash, the tile does not.

**Dropping the Liquid Assets tile was considered and declined upstream — please don't
re-propose it cold.**

**The label is spelled two ways and there is no shared constant.** `SERIES` two functions down
declares the opposite idiom ("the two lines, named once … so they cannot disagree"), so this is a
deliberate departure: the tile says "Net Worth excl. Housing & CPF Cash" and the column head says
"Excl. Hou+CPF Cash", which are different abbreviations of the same metric rather than one string
used twice. Hoisting them would mean inventing a shared fragment to interpolate, which is more
coupling than a rename ticket should install.

**Nothing behind the labels moved.** `metrics()` in `portfolio/networth.py` is not in the diff —
`excl_housing_cpf = excl_housing - cpf_a` is untouched, and both metric keys are unchanged. The
per-tile ids are keyed on the key, not the label (`data-testid={"metric-" + key}`), so
`metric-liquid_assets` and `metric-net_worth_excl_housing_cpf` still resolve. No stored value,
payload field, fixture or computed figure changes.

## Tests

**1367 passed, 470 skipped, at all ten viewports — and no spec file is edited**, which is the
criterion rather than a convenience: no spec asserts a tile label, so the suite is blind to this
change by design. `charts.spec.js:157`'s `["Net Worth", "Excl. Housing"]` is the line chart's key
chips, a different surface this PR does not touch.

**One thing the suite cannot assert, so it was measured.** `RESPONSIVE.md` scopes `NetWorth` out
of the universal list and leaves it "no overlapping or clipped controls, and *readable*" — an eye,
not a gate. The longest label in the view got four characters longer, and `.tiles` is
`repeat(auto-fit, minmax(180px, 1fr))`, so the question is whether it takes a third line and drops
its value out of line with the row. Measured at 360, 390, 640 and 1280, before and after:

| viewport | label lines, before | after | tile height |
| --- | --- | --- | --- |
| 360 × 740 | 1 | 1 | 94px (unchanged) |
| 390 × 844 | 1 | 1 | 94px (unchanged) |
| 640 × 844 | 2 | 2 | 112px (unchanged) |
| 1280 × 800 | 2 | 2 | 112px (unchanged) |

Character for character the same wrap the old string had, in a row whose height the neighbouring
"Net Worth excl. Housing" tile already set. `scrollWidth == clientWidth` on every label at every
width, so nothing is clipped. The measurement harness was a throwaway and is not in the diff.

The history head grew inside the `.contained` wrapper the hscroll ratchet guards; every number in
`hscroll-baseline.js` is still zero.

## Acceptance criteria

- [x] The three labels read exactly as specified.
- [x] `metrics()` and every metric key are unchanged; the per-tile test ids are keyed on the
      metric key and still resolve.
- [x] No stored value, payload field or computed figure changes.
- [x] The frontend suite passes with no spec edits.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Clarified Net Worth labels to distinguish spendable cash.
  * Updated summary cards and history table headers to indicate that CPF cash is excluded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->