### PR TITLE
feat(web): the snapshot form reads the catalogue it is capturing (#99)

### DIFF
--- a/web/TESTING.md
+++ b/web/TESTING.md
@@ -170,7 +170,12 @@ catch.
 
 `tests/inventory.spec.js` — the checks that read files rather than pixels: the table count, the
 single donut implementation, that no chart renders a `<Legend>` and that both multi-series charts
-carry a `<ChartKey>`, that **no spending surface mentions the `POSITIONAL_COLOURS` array** — only
+carry a `<ChartKey>`, that **no source file names a net-worth catalogue item code** — the New
+Snapshot form's headings and rows are derived from the catalogue's `band`, and the codes are read
+out of the fixture so a recapture cannot leave the gate asserting a stale list (`srs` is held out,
+because one word is a code, a band value *and* a funding bucket, so the claim is about the other
+thirteen) — that
+**no spending surface mentions the `POSITIONAL_COLOURS` array** — only
 `palette.js`, which declares it, and `charts.jsx`, whose portfolio donut slices by market and by
 account and so has no taxonomy to key a map on — and that **the two colour maps agree about
 Housing**, which is a deliberate coupling (spend Housing is the running cost of the same HDB whose
@@ -208,6 +213,28 @@ per row — realised when closed, unrealised when open — so folding the raw fi
 closed leg's realised result. What it deliberately does not check is anything responsive; the pin,
 the column count and the row shape stay `pinned.spec.js`'s, because consolidated rows are ordinary
 data rows and inherit those gates already.
+
+`tests/catalogue.spec.js` — the New Snapshot form's **headings**, and the second spec here whose
+subject is not layout. Which item a person types under which heading is either the catalogue's own
+banding or it is a second banding that agrees with the first until the day it does not — and that is
+the same partition at every width, so it runs at **one viewport in a project of its own**, on the
+reasoning `ticker.spec.js` and the inventory project already carry. The defect it was written for is
+one no responsive gate could ever see: the form rendered a frontend constant listing item codes, so a
+**fifteenth seeded item was invisible in the entry form and silently absent from every snapshot
+typed** — the creator's zeroing rule fabricating a $0 for it on every capture, forever, with nothing
+on screen to say so. So the central test serves a catalogue this frontend has never heard of and
+asserts the new item both renders a row and reaches the POST; the others assert the partition both
+ways (one band per heading *and* one heading per band — either alone is satisfiable by a degenerate
+layout) and that the payload is byte-for-byte the one the form always sent, prefill included. Every
+expectation is derived from the fixtures, and nothing in it names a catalogue code or a real band
+value: a gate that restated the constant would be the constant. Two more tests close the windows the
+first four leave open — an item whose band the frontend has no heading for is still typed, under a
+heading titled with the band itself, and a catalogue that GROWS while the form is open does not take
+the view down (the view refetches `/items` after every save, and `rows` is re-seeded by an effect
+that runs after that render). Three of the six would have passed against the deleted constant, which
+listed exactly the fixture's fourteen codes in exactly its band order; they are characterization, and
+the other three are the regression gates. What none of them check is the form's geometry, which stays
+`editors.spec.js`'s at all ten viewports.
 
 `tests/viewports.js` — the ten viewports, declared once. They mirror `RESPONSIVE.md`'s table
 one-for-one and a test fails if the two lists drift apart.

--- a/web/playwright.config.js
+++ b/web/playwright.config.js
@@ -46,6 +46,14 @@ export default defineConfig({
       testMatch: /ticker\.spec\.js/,
       use: { ...devices["Desktop Chrome"], viewport: { width: 1280, height: 800 } },
     },
+    // The New Snapshot form's groupings, on the same reasoning: which item is typed under which
+    // heading is the catalogue's banding or it is a second banding, and that is the same
+    // partition at every width. `editors.spec.js` keeps the form's geometry at all ten.
+    {
+      name: "catalogue",
+      testMatch: /catalogue\.spec\.js/,
+      use: { ...devices["Desktop Chrome"], viewport: { width: 1280, height: 800 } },
+    },
     ...VIEWPORTS.map((v) => ({
       name: v.name,
       testMatch: /(baseline|unconditional|foundations|shell|pinned|cards|drill|charts|editors|tablet|tap)\.spec\.js/,

--- a/web/src/modules/networth/NetWorth.jsx
+++ b/web/src/modules/networth/NetWorth.jsx
@@ -6,13 +6,67 @@ import { ChartKey } from "../../charts.jsx";
 
 const today = () => new Date().toISOString().slice(0, 10);
 
-// catalogue groups for the form layout
-const GROUPS = [
-  { title: "Cash / Liquid", codes: ["posb", "dbs_multiplier", "tiger_hkd", "tiger_sgd", "tiger_usd", "tiger_vault", "ibkr_sgd"] },
-  { title: "SRS", codes: ["srs"] },
-  { title: "CPF", codes: ["cpf_oa", "cpf_sa", "cpf_ma"] },
-  { title: "Housing", codes: ["hdb", "home_loan", "home_loan_accrued"] },
-];
+/**
+ * Band → the heading the New Snapshot form types it under. THE WORDS ONLY.
+ *
+ * Which item sits under which heading is `band` on the catalogue row, decided once server-side
+ * by `portfolio/networth.py`'s precedence function and read here — the same rule the composition
+ * chart will read, so the form a person types into and the chart they read are grouped by one
+ * decision that lives in one place.
+ *
+ * WHAT THIS REPLACED, because the difference is not tidiness. This was a constant listing item
+ * *codes* under four titles, and the form rendered the constant rather than the catalogue it is
+ * capturing: an item in no list rendered no row, so `save()` never sent it, so the creator's
+ * zeroing rule fabricated a $0 for it on every capture, forever, with nothing on screen to say
+ * so. A fifteenth seeded item was invisible in the form and silently absent from every snapshot
+ * typed. `tests/catalogue.spec.js` serves a catalogue this file has never heard of and asserts
+ * the row and the payload both carry it.
+ *
+ * THE FORM DOES NOT FOLD SRS INTO CASH, and that is not an oversight against `palette.js`'s
+ * `BAND_COLOURS`. Four keys either side, and deliberately not the same four: this map is keyed on
+ * what the *catalogue* partitions into, `BAND_COLOURS` on what the *chart* stacks — which folds
+ * `srs` into `cash` (an SRS area would be sub-pixel) and adds a synthetic `portfolio` that is no
+ * catalogue row at all. A heading costs one line and a field is a field, so the form shows every
+ * band a person can actually type into.
+ *
+ * A MISSING KEY FALLS BACK TO THE BAND ITSELF rather than dropping the rows, which is the whole
+ * failure mode this ticket removed: `band()` returns one of four values today, so a fifth is a
+ * server-side change that should arrive as an unstyled heading a reader can see and report — not
+ * as fields nobody can find.
+ */
+const BAND_TITLES = {
+  cash: "Cash / Liquid",
+  srs: "SRS",
+  cpf: "CPF",
+  housing: "Housing",
+};
+
+/**
+ * The catalogue, partitioned into the form's headed sections.
+ *
+ * SECTIONS AND NOT "GROUPS": `CONTEXT.md`'s Band entry names *group* as the word to avoid for
+ * exactly this thing, because it was this file's deleted constant. The CSS classes are still
+ * `.nw-group` / `.nw-grouptitle` and stay that way — renaming a stylesheet is a different change
+ * from renaming a decision.
+ *
+ * ORDER IS THE CATALOGUE'S, both ways: rows follow `sort_order` within a section because the
+ * endpoint already returns them that way, and the sections themselves follow the order their
+ * first item appears in. So there is no second ordering constant to disagree with the seed —
+ * re-order the catalogue and the form re-orders with it.
+ */
+function bandSections(items) {
+  const sections = [];
+  const byBand = new Map();
+  for (const it of items) {
+    if (!byBand.has(it.band)) {
+      const section = { band: it.band, title: BAND_TITLES[it.band] ?? it.band, items: [] };
+      byBand.set(it.band, section);
+      sections.push(section);
+    }
+    byBand.get(it.band).items.push(it);
+  }
+  return sections;
+}
 
 export default function NetWorth() {
   const [items, setItems] = useState(null);
@@ -152,15 +206,35 @@ function SnapshotForm({ items, prefill, onSaved, setErr }) {
   useEffect(() => { setRows(init()); }, [prefill, items]);   // eslint-disable-line
 
   const byCode = Object.fromEntries(items.map((it) => [it.code, it]));
-  const set = (code, field, val) => setRows((r) => ({ ...r, [code]: { ...r[code], [field]: val } }));
+
+  /**
+   * One item's typed row — and the reason nothing here reads `rows[code]` directly.
+   *
+   * `rows` is re-seeded by an EFFECT, which runs after the render that new `items` cause. The
+   * view refetches the catalogue after every save and after every delete, so there is one render
+   * in which the form is asked to draw an item that has no row yet — and that is not a
+   * hypothetical, it is precisely the newly-seeded item this form now renders *because* it reads
+   * the catalogue. Read unguarded it throws out of render into the whole-app `ErrorBoundary`, so
+   * the person who just saved a snapshot loses the page rather than gaining a field. `save()`
+   * reads through here for the same reason and inside the same window.
+   *
+   * The seed is what `init()` will put there a moment later — the catalogue's own default
+   * currency, not a blank — so the field cannot flicker through a different value on its way to
+   * being correct.
+   */
+  const blank = (code) => ({ native_value: 0, currency: byCode[code]?.currency_default ?? "SGD" });
+  const row = (code) => rows[code] ?? blank(code);
+
+  const set = (code, field, val) =>
+    setRows((r) => ({ ...r, [code]: { ...(r[code] ?? blank(code)), [field]: val } }));
 
   async function save() {
     setBusy(true); setErr("");
     try {
       const values = items.map((it) => ({
         code: it.code,
-        native_value: parseFloat(rows[it.code].native_value) || 0,
-        currency: rows[it.code].currency,
+        native_value: parseFloat(row(it.code).native_value) || 0,
+        currency: row(it.code).currency,
       }));
       await post("/api/networth/snapshots", { date, note: note || null, values });
       posthog.capture("net_worth_snapshot_saved", { has_note: Boolean(note) });
@@ -182,20 +256,20 @@ function SnapshotForm({ items, prefill, onSaved, setErr }) {
         <label>Note <input type="text" value={note} placeholder="optional"
                            onChange={(e) => setNote(e.target.value)} /></label>
       </div>
-      {GROUPS.map((g) => (
-        <div key={g.title} className="nw-group">
-          <div className="nw-grouptitle">{g.title}</div>
-          {g.codes.map((code) => {
-            const it = byCode[code];
-            if (!it) return null;
-            const sgdItem = (rows[code].currency || "SGD") === "SGD";
+      {bandSections(items).map((sec) => (
+        <div key={sec.band} className="nw-group">
+          <div className="nw-grouptitle">{sec.title}</div>
+          {sec.items.map((it) => {
+            const code = it.code;
+            const r = row(code);
+            const sgdItem = (r.currency || "SGD") === "SGD";
             return (
               <div className="nw-row" key={code}>
                 <span className="nw-label">{it.label}{it.kind === "liability" && <span className="pill">liab</span>}</span>
-                <input type="number" step="0.01" value={rows[code].native_value}
+                <input type="number" step="0.01" value={r.native_value}
                        data-testid={"input-" + code}
                        onChange={(e) => set(code, "native_value", e.target.value)} />
-                <select value={rows[code].currency} disabled={["SGD"].includes(it.currency_default) && sgdItem}
+                <select value={r.currency} disabled={["SGD"].includes(it.currency_default) && sgdItem}
                         onChange={(e) => set(code, "currency", e.target.value)}>
                   {["SGD", "USD", "HKD"].map((c) => <option key={c} value={c}>{c}</option>)}
                 </select>

--- a/web/tests/catalogue.spec.js
+++ b/web/tests/catalogue.spec.js
@@ -1,0 +1,245 @@
+/**
+ * The New Snapshot form's headings — and the item that must never be invisible.
+ *
+ * WHY THIS FILE IS NOT IN `editors.spec.js`. That file gates the two editors' *floor*: what
+ * happens to their geometry below 1024. This gates a partition — which catalogue item is typed
+ * under which heading — and a partition has no width. It is either the catalogue's own banding
+ * or it is a second banding that agrees with the first until the day it does not, and that is
+ * the same at ten viewports. So it runs at **one**, in a project of its own, on the reasoning
+ * `ticker.spec.js` and the inventory project are both built on.
+ *
+ * WHAT IT EXISTS FOR. The form used to render a frontend constant listing item codes under four
+ * headings — not the catalogue it is capturing. That is a latent bug rather than duplication: a
+ * fifteenth seeded item is in no list, so it renders no row, so `save()` never sends it and the
+ * zeroing rule fabricates a $0 for it on every capture, forever, with nothing on screen to say
+ * so. `test("a newly seeded item…")` below is that bug, written down: it serves a catalogue the
+ * constant could not have known and asserts the item both renders and reaches the payload.
+ *
+ * THREE OF THESE SIX ARE CHARACTERIZATION, and saying so is the honest framing: the constant
+ * listed exactly the fixture's fourteen codes in exactly its band order, so the partition and the
+ * payload tests would have passed against it too. They are here to hold the refactor to "a
+ * rendering change and nothing else". The regression gates are the three that could not have
+ * passed before: the newly seeded item, the unknown band, and the catalogue that grows while the
+ * form is open.
+ *
+ * EVERY EXPECTATION IS DERIVED FROM THE FIXTURE, never written as a literal — the same
+ * discipline `ticker.spec.js` and `charts.spec.js` hold, and here it is what stops the gate from
+ * becoming a restatement of the constant it exists to forbid. Nothing below names a heading, a
+ * *catalogue* item code or a band value; the fixture's own `band` is the only partition any of it
+ * reads. The two strings written out are the fifteenth item's code and the band nothing has ever
+ * returned — both invented here precisely because no catalogue and no frontend carries them.
+ */
+import { expect, test } from "@playwright/test";
+import { mockApi, VIEWS } from "./support/app.js";
+import catalogue from "./fixtures/api/networth-items.json" with { type: "json" };
+import latest from "./fixtures/api/networth-latest.json" with { type: "json" };
+
+const netWorth = VIEWS.find((v) => v.name === "Net Worth");
+
+const BAND_OF = Object.fromEntries(catalogue.map((i) => [i.code, i.band]));
+const BANDS = new Set(catalogue.map((i) => i.band));
+
+/**
+ * What the form starts every field at: the latest snapshot's figure where it has one, and the
+ * catalogue's own default where it does not.
+ *
+ * Restated here rather than assumed, because the *prefill* is what makes the payload gate below
+ * mean something. A form that rendered its rows correctly and then posted zeroes for all of them
+ * would satisfy every other assertion in this file and wipe the snapshot.
+ */
+const PREFILLED = Object.fromEntries((latest.values ?? []).map((v) => [v.code, v]));
+const startingValue = (it) => PREFILLED[it.code]?.native_value ?? 0;
+const startingCurrency = (it) => PREFILLED[it.code]?.currency ?? it.currency_default;
+
+/**
+ * The form as rendered: one entry per headed section, in DOM order, with the codes typed under it.
+ *
+ * "Section" and not "group": `CONTEXT.md`'s Band entry names *group* as the word to avoid for this,
+ * because it was the name of the constant this file exists to keep deleted. `.nw-group` is the
+ * pre-existing class and is what the DOM is queried by.
+ *
+ * Read off `data-testid="input-<code>"` rather than off the visible label, because the code is
+ * what `save()` posts — a heading holding the right *words* over the wrong row would pass a
+ * label-keyed gate and still write the wrong snapshot.
+ */
+const renderedSections = (page) =>
+  page.$$eval("[data-testid=networth-form] .nw-group", (sections) =>
+    sections.map((g) => ({
+      title: g.querySelector(".nw-grouptitle")?.textContent ?? null,
+      codes: [...g.querySelectorAll("input[data-testid^='input-']")].map((i) =>
+        i.getAttribute("data-testid").slice("input-".length)),
+    })));
+
+/**
+ * Load the app with the seam installed, optionally serving a catalogue of our own, and open
+ * Net Worth.
+ *
+ * `catalogueFor` is a function of the *fetch count*, not a constant, because the view refetches
+ * `/items` after every save and delete — so "the catalogue grew while the form was open" is a
+ * state this app reaches on its own and a test that could only answer the first fetch could
+ * never reach it.
+ *
+ * `loadApp` is deliberately not used: it installs `mockApi` itself, and Playwright matches
+ * routes in reverse registration order — so calling it after the override would put the
+ * committed fixture back in front of it.
+ */
+async function openForm(page, baseURL, catalogueFor) {
+  await mockApi(page, baseURL);
+  if (catalogueFor) {
+    let served = 0;
+    await page.route("**/api/networth/items", (route) =>
+      route.fulfill({
+        status: 200, contentType: "application/json",
+        body: JSON.stringify(catalogueFor(served++)),
+      }));
+  }
+  await page.goto("/");
+  await expect(page.locator(".app")).toBeVisible({ timeout: 20_000 });
+  await netWorth.open(page);
+  await expect(page.getByTestId("networth-form")).toBeVisible();
+}
+
+/** The whole-app fallback `ErrorBoundary` renders when a render throws. */
+const crashed = (page) => page.getByText("Something went wrong");
+
+/**
+ * Type a snapshot and capture what the form posted.
+ *
+ * The POST has no committed fixture — the captures are GETs from the live database — so this
+ * both answers it and records it. `fallback()` on anything else hands the path back to
+ * `mockApi`'s catch-all, which is what keeps the reload after a save working.
+ */
+async function saveAndCapture(page) {
+  let posted = null;
+  await page.route("**/api/networth/snapshots", async (route) => {
+    if (route.request().method() !== "POST") return route.fallback();
+    posted = route.request().postDataJSON();
+    return route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ id: 1 }) });
+  });
+  await page.getByTestId("snapshot-save").click();
+  await expect.poll(() => posted, { message: "the form never posted" }).not.toBeNull();
+  return posted;
+}
+
+test("every catalogue item is typed exactly once", async ({ page, baseURL }) => {
+  // The whole of the bug in one assertion: an item the form does not render is an item the
+  // form cannot send. A set comparison rather than an ordered one on purpose — within a
+  // heading the rows follow the catalogue's `sort_order`, but the headings themselves are not
+  // required to interleave with it, so asserting the flattened order would be asserting that
+  // no two bands ever alternate in the seed.
+  await openForm(page, baseURL);
+  const codes = (await renderedSections(page)).flatMap((g) => g.codes);
+  expect([...codes].sort(), "a catalogue item with no row is silently $0 in every snapshot")
+    .toEqual(catalogue.map((i) => i.code).sort());
+});
+
+test("each heading is one band, and each band is one heading", async ({ page, baseURL }) => {
+  // The partition, both ways. "One band per heading" alone is satisfied by splitting a band
+  // across two headings; "one heading per band" alone is satisfied by one heading holding
+  // everything. Together they say the headings *are* the banding.
+  expect(BANDS.size, "the fixture carries one band — both gates below are vacuous")
+    .toBeGreaterThan(1);
+
+  await openForm(page, baseURL);
+  const rendered = await renderedSections(page);
+
+  for (const g of rendered) {
+    const bands = new Set(g.codes.map((c) => BAND_OF[c]));
+    expect([...bands], `"${g.title}" holds rows from more than one band`).toHaveLength(1);
+  }
+  const headed = rendered.map((g) => BAND_OF[g.codes[0]]);
+  expect(new Set(headed).size, "a band split across two headings").toBe(rendered.length);
+  expect(new Set(headed), "a band with no heading").toEqual(BANDS);
+});
+
+/**
+ * The fifteenth item, and the reason this file exists.
+ *
+ * Its code is in no list anywhere in the frontend and never will be — `inventory.spec.js`
+ * forbids one. It inherits the first catalogue row's band, so the tests that use it are asking
+ * about *membership* rather than about a new heading appearing; `UNBANDED` below asks the other
+ * question.
+ */
+const HOST = catalogue[0];
+const SEEDED = {
+  ...HOST, id: 9_001, code: "seeded_after_the_frontend_shipped",
+  label: "Seeded After The Frontend Shipped", sort_order: 9_001,
+};
+
+test("a newly seeded item appears in the form, and in what the form posts", async ({ page, baseURL }) => {
+  const host = HOST;
+  const seeded = SEEDED;
+  await openForm(page, baseURL, () => [...catalogue, seeded]);
+
+  const rendered = await renderedSections(page);
+  expect(rendered.flatMap((g) => g.codes),
+    "a catalogue item the frontend has never heard of renders no row").toContain(seeded.code);
+  expect(rendered.find((g) => g.codes.includes(host.code)).codes,
+    "the new item is under a heading of its own rather than its band's").toContain(seeded.code);
+  expect(rendered, "a new item in an existing band grew a heading").toHaveLength(BANDS.size);
+
+  const posted = await saveAndCapture(page);
+  expect(posted.values.map((v) => v.code).sort(),
+    "rendered but not posted is the same silent $0 by another route")
+    .toEqual([...catalogue.map((i) => i.code), seeded.code].sort());
+  // No snapshot has ever carried it, so its row is the one the zeroing rule would have
+  // fabricated anyway — the difference is that a person can now see the field and type in it.
+  expect(posted.values.find((v) => v.code === seeded.code))
+    .toEqual({ code: seeded.code, native_value: 0, currency: seeded.currency_default });
+});
+
+test("a catalogue that grows while the form is open does not take the view down", async ({ page, baseURL }) => {
+  // THE WINDOW THE OLD CONSTANT CLOSED BY BEING WRONG. The view refetches `/items` after every
+  // save, and `rows` — the typed values, keyed by code — is re-seeded by an effect that runs
+  // *after* the render the new catalogue causes. So there is one render in which the form is
+  // asked to draw an item that has no row yet, and reading the row unguarded throws out of
+  // render into the whole-app `ErrorBoundary`: the person who just saved a snapshot loses the
+  // page, not the field.
+  //
+  // The constant never met this because it drew four fixed lists and skipped anything it did not
+  // recognise — the same blindness this ticket removed. Deriving the layout is what puts the new
+  // item on screen, and it has to survive being put there mid-session, not only on first load.
+  await openForm(page, baseURL, (n) => (n === 0 ? catalogue : [...catalogue, SEEDED]));
+  expect((await renderedSections(page)).flatMap((g) => g.codes)).not.toContain(SEEDED.code);
+
+  await saveAndCapture(page);                            // the save is what refetches the catalogue
+
+  await expect(crashed(page), "the form threw out of render on the refetched catalogue")
+    .toHaveCount(0);
+  await expect(page.getByTestId("input-" + SEEDED.code)).toBeVisible();
+});
+
+test("an item in a band the frontend has no heading for is still typed", async ({ page, baseURL }) => {
+  // The fallback, gated rather than only claimed. `band()` returns one of four values today, so
+  // a fifth is a server-side change — and the failure mode this whole ticket exists to remove is
+  // fields nobody can find. So an unrecognised band gets a heading of its own, titled with the
+  // band itself: ugly, visible, and reportable, which is the trade this file argues for.
+  //
+  // The one place a heading's *text* is asserted, and it costs nothing to derive: the claim is
+  // precisely that the title falls back to the band string, so the band string is the expectation.
+  const unbanded = { ...SEEDED, band: "a_band_the_frontend_has_never_seen" };
+  await openForm(page, baseURL, () => [...catalogue, unbanded]);
+
+  const rendered = await renderedSections(page);
+  expect(rendered, "the unknown band grew no heading").toHaveLength(BANDS.size + 1);
+  const its = rendered.find((g) => g.codes.includes(unbanded.code));
+  expect(its, "the item vanished — the exact failure this ticket removed").toBeTruthy();
+  expect(its.codes, "the unknown band was merged into a heading that is not its own")
+    .toEqual([unbanded.code]);
+  expect(its.title).toBe(unbanded.band);
+});
+
+test("the payload is the one it always was", async ({ page, baseURL }) => {
+  // The other half of "derived, not restated": deriving the *layout* must not touch the *write*.
+  // `save()` has always walked the catalogue rather than the rendered groups, so the order here
+  // is `sort_order` — asserted in full, values included, because this is the gate that says the
+  // refactor was a rendering change.
+  expect(Object.keys(PREFILLED).length, "the latest fixture prefills nothing").toBeGreaterThan(0);
+
+  await openForm(page, baseURL);
+  const posted = await saveAndCapture(page);
+
+  expect(posted.values).toEqual(catalogue.map((it) => ({
+    code: it.code, native_value: startingValue(it), currency: startingCurrency(it),
+  })));
+});

--- a/web/tests/inventory.spec.js
+++ b/web/tests/inventory.spec.js
@@ -122,6 +122,48 @@ test("no spending surface indexes the positional palette", () => {
     .toEqual(["src/charts.jsx", "src/palette.js"]);
 });
 
+test("no source file hard-codes a net-worth catalogue code", () => {
+  // WHAT THIS FORBIDS IS A LIST OF ITEMS. The New Snapshot form used to render a constant that
+  // named fourteen item codes under four headings — not the catalogue it is capturing — so an
+  // item in no list rendered no row, `save()` never sent it, and the creator's zeroing rule
+  // fabricated a $0 for it on every capture with nothing on screen to say so. The form now reads
+  // `band` off the catalogue; this is what stops the constant coming back, in that file or in a
+  // new one, because a paste re-introduces it in ten seconds and nothing else would notice.
+  //
+  // A behavioural gate cannot close this on its own. `catalogue.spec.js` proves the *rendering*
+  // is derived — it serves a fifteenth item and finds its row — but a list kept for the headings
+  // alone, or for a subset of rows, would pass every assertion in that file and still be a second
+  // catalogue free to drift from the first.
+  //
+  // DERIVED FROM THE FIXTURE, so a recapture keeps the gate honest rather than stale. `srs` is
+  // the one code held out, and the reason is a three-way collision rather than an exemption: the
+  // same word is a catalogue *code*, a *band* value (`NetWorth.jsx`'s `BAND_TITLES` is keyed on
+  // bands and legitimately writes it) and a *funding bucket* (`Dividends.jsx`'s `BUCKET_LABEL`,
+  // `account.funding_bucket` server-side). Three partitions, one word — so this gate cannot see
+  // it, and the gate's claim is therefore about the other thirteen. They still cover the deleted
+  // constant, which named all fourteen. RENAMING THE `srs` ITEM IS THE ONE CHANGE THIS WOULD NOT
+  // CATCH: `BAND_TITLES.srs` would go dead silently, so check it by hand if that day comes.
+  //
+  // Comments stripped, like its siblings above: this file and `NetWorth.jsx` both explain at
+  // length what the constant was, and a gate that cannot tell prose from markup gets the
+  // explanation deleted rather than the defect. `stripComments` only strips a `//` that starts a
+  // line, so a code written in a TRAILING comment would fail this gate on prose — `palette.js`
+  // already has one for `srs`, which the hold-out above happens to cover. The next one will not
+  // be covered, and the fix then is that comment or this regex, not the exemption list.
+  const codes = readFixture("networth-items.json").map((i) => i.code).filter((c) => c !== "srs");
+  expect(codes.length, "the catalogue fixture is empty — this gate would be vacuous")
+    .toBeGreaterThan(0);
+
+  const offenders = sourceFiles(path.join(WEB, "src")).flatMap((f) => {
+    const src = stripComments(fs.readFileSync(f, "utf8"));
+    return codes
+      .filter((c) => new RegExp(`\\b${c}\\b`).test(src))
+      .map((c) => `${path.relative(WEB, f)}: ${c}`);
+  });
+  expect(offenders, "group by `band` off the catalogue — see `BAND_TITLES` in `NetWorth.jsx`")
+    .toEqual([]);
+});
+
 test("the two colour maps agree about Housing", async () => {
   // THE COUPLING IS DELIBERATE AND THIS IS WHERE IT IS ENFORCED. Spend Housing holds
   // Mortgage, Property Taxes and Utilities — the running cost of the same HDB whose equity


### PR DESCRIPTION
Closes #99. Spec: #92 (map #74) — §C, last bullet. Blocked by #95, which landed.

The New Snapshot form's headings and their membership now come from `band` on the catalogue
row — the same precedence function `portfolio/networth.py` defines and the composition chart
will read — instead of a frontend constant listing fourteen item codes under four titles.

## The constant was a latent bug, not duplication

The form rendered the list rather than the catalogue, so an item in no list rendered no row;
`save()` walks the catalogue, so the row was never sent; and the creator's zeroing rule then
fabricated a $0 for it. A fifteenth seeded item would have been invisible in the entry form and
silently absent from every snapshot typed, forever, with nothing on screen to say so.

## The rendered DOM is unchanged, asserted rather than assumed

Within a heading the rows follow `sort_order` because the endpoint already returns them that
way; the headings follow the order their first item appears in, so there is no second ordering
constant to disagree with the seed. Against the committed fixture that reproduces the constant's
four sections and their exact member order, and the payload — codes, currencies and prefilled
values — is byte-for-byte the one the form always sent.

`BAND_TITLES` is the words only, and it does **not** fold `srs` into `cash`: four keys against
`palette.js`'s four, deliberately not the same four. This map is keyed on what the *catalogue*
partitions into, `BAND_COLOURS` on what the *chart* stacks — which folds SRS (its area would be
sub-pixel) and adds a synthetic `portfolio` that is no catalogue row. A band with no entry falls
back to a heading titled with the band itself: ugly, visible and reportable, which is the point.

## A null guard the old code did not need

`rows` is re-seeded by an effect that runs *after* the render new `items` cause, and the view
refetches `/items` after every save and delete — so deriving the layout opens one render in which
the form is asked to draw an item that has no row yet. Read unguarded that throws out of render
into the whole-app `ErrorBoundary`: the person who just saved a snapshot loses the page rather
than gaining a field. Found by review, reproduced with a test, then fixed — `row()` seeds from the
catalogue's own default, which is what the effect will put there a moment later.

## Tests

`tests/catalogue.spec.js` runs at **one viewport in a project of its own**, on the reasoning
`ticker.spec.js` carries: a partition has no width. Six tests — three of them characterization,
said so in the file, because the constant listed exactly the fixture's fourteen codes in exactly
its band order and would have passed them. The three that could not have passed before:

- a newly seeded item renders a row **and** reaches the POST;
- an item in a band the frontend has no heading for is still typed;
- a catalogue that grows while the form is open does not take the view down.

Every expectation is derived from the fixtures; the only literals are a code and a band nothing
has ever carried, invented precisely because nothing has.

`tests/inventory.spec.js` gains the gate a behavioural test cannot give: no source file under
`web/src` may name a catalogue item code, the list read out of the fixture so a recapture cannot
leave it stale. A list kept for the headings alone would pass every test in `catalogue.spec.js`
and still be a second catalogue free to drift. `srs` is held out — one word is a code, a band
value and a funding bucket — so the claim is about the other thirteen, and the constant named all
fourteen.

## Verification

- `catalogue` + `inventory` projects: 24 passed.
- All eleven spec files at one viewport plus the three non-viewport projects: 203 passed, exit 0.
- `editors.spec.js` and `charts.spec.js` across all ten viewport projects: exit 0.
- `pytest`: 456 passed (no backend change).

The full ten-viewport sweep was **not** run to completion locally — the machine was saturated by
other work and its geometry timings would have been noise. CI runs it here.

https://claude.ai/code/session_01VRgqBbkcDfWmdvWiBDSiux


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Net Worth forms now dynamically display all catalogue items and group them by category.
  * Newly added catalogue items appear automatically without requiring form updates.
  * Unknown categories use a clear fallback heading.
  * Missing values safely default to each item’s currency and zero.

* **Bug Fixes**
  * Improved reliability of saved Net Worth data when catalogue items are newly added or uninitialized.

* **Tests**
  * Added automated coverage for catalogue rendering, grouping, defaults, saves, and catalogue growth.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->