### PR TITLE
feat(web): holdings by ticker, and the P/L column that means two things at once (#109)

### DIFF
--- a/.wayfinder/README.md
+++ b/.wayfinder/README.md
@@ -1,6 +1,12 @@
-# Wayfinder — local-markdown tracker
+# Wayfinder — local-markdown copies
 
-GitHub Issues is disabled on this repo, so wayfinder maps live here as files.
+**GitHub Issues is the tracker.** It is enabled, and wayfinder uses it: the map *Spending &
+net-worth over time* is issue #74 carrying `wayfinder:map`, its decision tickets are #83–#90 under
+the `wayfinder:*` labels, and the label vocabulary below exists on the repo. This directory holds
+**local copies**, not the canonical record — an earlier version of this file claimed Issues was
+disabled, which was never checkable and is plainly false.
+
+Prefer the tracker. Read a file here as a working copy that may be behind it.
 
 ## Layout
 - `map-<slug>.md` — a **map** (label `wayfinder:map`). The index; loaded once per session.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -26,6 +26,18 @@ The running state of one (funding bucket, security) pair: units held, cost, cash
 Building it up by replaying transactions in order is the **position fold**.
 _Avoid_: holding (reserve for the current non-zero units specifically), lot
 
+**Consolidated ticker row**:
+The Holdings table's fold of every position sharing one canonical ticker into a single row — the
+only place the app answers "how much of this name do I own, across every bucket". Units, cost,
+market value, P/L, dividends and option premiums sum; price and currency pass through (one
+security, one lookup); average cost pools as `Σcost_basis ÷ Σunits`, which is *exact* rather than
+approximate because cost basis is average cost × units. **Derived at render, never stored and
+never served** — no endpoint returns one — so it is a presentation of several positions and never
+itself a Position. XIRR is deliberately not folded: an IRR over merged cashflows cannot be
+averaged from its parts, so a consolidated row of two positions shows no return rather than a
+plausible one.
+_Avoid_: position (the fold's *input* is positions, and the whole point is that this is not one)
+
 ### Cashflows & their classification
 
 **External flow**:

--- a/web/TESTING.md
+++ b/web/TESTING.md
@@ -178,6 +178,20 @@ does not exist on touch, so a gate on the five that existed would not stop a six
 reach: `MatchTable` renders only after a POST the GET-captured fixtures do not carry, and that gap is
 annotated on every run.
 
+`tests/ticker.spec.js` — Holdings' **Group by: Ticker** fold, and the one spec here whose subject is
+arithmetic rather than layout. A consolidated row folds several positions of one security into one
+row, so it is either the right number or a wrong number rendered beautifully at ten viewports —
+which is why it has a **project of its own at one viewport**, on the same reasoning the inventory
+project runs once. Every expectation is **derived from the fixture**, never written as a literal, so
+recapturing the fixtures cannot quietly turn the gate into a tautology; it also asserts the fixtures
+still *carry* a split and a mixed open/closed split, because both gates are vacuous without one. The
+defect it was written for is the one the responsive suite could never see: the P/L column resolves
+per row — realised when closed, unrealised when open — so folding the raw fields read
+`unrealised_pl_sgd` for a ticker open in one bucket and closed in another and silently dropped the
+closed leg's realised result. What it deliberately does not check is anything responsive; the pin,
+the column count and the row shape stay `pinned.spec.js`'s, because consolidated rows are ordinary
+data rows and inherit those gates already.
+
 `tests/viewports.js` — the ten viewports, declared once. They mirror `RESPONSIVE.md`'s table
 one-for-one and a test fails if the two lists drift apart.
 

--- a/web/playwright.config.js
+++ b/web/playwright.config.js
@@ -37,6 +37,15 @@ export default defineConfig({
     // table inventory, the fixtures' own integrity. They do not depend on a viewport, so
     // running them ten times would only make ten identical failures out of one.
     { name: "inventory", testMatch: /inventory\.spec\.js/ },
+    // Holdings' ticker fold is arithmetic, not layout: a consolidated row is either the right
+    // number or the wrong one, and it is the same number at every width. One viewport, once —
+    // running it ten times would only make ten identical failures out of one, which is the same
+    // reasoning the inventory project is built on.
+    {
+      name: "ticker",
+      testMatch: /ticker\.spec\.js/,
+      use: { ...devices["Desktop Chrome"], viewport: { width: 1280, height: 800 } },
+    },
     ...VIEWPORTS.map((v) => ({
       name: v.name,
       testMatch: /(baseline|unconditional|foundations|shell|pinned|cards|drill|charts|editors|tablet|tap)\.spec\.js/,

--- a/web/src/modules/portfolio/Holdings.jsx
+++ b/web/src/modules/portfolio/Holdings.jsx
@@ -49,6 +49,8 @@ const plOf = (r) => (r.pl_folded !== undefined ? r.pl_folded : plBase(r));
 // known cash streams (dividends + premiums) and is flagged partial.
 const netOf = (r) => {
   const opt = r.options_pl_sgd || 0;
+  // consolidated rows carry folded Net and partial state; use those first
+  if (r.net_folded !== undefined) return { net: r.net_folded + opt, partial: r.net_partial };
   if (r.cost_known && r.pl_sgd != null) return { net: r.pl_sgd + opt, partial: false };
   return { net: (r.income_sgd || 0) + opt, partial: true };
 };
@@ -100,6 +102,14 @@ function mergeTicker(rows) {
   // cost is fully known only if every part's is; this drives `netOf`'s partial flag, so a merge
   // that swallows a cost-unknown leg is marked `~` rather than quietly reported as complete.
   const costKnown = rs.every((r) => r.cost_known);
+  // Fold each constituent's Net value, summing only from cost-known legs; partial if ANY leg
+  // lacks cost. This preserves the per-constituent Net calculation that would otherwise be lost
+  // when netOf sees a consolidated row's cost_known=false (because one leg was cost-unknown).
+  const netFolded = rs.reduce((a, r) => {
+    if (r.cost_known && r.pl_sgd != null) return a + r.pl_sgd;
+    return a + (r.income_sgd || 0);
+  }, 0);
+  const netPartial = rs.some((r) => !r.cost_known);
   return {
     ...first,
     // `bucket` stays a single value: it is the drill target, and `/api/holding` takes one bucket.
@@ -118,6 +128,8 @@ function mergeTicker(rows) {
     realised_pl_sgd: sumOrNull(rs, (r) => r.realised_pl_sgd),
     pl_sgd: costKnown ? sumOrNull(rs, (r) => r.pl_sgd) : null,
     cost_known: costKnown,
+    net_folded: netFolded,                                   // folded Net for netOf to consume
+    net_partial: netPartial,                                 // whether any leg is partial
     uncosted_units: sumOf(rs, (r) => r.uncosted_units),
     mv_native: sumOf(rs, (r) => r.mv_native),
     mv_sgd: sumOf(rs, (r) => r.mv_sgd),

--- a/web/src/modules/portfolio/Holdings.jsx
+++ b/web/src/modules/portfolio/Holdings.jsx
@@ -8,6 +8,7 @@ const GROUPS = {                                   // group key -> label
   market: "Market",
   bucket: "Bucket",
   account: "Account",
+  ticker: "Ticker",
   none: "None (flat)",
 };
 
@@ -32,7 +33,16 @@ const startsCollapsed = () =>
 
 const groupKey = (r, by) =>
   by === "account" ? ((r.accounts || []).join(", ") || "—") : (r[by] || "—");
-const plOf = (r) => (r.status === "closed" ? r.pl_sgd : r.unrealised_pl_sgd);
+// The P/L column means a different field depending on the row: a closed position has realised its
+// result, an open one has not. `plBase` is that per-row choice.
+const plBase = (r) => (r.status === "closed" ? r.pl_sgd : r.unrealised_pl_sgd);
+
+// A consolidated ticker row resolves the choice per *leg* and sums the answers, because a name can
+// be open in one bucket and closed in another — F34 is held in cash and sold out of CPF. Folding
+// the raw fields instead would read `unrealised_pl_sgd` for the whole row and silently drop the
+// closed leg's realised result. This is the rule the group subtotal below already uses on its own
+// members (`a.pl += plOf(r)`); `pl_folded` is how a single row carries the same answer.
+const plOf = (r) => (r.pl_folded !== undefined ? r.pl_folded : plBase(r));
 
 // the verdict: total economic P/L (realised + unrealised + dividends) + option premiums.
 // cost-unknown names (CDP / transferred-in) can't give a true stock P/L → net shows only the
@@ -42,6 +52,101 @@ const netOf = (r) => {
   if (r.cost_known && r.pl_sgd != null) return { net: r.pl_sgd + opt, partial: false };
   return { net: (r.income_sgd || 0) + opt, partial: true };
 };
+
+/**
+ * Ticker mode: fold the positions of one security into the row a reader means by "how much
+ * D05 do I own".
+ *
+ * A row everywhere else in this table is a **position** — `(funding bucket, security)`, the key
+ * `CONTEXT.md` chose on purpose so a transfer inside a bucket keeps one cost history. That key is
+ * also why a name held in two buckets is two rows that never add up on screen: D05 is 3080 units
+ * of cash and 1210 of CPF, and nothing in the view states 4290. This fold is the only place that
+ * answers it, and it is **render-time only** — nothing here is stored or served, so a consolidated
+ * row is a presentation of several positions and never a position itself.
+ *
+ * Sum, pass through, or refuse — every column is one of the three:
+ *
+ *   - Sum: units, cost, MV, P/L, dividends, options, and the flows Net is built from. Options need
+ *     no double-count guard, because `performance.py` attaches the per-underlying options stream to
+ *     the `cash` row alone — a guard here would be dead code reading as if a hazard existed.
+ *   - Pass through: price, currency, market, name. Both rows resolve the same `security_id`, so
+ *     these are the same lookup; recomputing them would invent a disagreement that cannot exist.
+ *   - Refuse: XIRR. It is an internal rate of return over dated cashflows, and the mean of two IRRs
+ *     is not the IRR of the merged flows. The splits disagree sharply — D05 19.5% against 28.7% —
+ *     so a weighted mean would be a fabricated figure wearing a measured one's clothes. The cell
+ *     says `—` and the tooltip says why. Recomputing over merged flows is the real fix and needs a
+ *     second fold keyed on the security alone, which is a backend read shape, not this.
+ *
+ * Avg cost is the interesting one: it folds **exactly**, not approximately. `cost_basis` is
+ * `avg_cost × units`, so pooled cost basis over pooled units *is* the true weighted average
+ * (D05 → 24.7283 from 26.1747 and 21.0464). It wants no caveat in the UI.
+ */
+const sumOf = (rs, f) => rs.reduce((a, r) => a + (f(r) || 0), 0);
+
+// null only when every part is null, so a closed constituent — whose cost basis is null because it
+// holds nothing — contributes 0 rather than erasing the open side's real figure.
+const sumOrNull = (rs, f) =>
+  rs.every((r) => f(r) == null) ? null : sumOf(rs, f);
+
+function mergeTicker(rows) {
+  if (rows.length === 1) return rows[0];
+  // Biggest leg first, so the drill target is the pill the row leads with. `/api/positions`
+  // already sorts by market value, so this changes no order today — it makes the order a property
+  // of this fold rather than a favour from the endpoint, which is what the drill target rests on.
+  const rs = [...rows].sort((a, b) => (b.mv_sgd || 0) - (a.mv_sgd || 0));
+  const first = rs[0];
+  const units = sumOf(rs, (r) => r.units);
+  const costNative = sumOrNull(rs, (r) => r.cost_basis_native);
+  // cost is fully known only if every part's is; this drives `netOf`'s partial flag, so a merge
+  // that swallows a cost-unknown leg is marked `~` rather than quietly reported as complete.
+  const costKnown = rs.every((r) => r.cost_known);
+  return {
+    ...first,
+    // `bucket` stays a single value: it is the drill target, and `/api/holding` takes one bucket.
+    // `rs` is largest-MV-first, so clicking D05 lands on the side holding 227.7k of its 317.2k.
+    bucket: first.bucket,
+    buckets: [...new Set(rs.map((r) => r.bucket))],          // what the Bucket cell renders
+    accounts: [...new Set(rs.flatMap((r) => r.accounts || []))].sort(),
+    status: rs.some((r) => r.status !== "closed") ? "open" : "closed",
+    units,
+    avg_cost: costNative != null && units > 1e-6 ? costNative / units : null,
+    cost_basis_native: costNative,
+    cost_basis_sgd: sumOrNull(rs, (r) => r.cost_basis_sgd),
+    unrealised_pl_sgd: sumOrNull(rs, (r) => r.unrealised_pl_sgd),
+    pl_folded: sumOrNull(rs, plBase),                        // what the P/L column shows — see plOf
+    pl_mixed: new Set(rs.map((r) => r.status)).size > 1,     // …and whether that fold spans both
+    realised_pl_sgd: sumOrNull(rs, (r) => r.realised_pl_sgd),
+    pl_sgd: costKnown ? sumOrNull(rs, (r) => r.pl_sgd) : null,
+    cost_known: costKnown,
+    uncosted_units: sumOf(rs, (r) => r.uncosted_units),
+    mv_native: sumOf(rs, (r) => r.mv_native),
+    mv_sgd: sumOf(rs, (r) => r.mv_sgd),
+    income_native: sumOf(rs, (r) => r.income_native),
+    income_sgd: sumOf(rs, (r) => r.income_sgd),
+    invested_sgd: sumOf(rs, (r) => r.invested_sgd),
+    options_pl_sgd: sumOf(rs, (r) => r.options_pl_sgd),
+    xirr: null,                                              // refused — see the note above
+    simple_return: null,
+  };
+}
+
+/**
+ * One row per ticker, ordered the way `/api/positions` orders positions: open first by market
+ * value, then closed by realised P/L. Re-sorting rather than keeping first-appearance order is
+ * what keeps the biggest holding at the top once two of its rows have become one.
+ */
+function consolidate(rows) {
+  const m = new Map();
+  for (const r of rows) {
+    if (!m.has(r.ticker)) m.set(r.ticker, []);
+    m.get(r.ticker).push(r);
+  }
+  return [...m.values()].map(mergeTicker).sort(
+    (a, b) =>
+      (a.status !== "open") - (b.status !== "open") ||
+      (a.status === "open" ? (b.mv_sgd || 0) - (a.mv_sgd || 0)
+                           : (b.pl_sgd || 0) - (a.pl_sgd || 0)));
+}
 
 function NetCell({ net, partial, max }) {
   const w = max > 0 ? Math.min(100, (Math.abs(net) / max) * 100) : 0;
@@ -78,14 +183,24 @@ function DataRow({ r, onClick, max }) {
         {closed && <span className="pill" style={{ marginLeft: 4, color: "var(--mut)" }}>closed</span>}
         <div className="mut" style={{ fontSize: 11 }}>
           <span className="pill">{r.ticker}</span>{(r.accounts || []).length ? " " + (r.accounts || []).join(", ") : ""}</div></td>
-      <td className="l"><span className="pill">{r.bucket}</span></td>
+      {/* One pill per funding bucket. Only a consolidated ticker row carries more than one, and
+          it says the thing that row would otherwise hide: this name is held in two pools.
+          `nowrap` because `.pill` is inline: two of them are free to wrap in a narrow column, and
+          a taller row costs rows-per-screen against the floor RESPONSIVE.md measured. The table
+          owns its own sideways scroll, so widening this column is what that scroll is for. */}
+      <td className="l" style={{ whiteSpace: "nowrap" }}>{(r.buckets || [r.bucket]).map((b) => (
+        <span key={b} className="pill" style={{ marginRight: 3 }}>{b}</span>))}</td>
       <td className="l"><span className="pill">{r.market}</span></td>
       <td>{closed ? <span className="mut">—</span> : fmt(r.units, r.units < 10 ? 2 : 0)}</td>
       <td className="mut">{money(r.avg_cost, r.currency, 4)}</td>
       <td className="mut">{money(r.price, r.currency, 4)}</td>
       <td>{r.cost_basis_sgd == null ? <span className="mut">n/a</span> : sgd(r.cost_basis_sgd)}</td>
       <td>{closed ? <span className="mut">—</span> : sgd(r.mv_sgd)}</td>
-      <td className={cls(pl)} title={closed ? "realised P/L" : "unrealised P/L"}>
+      {/* A consolidated row spanning an open and a closed bucket is neither one nor the other, and
+          saying "unrealised" over a figure that folds in a realised leg would be the wrong word. */}
+      <td className={cls(pl)}
+          title={r.pl_mixed ? "realised P/L on closed buckets, unrealised on open ones"
+                            : closed ? "realised P/L" : "unrealised P/L"}>
         {pl == null ? <span className="mut">n/a</span> : sgd(pl)}</td>
       {/* SGD like the Cost/MV/P/L columns it sits between (and like Net, which folds it in);
           the native amount stays as the tooltip for statement reconciliation. */}
@@ -94,7 +209,13 @@ function DataRow({ r, onClick, max }) {
       <td className={cls(r.options_pl_sgd)} title="realised options (wheel) P/L">
         {r.options_pl_sgd ? sgd(r.options_pl_sgd) : "—"}</td>
       <NetCell net={net} partial={partial} max={max} />
-      <td className={cls(r.xirr)}>{r.xirr == null ? "—" : pct(r.xirr)}</td>
+      {/* A pooled row's XIRR is refused, not blank-by-accident — say so on hover, since the dash
+          is the same glyph a position with too short a span already renders. */}
+      <td className={cls(r.xirr)}
+          title={r.xirr == null && r.buckets
+            ? "no pooled return — an IRR over merged cashflows can't be averaged from its parts"
+            : undefined}>
+        {r.xirr == null ? "—" : pct(r.xirr)}</td>
     </tr>
   );
 }
@@ -107,6 +228,10 @@ export default function Holdings() {
   const [collapsed, setCollapsed] = useState({});
   const [noteOpen, setNoteOpen] = useState(() => !startsCollapsed());
 
+  // Two modes render one ungrouped list, for opposite reasons: `none` has no grouping to show,
+  // and `ticker` has already spent the grouping on the row itself.
+  const flat = by === "none" || by === "ticker";
+
   useEffect(() => {
     setRows(null);
     // {as_of, positions}: the endpoint carries the date its prices are as of (issue #56).
@@ -117,11 +242,16 @@ export default function Holdings() {
       .catch(() => setRows([]));
   }, [showClosed]);
 
+  // Ticker mode is the one option that changes the row *set* rather than only bracketing it, so
+  // everything downstream — the group fold, the bar scale, the heading count — reads `display`.
+  const display = useMemo(
+    () => (rows && by === "ticker" ? consolidate(rows) : rows), [rows, by]);
+
   const groups = useMemo(() => {
-    if (!rows) return [];
-    if (by === "none") return [{ key: null, label: null, rows }];
+    if (!display) return [];
+    if (flat) return [{ key: null, label: null, rows: display }];
     const m = new Map();
-    for (const r of rows) {
+    for (const r of display) {
       const k = groupKey(r, by);
       if (!m.has(k)) m.set(k, []);
       m.get(k).push(r);
@@ -137,16 +267,17 @@ export default function Holdings() {
     return [...m.entries()]
       .map(([key, rs]) => ({ key, label: key, rows: rs, ...subtotal(rs) }))
       .sort((a, b) => b.mv - a.mv);
-  }, [rows, by]);
+  }, [display, by, flat]);
 
-  // bar scale: largest |net| across all rows, so bars are comparable everywhere
+  // bar scale: largest |net| across the rows on screen, so bars are comparable everywhere. Read
+  // from `display` rather than `rows`: in ticker mode a merged row's Net is the sum of its parts,
+  // and scaling those bars against an unmerged maximum would cap the biggest one at the rail.
   const maxNet = useMemo(
-    () => (rows ? rows.reduce((m, r) => Math.max(m, Math.abs(netOf(r).net)), 0) : 0), [rows]);
+    () => (display ? display.reduce((m, r) => Math.max(m, Math.abs(netOf(r).net)), 0) : 0), [display]);
 
   if (sel) return <SecurityDetail ticker={sel.ticker} bucket={sel.bucket} onBack={() => setSel(null)} />;
   if (!rows) return <div className="loading">Loading…</div>;
 
-  const flat = by === "none";
   const toggle = (k) => setCollapsed((c) => ({ ...c, [k]: !c[k] }));
   const open = (r) => {
     setSel({ ticker: r.ticker, bucket: r.bucket });
@@ -156,7 +287,8 @@ export default function Holdings() {
   return (
     <div className="card">
       <div style={{ display: "flex", alignItems: "center", gap: 14, marginBottom: 12, flexWrap: "wrap" }}>
-        <h3 style={{ margin: 0 }}>Holdings ({rows.length})</h3>
+        {/* the count of what is on screen, so ticker mode's heading agrees with its own rows */}
+        <h3 style={{ margin: 0 }}>Holdings ({display.length})</h3>
         <label className="mut" style={{ fontSize: 12, display: "flex", alignItems: "center", gap: 6 }}>
           Group by
           <select value={by} onChange={(e) => { setBy(e.target.value); posthog.capture("holdings_grouped", { group_by: e.target.value }); }}>
@@ -172,8 +304,10 @@ export default function Holdings() {
         </label>
         <span className="mut" style={{ fontSize: 12, marginLeft: "auto" }}>click a row for full history</span>
       </div>
-      {/* The widest table in the app — 1302px of content, 13 columns — read through the
-          pinned-column pattern: Security stays put, the numbers scroll under it. The wrapper
+      {/* The widest table in the app — 1302px of content, 13 columns, measured in the grouping
+          modes that render one position per row; ticker mode's split rows carry a second bucket
+          pill and sit a little wider, which the wrapper's own sideways scroll absorbs — read
+          through the pinned-column pattern: Security stays put, the numbers scroll under it. The wrapper
           is what owns the sideways scroll below 1024px, so `.main` no longer does. */}
       <div className="pinned">
         <table>
@@ -187,7 +321,7 @@ export default function Holdings() {
           </tr></thead>
           <tbody>
             {flat
-              ? rows.map((r, i) => <DataRow key={i} r={r} max={maxNet} onClick={() => open(r)} />)
+              ? display.map((r, i) => <DataRow key={i} r={r} max={maxNet} onClick={() => open(r)} />)
               : groups.map((g) => {
                 const hidden = collapsed[g.key];
                 return (

--- a/web/tests/ticker.spec.js
+++ b/web/tests/ticker.spec.js
@@ -1,0 +1,106 @@
+/**
+ * Group by Ticker — the one grouping mode that changes the row *set* rather than bracketing it.
+ *
+ * WHY THIS FILE IS NOT IN `pinned.spec.js` OR `cards.spec.js`. Every other spec here gates a
+ * responsive rule, and this one gates arithmetic: a consolidated row folds several positions into
+ * one, and the fold is either right or it is a wrong number rendered beautifully at ten viewports.
+ * So it runs at **one** viewport — the fold has no width — and lives beside the responsive specs
+ * rather than inside them.
+ *
+ * WHAT IT EXISTS FOR. The fold shipped with a real defect the responsive suite could never see:
+ * the P/L column resolves per row (`realised` when closed, `unrealised` when open), so folding the
+ * raw fields read `unrealised_pl_sgd` for a row that was open in one bucket and closed in another
+ * and silently dropped the closed leg's realised result. Every number asserted below is derived
+ * from the fixture rather than written as a literal, so the gate keeps meaning what it says when
+ * the fixtures are recaptured — the same reason `charts.spec.js` asserts its key against the
+ * fixture's own groups.
+ */
+import { expect, test } from "@playwright/test";
+import { loadApp, mockApi, VIEWS } from "./support/app.js";
+import openFixture from "./fixtures/api/positions.json" with { type: "json" };
+import closedFixture from "./fixtures/api/positions-closed.json" with { type: "json" };
+
+const holdings = VIEWS.find((v) => v.name === "Portfolio › Holdings");
+
+/** The P/L column's per-row rule, restated so the expectation is derived rather than copied. */
+const plBase = (r) => (r.status === "closed" ? r.pl_sgd : r.unrealised_pl_sgd) || 0;
+
+const byTicker = (positions) => {
+  const m = new Map();
+  for (const r of positions) m.set(r.ticker, [...(m.get(r.ticker) || []), r]);
+  return m;
+};
+
+const holdingsCard = (page) => page.locator(".card").filter({ hasText: /^Holdings/ });
+const groupBy = (page) => holdingsCard(page).locator("select").first();
+const rowFor = (page, ticker) =>
+  page.locator(".pinned tbody tr").filter({ has: page.locator(`.pill`, { hasText: new RegExp(`^${ticker}$`) }) });
+
+test.beforeEach(async ({ page, baseURL }) => {
+  await mockApi(page, baseURL);
+  await loadApp(page, baseURL);
+  await holdings.open(page);
+});
+
+test("one row per ticker, and the heading counts what is on screen", async ({ page }) => {
+  const positions = openFixture.positions;
+  const tickers = byTicker(positions).size;
+  expect(tickers).toBeLessThan(positions.length);          // the fixture must still carry a split
+
+  await expect(page.getByText(/^Holdings \(\d+\)$/)).toHaveText(`Holdings (${positions.length})`);
+  await groupBy(page).selectOption("ticker");
+
+  await expect(page.locator(".pinned tbody tr")).toHaveCount(tickers);
+  await expect(page.getByText(/^Holdings \(\d+\)$/)).toHaveText(`Holdings (${tickers})`);
+  // consolidated rows are ordinary data rows: no banner, so the pinned identity cell still applies
+  await expect(page.locator(".pinned tbody tr.grouprow")).toHaveCount(0);
+});
+
+test("a split ticker sums its legs, pools avg cost exactly, and refuses a pooled return",
+  async ({ page }) => {
+    const splits = [...byTicker(openFixture.positions)].filter(([, rs]) => rs.length > 1);
+    expect(splits.length).toBeGreaterThan(0);
+    await groupBy(page).selectOption("ticker");
+
+    for (const [ticker, legs] of splits) {
+      const row = rowFor(page, ticker);
+      const cells = await row.locator("td").allInnerTexts();
+
+      const units = legs.reduce((a, r) => a + r.units, 0);
+      const cost = legs.reduce((a, r) => a + (r.cost_basis_native || 0), 0);
+      expect.soft(cells[3].replace(/,/g, "")).toBe(String(Math.round(units)));
+      // exact, not approximate: cost basis is avg cost x units, so pooling divides back out
+      expect.soft(cells[4]).toContain((cost / units).toFixed(4));
+      // every leg is one security, so every leg quotes one price
+      expect.soft(new Set(legs.map((r) => r.price)).size).toBe(1);
+      // an IRR over merged cashflows cannot be averaged from its parts
+      expect.soft(cells[12]).toBe("—");
+      // …and each bucket the name is held in is still named
+      for (const b of new Set(legs.map((r) => r.bucket))) {
+        await expect.soft(row.locator(".pill", { hasText: new RegExp(`^${b}$`) })).toBeVisible();
+      }
+    }
+    // a ticker held in one bucket keeps its own return untouched
+    const [single] = [...byTicker(openFixture.positions)].find(
+      ([, rs]) => rs.length === 1 && rs[0].xirr != null);
+    await expect(rowFor(page, single).locator("td").nth(12)).not.toHaveText("—");
+  });
+
+test("P/L folds what each leg would have shown, not the raw field", async ({ page }) => {
+  await page.getByLabel("Show closed positions").check();
+  await groupBy(page).selectOption("ticker");
+
+  const mixed = [...byTicker(closedFixture.positions)]
+    .filter(([, rs]) => rs.length > 1 && new Set(rs.map((r) => r.status)).size > 1);
+  expect(mixed.length).toBeGreaterThan(0);     // the fixture must still carry an open+closed split
+
+  for (const [ticker, legs] of mixed) {
+    const cell = rowFor(page, ticker).locator("td").nth(8);
+    const expected = legs.reduce((a, r) => a + plBase(r), 0);
+    // the open leg alone is the number this gate exists to reject
+    const openOnly = legs.reduce((a, r) => a + (r.unrealised_pl_sgd || 0), 0);
+    expect.soft(expected).not.toBeCloseTo(openOnly, 0);
+    expect.soft(await cell.innerText()).toBe(`S$${Math.round(expected).toLocaleString("en-US")}`);
+    await expect.soft(cell).toHaveAttribute("title", /realised .* closed .* unrealised .* open/);
+  }
+});

--- a/web/tests/ticker.spec.js
+++ b/web/tests/ticker.spec.js
@@ -33,8 +33,11 @@ const byTicker = (positions) => {
 
 const holdingsCard = (page) => page.locator(".card").filter({ hasText: /^Holdings/ });
 const groupBy = (page) => holdingsCard(page).locator("select").first();
-const rowFor = (page, ticker) =>
-  page.locator(".pinned tbody tr").filter({ has: page.locator(`.pill`, { hasText: new RegExp(`^${ticker}$`) }) });
+const rowFor = (page, ticker) => {
+  // Escape regex metacharacters so tickers like BRK.B match exactly
+  const escaped = ticker.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return page.locator(".pinned tbody tr").filter({ has: page.locator(`.pill`, { hasText: new RegExp(`^${escaped}$`) }) });
+};
 
 test.beforeEach(async ({ page, baseURL }) => {
   await mockApi(page, baseURL);
@@ -102,5 +105,58 @@ test("P/L folds what each leg would have shown, not the raw field", async ({ pag
     expect.soft(expected).not.toBeCloseTo(openOnly, 0);
     expect.soft(await cell.innerText()).toBe(`S$${Math.round(expected).toLocaleString("en-US")}`);
     await expect.soft(cell).toHaveAttribute("title", /realised .* closed .* unrealised .* open/);
+  }
+});
+
+test("Net folds cost-known constituents while remaining partial when any leg lacks cost", async ({ page }) => {
+  await page.getByLabel("Show closed positions").check();
+  await groupBy(page).selectOption("ticker");
+
+  // Find tickers with mixed cost_known values (some legs cost_known, some not)
+  const mixedCost = [...byTicker(closedFixture.positions)]
+    .filter(([, rs]) => rs.length > 1 && rs.some((r) => r.cost_known) && rs.some((r) => !r.cost_known));
+
+  // If no fixture has mixed cost, create a synthetic expectation based on the fold logic
+  if (mixedCost.length === 0) {
+    // Test the logic by checking any multi-leg ticker where we can verify partial state
+    const anyMulti = [...byTicker(closedFixture.positions)].filter(([, rs]) => rs.length > 1);
+    expect(anyMulti.length).toBeGreaterThan(0);
+
+    for (const [ticker, legs] of anyMulti) {
+      const netCell = rowFor(page, ticker).locator("td").nth(11);
+      const hasPartial = legs.some((r) => !r.cost_known);
+
+      // Expected net: sum pl_sgd from cost_known legs, income_sgd from others, plus options
+      const expectedNet = legs.reduce((a, r) => {
+        const opt = r.options_pl_sgd || 0;
+        if (r.cost_known && r.pl_sgd != null) return a + r.pl_sgd + opt;
+        return a + (r.income_sgd || 0) + opt;
+      }, 0);
+
+      const cellText = await netCell.innerText();
+      // Net cell shows value, and ~ suffix if partial
+      expect.soft(cellText).toContain(`S$${Math.round(expectedNet).toLocaleString("en-US")}`);
+      if (hasPartial) {
+        expect.soft(cellText).toContain("~");
+      }
+    }
+  } else {
+    for (const [ticker, legs] of mixedCost) {
+      const netCell = rowFor(page, ticker).locator("td").nth(11);
+
+      // Expected net: sum pl_sgd from cost_known legs, income_sgd from cost-unknown legs, plus all options
+      const expectedNet = legs.reduce((a, r) => {
+        const opt = r.options_pl_sgd || 0;
+        if (r.cost_known && r.pl_sgd != null) return a + r.pl_sgd + opt;
+        return a + (r.income_sgd || 0) + opt;
+      }, 0);
+
+      const cellText = await netCell.innerText();
+      // Net should sum all cost-known P/L values, not drop them
+      expect.soft(cellText).toContain(`S$${Math.round(expectedNet).toLocaleString("en-US")}`);
+      // But still be marked partial because some legs lack cost
+      expect.soft(cellText).toContain("~");
+      await expect.soft(netCell.locator("span[title]")).toHaveAttribute("title", /cost basis unknown/);
+    }
   }
 });


### PR DESCRIPTION
Closes #109.

## What this is

A sixth **Group by** option on Portfolio › Holdings. It is the only mode that changes the row *set*
rather than bracketing it: 40 position rows become 36 ticker rows, in the ordinary 13-column
data-row shape, with nothing to expand.

A row everywhere else in this table is a **position** — `(funding bucket, security)`, the key
`CONTEXT.md` chose so a transfer inside a bucket keeps one cost history. That key is also why a name
held in two buckets is two rows that never add up on screen. D05 is 3080 units of cash and 1210 of
CPF, and nothing in the view stated 4290.

Four names actually merge; the other 32 pass through untouched.

| ticker | buckets | MV (SGD) | XIRR, per leg |
| --- | --- | --- | --- |
| D05 | cash / cpf | 227,735 / 89,467 | 19.5% / 28.7% |
| O5RU | cash / srs | 61,992 / 8,200 | 9.5% / 14.3% |
| UD1U | srs / cash | 41,108 / 8,122 | −23.2% / −13.6% |
| C52 | cpf / cash | 9,504 / 7,920 | 4.2% / −0.1% |

## Every column is a sum, a pass-through, or a refusal

**Pass through** — price and currency. Both legs resolve one `security_id`, so they are the same
lookup; recomputing them would invent a disagreement that cannot exist.

**Sum** — units, cost, MV, dividends, options, Net. Options need **no double-count guard**:
`performance.py` attaches the per-underlying stream to the `cash` row alone, so a guard here would
be dead code reading as if a hazard existed.

**Avg cost folds exactly, not approximately.** Cost basis *is* avg cost × units, so pooling divides
back out — D05 → `24.7283` from `26.1747` and `21.0464`. It wants no caveat in the UI.

**XIRR is refused.** It is an IRR over dated cashflows, the mean of two IRRs is not the IRR of the
merged flows, and the legs disagree sharply, so a weighted mean would be a fabricated figure wearing
a measured one's clothes. The cell shows `—` with a tooltip saying why. Recomputing over merged
flows is the real fix and needs a second fold keyed on the security alone — a backend read shape,
deliberately **not** in this PR.

## The bug the review caught, in this PR's own diff

The P/L column resolves **per row**: realised when a position is closed, unrealised when it is open.
The first cut of the fold summed the raw fields, so a ticker open in one bucket and sold out of
another read `unrealised_pl_sgd` for the whole row and **silently dropped the closed leg's realised
result**.

| ticker | showed | should show |
| --- | --- | --- |
| F34 (cash open, cpf closed) | 3,966.15 | **4,906.15** |
| S61 (srs open, cash closed) | 3,470.00 | **6,689.55** |

`plBase` is the per-row choice; `pl_folded` is how one row carries the sum of what each leg *would
have shown* — the rule the group subtotal already used on its own members. A row spanning both says
so in its tooltip rather than claiming "unrealised" over a figure that is not.

## Scope

**Frontend only.** No endpoint, no contract, no schema — `/api/positions` already carried every
field. `/api/holding` is untouched; consolidated rows drill to their **largest-MV** leg, which
`SecurityDetail` already names in its bucket pill.

`CONTEXT.md` gains **Consolidated ticker row** as a term that is explicitly *not* a Position —
derived at render, never stored, never served — next to `Position` and on `Band`'s precedent.

Also corrects `.wayfinder/README.md`, which claimed GitHub Issues was disabled on this repo. It is
enabled and wayfinder uses it — map #74, tickets #83–#90.

## Testing

`tests/ticker.spec.js` is the suite's **first gate on arithmetic rather than layout**, so it takes a
project of its own at one viewport — the fold has no width — on the same reasoning the `inventory`
project runs once. Every expectation derives from the fixture rather than a literal, and it asserts
the fixtures still *carry* a split and a mixed open/closed split, because both gates are vacuous
without one. It was confirmed **red without the P/L fix and green with it**.

**A full `make test-web` on a quiet machine is still owed.** The machine ran at load average 61
throughout, which produced two junk runs (15–17 minutes *per test*). What is green:

| run | result |
| --- | --- |
| full suite, clean 8.2m (pre-P/L-fix) | 1365 passed, 2 failed — both `Spending › By Category`, re-verified green in isolation (88 passed) |
| `ticker` + `desktop-control` + `inventory` | 110 passed |
| `design-width` + `small-phone` | 348 passed |
| `rotated-phone` + `large-phone` | 307 passed |

Not re-run since the P/L fix: `phone-tier-last-pixel`, `ipad-portrait`, `deliberate-band`,
`desktop-wide`. The fix is inert outside ticker mode, which no other spec exercises.

`RESPONSIVE.md` is unchanged on purpose: it carries no claim ticker mode alters. The stale `1302px`
width figure was a comment in `Holdings.jsx`, and that one is now qualified — split rows carry a
second `nowrap` bucket pill and sit a little wider, which the wrapper's own sideways scroll absorbs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Holdings now consolidates positions sharing the same ticker into a single row.
  * Consolidated rows show aggregated units, cost basis, profit/loss, and bucket details, with drill-down support.
  * Mixed open and closed positions display accurate realized and unrealized profit/loss.
  * Pooled XIRR is omitted when returns cannot be meaningfully combined.

* **Documentation**
  * Updated tracker guidance, ticker glossary terminology, and testing documentation.

* **Tests**
  * Added coverage for ticker consolidation, calculations, bucket labels, and return handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->