### PR TITLE
feat(web): the spend trend, four panels and four scales (#100)

### DIFF
--- a/RESPONSIVE.md
+++ b/RESPONSIVE.md
@@ -5,8 +5,8 @@ carries most of it.
 
 **The regression trigger is the suite, and the command is `make test-web`.** Ten named viewports ×
 thirteen views, run against a production build through vite's preview server with every API call
-served from committed fixtures: **1,345 passed, 470 skipped, 0 failed, ~7.5 minutes on an unloaded
-machine**, as of #47. The skips are structural rather than disabled tests — a gate
+served from committed fixtures: **1,415 passed, 477 skipped, 0 failed**, as of #100 — and ~7.5
+minutes on an unloaded machine, measured at #47 and not re-measured since. The skips are structural rather than disabled tests — a gate
 whose subject does not render at a viewport skips there, which is what makes "no card-per-row at 640
 and above" and "the desktop table is untouched" separate claims from their positive halves.
 `web/TESTING.md` says what each spec claims. The table-inventory grep this file used to ask a human
@@ -166,7 +166,7 @@ person still looks at, and "—" means the suite has all of it.
 | Portfolio › Transactions | **B** below 640 · **A** on `Date` from 640 to 1024 | — *(telling two same-day trades apart is an [open call](#open-calls), not a check)* |
 | Portfolio › SecurityDetail | txn history **B** · dividend history **B** · options history **A**, pinning the merged two-line `Contract` cell — and **B, A, A** above 640, since the tier gives both histories the pin on `Date` · `← Holdings` is `a.backlink`, a ≥44px target below the tier and the only way back — it was 17px until #47, see [Observations](#observations) | the dividend history renders for no fixture (PLTR has none) — its wrapper is the one thing in the tier no fixture reaches, and `pinned.spec.js` annotates that on every run |
 | Net Worth | editor floor · line chart carries a DOM `.chartkey`, not `<Legend>` · Breakdown and History `.contained` **below 1024**, not unconditionally · row grid unchanged | readable — the editors' remaining criterion |
-| Spending › Overview | donut dropped below 640, the list is the chart · stacked bar chart's `<Legend>` is a `.chartkey` · Top Line Items **B** below 640, **A** on `Category` from 640 to 1024 | — *(the stacked bar chart was unreachable while `/api/spending/trends` was captured as a **500**; **#35** fixed the endpoint, the fixture holds a real chart, and `charts.spec.js` asserts its key in the DOM. The view's hscroll residual did not move — the chart is a full-width card holding a percentage-width container, and that number was always the `.grid2` track floor)* |
+| Spending › Overview | donut dropped below 640, the list is the chart · stacked bar chart's `<Legend>` is a `.chartkey` · Top Line Items **B** below 640, **A** on `Category` from 640 to 1024 · spend-trend small multiples full-width between the grid and the stacked bar: `auto-fit` at a **185px floor and a 14px gap**, 4 → 2 → 1 with **no new breakpoint**, panels 140px, present at 390 as one column — and three panels with an orphan at 844×390 and only there, see [Observations](#observations) · that card carries **no `.chartkey` by decision** — its four panel headers are the key | whether the two charts reading in **opposite directions** is confusing in one viewport — the trend runs newest-at-the-left and the stacked bar left-to-right, which is accepted because every panel's caption states its direction in words, and the bar is deliberately **not** flipped *(the stacked bar chart was unreachable while `/api/spending/trends` was captured as a **500**; **#35** fixed the endpoint, the fixture holds a real chart, and `charts.spec.js` asserts its key in the DOM. The view's hscroll residual did not move — both charts are full-width cards holding percentage-width containers, and that number was always the `.grid2` track floor)* |
 | Spending › By Category | donut dropped below 640 · Categories **A** with the name column pinned, keeping its own `▸`/`▾` and the `.rowtap` flash *instead of* the persistent `›` · drilled transactions **B**, **outside the `.grid2` entirely** rather than merely outside the table | whether three levels of drill read as one structure once the third leaves the grid |
 | Spending › Classify | editor floor · `.fillpane`/`.grow` become blocks below 640 so the page scrolls as one, `.scroll` deliberately untouched · ⇅ Reorder `display: none`, so the reorder modal is unreachable below the tier by design · `RuleModal` on `svh`, its control rows wrap, `CatSelect` capped at `max-width: 100%`, `MatchTable` `.contained` | readable · `MatchTable` renders only after a POST the GET-captured fixtures do not carry — `editors.spec.js` annotates that gap |
 | Spending › Recurring | monitor **A** · candidates **A** | the monitor never mounts — the owner tracks nothing, so `/api/spending/recurring` is `[]` and its pin is eyes-only (`pinned.spec.js` annotates it) · the **two nested scroll regions**, which is the feel check |
@@ -221,6 +221,18 @@ reconciliation unless marked otherwise.
   ~45px → ~88px. Right direction, wrong magnitude in both readings: the cell already carried more
   than the bare buttons, so the floor cost **18px** rather than the 43px predicted. Paid in scroll
   distance inside a pinned table, which is what the forecast said it would be.
+- **The spend trend draws three panels and an orphan at 844×390, and only there.** The card is
+  **754px** inner at that viewport against **809px** at the gated 1100 — narrower on a *wider*
+  screen, which is the rotated phone's own contradiction showing up in a column count: 844×390
+  takes the phone shell on the `(max-height: 500px)` guard so the 200px rail leaves the flow,
+  but `.main`'s gutter follows **width**, so a 844px-wide pane keeps the 28px desktop padding
+  it would have had with the rail. 754 holds three 185px tracks; 809 holds four.
+  **Accepted rather than tuned away, and the arithmetic is why**: a floor big enough to make
+  754 draw two makes 809 draw three, and 809 is the width the whole 185-over-220 decision turns
+  on. The only other lever is a breakpoint, and the rule is specced not to add one. Recorded
+  here because the ticket's "4 → 2 → 1 with no third rung" is true at nine viewports and not at
+  the tenth; `charts.spec.js` asserts the orphan happens at **exactly** that named viewport, so
+  a second one — or its disappearance — is a failure rather than a surprise.
 - **The drawer's row height at 844×390 — 39px** (`Settings`, the dim one, 37.5px), against **44px**
   for the same rows at 390×844. Predicted ~38px. This is the residual the tablet tier's height guard
   creates and the one place two of that tier's decisions pull against each other: the shell travels

--- a/scripts/capture_web_fixtures.py
+++ b/scripts/capture_web_fixtures.py
@@ -201,12 +201,12 @@ def write(name: str, payload) -> None:
     print(f"  {name}.json  ({size:,} bytes)")
 
 
-# ---------------- the four pathological rows ----------------
+# ---------------- the five pathological rows ----------------
 # Each of these broke, or nearly broke, a measurement during planning. Fixtures that
 # were merely *plausible* would reproduce the original error, so capture asserts they
 # are present and fails loudly if the database no longer holds them.
 #
-# The same four are asserted again on every test run, from the committed files, in
+# The same five are asserted again on every test run, from the committed files, in
 # `web/tests/fixtures/index.js` (PATHOLOGICAL). Deliberately both: here it fails at the
 # source, the moment a recapture would have quietly dropped one; there it fails for
 # whoever hand-edits a fixture without ever running this script. Move a threshold in one
@@ -233,6 +233,30 @@ def _ensure_long_merchant(base: str, rows: list[dict]) -> list[dict]:
     rows = rows + [worst]
     rows.sort(key=lambda r: str(r.get("txn_date") or ""), reverse=True)
     return rows
+
+
+def _flat_series_span_px(trends: dict, window: dict, plot_px: float = 140.0) -> tuple[str, float]:
+    """The spend trend's counterfactual: how many pixels the SMALLEST of the four series
+    would get if all four shared one y-axis floored at zero.
+
+    This is the measurement the small-multiples form was chosen on, so it is the one thing
+    that can make `charts.spec.js`'s "none is flattened onto the floor" gate vacuous — a
+    window whose four series happened to agree in magnitude would pass that gate under a
+    shared axis too. 140 is the panel plot height (`SpendTrend.jsx`'s PANEL_H).
+
+    Returns the worst series and its span in pixels. With no window there is nothing to
+    measure and the caller is told so by an empty name.
+    """
+    start, end = window.get("start"), window.get("end")
+    if not start or not end:
+        return "", float("inf")
+    rows = [r for r in trends["series"] if start <= r["ym"] <= end]
+    spans = {g: (min(float(r.get(g) or 0) for r in rows), max(float(r.get(g) or 0) for r in rows))
+             for g in trends["groups"]}
+    ceiling = max(hi for _, hi in spans.values())
+    worst = min(spans, key=lambda g: spans[g][1] - spans[g][0])
+    lo, hi = spans[worst]
+    return worst, (hi - lo) / ceiling * plot_px if ceiling else float("inf")
 
 
 def check_pathological(captured: dict[str, object]) -> None:
@@ -267,6 +291,15 @@ def check_pathological(captured: dict[str, object]) -> None:
         (any(g.get("category") is None for g in groups),
          "no null-category row in the spending summary"),
     ]
+    # The ~150x spread across the four spend categories inside the trend's own window. It is
+    # what makes the spend trend four panels rather than one chart, and a capture that lost
+    # it would leave the "no series is flattened onto the floor" gate passing against data a
+    # shared axis would also have passed.
+    flat_series, flat_px = _flat_series_span_px(captured["spending-trends"], captured["spending-window"])
+    checks.append((flat_px < 5,
+                   f"the four spend series no longer span two orders of magnitude inside the "
+                   f"window: {flat_series or 'no window'} would draw {flat_px:.1f}px of a 140px "
+                   f"plot under a shared axis, expected < 5"))
     # SecurityDetail is reached through PLTR precisely because of its options history. A
     # holding fixture that lost it would silently turn the tallest view in the app into
     # three short tables, and every measurement taken there would be of the wrong view.
@@ -283,7 +316,7 @@ def check_pathological(captured: dict[str, object]) -> None:
         sys.exit(1)
     print(f"\n  pathological rows present: {len(longest_sub)}-char subcategory, "
           f"PLTR x{len(pltr_trades)} option trades, {len(longest_merchant)}-char merchant, "
-          f"null-category row")
+          f"null-category row, {flat_series} at {flat_px:.1f}px under a shared axis")
 
 
 def main() -> None:

--- a/web/TESTING.md
+++ b/web/TESTING.md
@@ -145,7 +145,7 @@ coordinates the rejected layout passes. It also carries the group header — the
 and the chevron carve-out, which is the only place pattern A's affordance rule is deliberately not
 applied.
 
-`tests/charts.spec.js` — the six chart surfaces. Below 640 the donuts are not rendered and the
+`tests/charts.spec.js` — the six chart surfaces, plus the spend trend's four panels. Below 640 the donuts are not rendered and the
 `.barrow` list beneath them becomes the chart, which is the one gate here that asserts an *absence*:
 `display: none` starves a `ResponsiveContainer` to 0×0, so a hidden chart and a collapsed chart are
 the same DOM and the treatment has to be a hook rather than a rule. Everything else it checks holds at
@@ -168,9 +168,29 @@ against the map declared in `src/palette.js`, which it **imports rather than res
 hexes in the suite is a second palette, and the drift it would be blind to is the one it exists to
 catch.
 
+It also carries the **spend trend**, whose gates are shaped by what that chart would still look
+right while getting wrong. Its four series span two orders of magnitude, so the load-bearing claim is
+that **no series is flattened onto the floor**: the file computes what the smallest of them would draw
+under one shared axis — under 3px of a 140px plot — and then measures what each one actually draws, so
+a regression to a shared scale is caught by geometry rather than by a prop. The **caption** is gated
+for the same reason it exists: newest is at the **left**, so every panel reads backwards and a panel
+has no y-axis at all, which makes "latest value and signed delta, in words" the thing that keeps the
+slope from lying. The **footnote** is checked against figures recomputed from `/api/spending/window`'s
+material-source flags rather than against a sentence, because a typed "two of three sources" is right
+on today's ledger and wrong on the very payload that ships with it — four sources, three material.
+The **dash** on Uncategorized is read only after the line has finished drawing itself: recharts
+animates a line by rewriting `stroke-dasharray`, so mid-animation every line is dashed and the
+declared pattern is unreadable — which is also why the settle helper here samples the dash rather
+than `d`, the way the bar helper samples geometry. And the **grid** is asserted against the rule
+rather than against ten literals: the column count is derived from the card's measured inner width,
+and the one viewport that draws three panels and an orphan — 844×390, where the rail leaves the flow
+but the 28px desktop gutter does not — is pinned **by name**, so a second orphan is a failure.
+
 `tests/inventory.spec.js` — the checks that read files rather than pixels: the table count, the
-single donut implementation, that no chart renders a `<Legend>` and that both multi-series charts
-carry a `<ChartKey>`, that **no spending surface mentions the `POSITIONAL_COLOURS` array** — only
+single donut implementation, that no chart renders a `<Legend>` and that every multi-series chart that
+needs a `<ChartKey>` carries one — the spend trend is deliberately *not* on that list, because its
+panel headers are the key and a key under the grid would restate four names written four times
+immediately above it, that **no spending surface mentions the `POSITIONAL_COLOURS` array** — only
 `palette.js`, which declares it, and `charts.jsx`, whose portfolio donut slices by market and by
 account and so has no taxonomy to key a map on — and that **the two colour maps agree about
 Housing**, which is a deliberate coupling (spend Housing is the running cost of the same HDB whose
@@ -218,11 +238,16 @@ intercepted in the browser: real Chromium, real layout, real media queries above
 fixtures below it. No test touches Postgres or the network, and the auth gate is satisfied by
 a mocked session endpoint, so Google's identity script never loads.
 
-Fixtures are not hand-written and should not be hand-edited. They carry four deliberately
+Fixtures are not hand-written and should not be hand-edited. They carry five deliberately
 pathological rows — a 30-character subcategory name, a security with 73 option trades, a
-65-character merchant string, and the null-category row — each with a comment saying why.
+65-character merchant string, the null-category row, and the two-orders-of-magnitude spread
+across the four spend series inside the trend's window — each with a comment saying why.
 Plausible-looking data is what produced the 415px-vs-519px error that made fixtures
-necessary in the first place.
+necessary in the first place. The last of the five is the only one that is a claim about **two**
+payloads at once, since the spread only exists inside the window a second endpoint defines, and
+it is the one that keeps a gate from going vacuous rather than a measurement from being wrong:
+a window whose four series happened to agree in magnitude would pass "no series is flattened
+onto the floor" under a shared axis too.
 
 ## Where the reasoning lives
 

--- a/web/src/api.js
+++ b/web/src/api.js
@@ -55,3 +55,17 @@ export const cls = (n) => (n == null ? "" : n >= 0 ? "pos" : "neg");
 // straight to `<Bar dataKey>`, and JSON has no null key — so that one must be named before
 // it is serialized or it becomes the string "null". Change the word and change it in both.
 export const catName = (c) => c || "Uncategorized";
+/**
+ * A `YYYY-MM` bucket as prose, and as a label with ~40px to live in.
+ *
+ * Beside the money formatters because that is what these are: the compute layer emits months
+ * as `to_char(txn_date,'YYYY-MM')` strings and every surface that prints one has to turn it
+ * into a word. Here rather than in the one chart that draws them so the suite can assert a
+ * rendered label against the app's own formatter instead of restating the month names — a
+ * restated table of abbreviations is a second formatter, free to disagree with the first, and
+ * a spec file cannot import a module that imports React.
+ */
+const MONTHS = ["Jan", "Feb", "Mar", "Apr", "May", "Jun",
+                "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
+export const monthName = (ym) => `${MONTHS[Number(ym.slice(5, 7)) - 1]} ${ym.slice(0, 4)}`;
+export const monthTick = (ym) => `${MONTHS[Number(ym.slice(5, 7)) - 1]} '${ym.slice(2, 4)}`;

--- a/web/src/modules/spending/Overview.jsx
+++ b/web/src/modules/spending/Overview.jsx
@@ -7,6 +7,7 @@ import { get, sgd, fmt, catName } from "../../api.js";
 import { ChartKey, Donut } from "../../charts.jsx";
 import { categoryColour } from "../../palette.js";
 import { Cards, RowCard, usePhone } from "../../cards.jsx";
+import SpendTrend from "./SpendTrend.jsx";
 
 export default function SpendOverview() {
   const [sum, setSum] = useState(null);
@@ -98,6 +99,20 @@ export default function SpendOverview() {
           )}
         </div>
       </div>
+      {/* TRAJECTORY BEFORE DETAIL, AND IT IS A SIBLING CARD RATHER THAN A GRID CELL. The page
+          reads tiles → grid[donut | top line items] → trend → stacked bar, so the coarse-to-fine
+          order survives: where the money went, then where it is going, then what happened in
+          March. Full-width because small multiples want all four panels adjacent in ONE row —
+          that adjacency is the only thing that partly recovers what per-panel scaling gives up,
+          and a half-width cell in the grid above would take it away. It replaces nothing: the
+          stacked bar below still answers the per-month question on the same page.
+
+          `trend` rather than a second fetch — this is a slice of the array the bar chart is
+          already drawing, so the two cannot disagree about a shared month. Rendered
+          unconditionally, unlike the card below: it also needs the window endpoint before it
+          can draw anything, so both of its "not yet" branches are one guard inside it rather
+          than half a guard here and half there. */}
+      <SpendTrend trend={trend} />
       {trend && trend.series.length > 0 && (
         <div className="card" style={{ marginTop: 16 }}>
           <h3>Monthly Spend by Category</h3>

--- a/web/src/modules/spending/SpendTrend.jsx
+++ b/web/src/modules/spending/SpendTrend.jsx
@@ -1,0 +1,268 @@
+import React, { useEffect, useState } from "react";
+import { ResponsiveContainer, LineChart, Line, XAxis, YAxis, Tooltip } from "recharts";
+import { get, sgd, fmt, catName, monthName, monthTick } from "../../api.js";
+import { categoryColour, CATEGORY_DASH } from "../../palette.js";
+
+/** The plot's height. The caption sits above it; 140 is the drawing, not the grid cell. */
+const PANEL_H = 140;
+
+/**
+ * The spend trend: small multiples, one panel per spend category, each on its own y-axis.
+ *
+ * WHY FOUR SCALES AND NOT ONE. Measured on a throwaway prototype against real data, the four
+ * series span ~150×, and under one shared axis the smallest of them is drawn flat on the
+ * floor — 3.4px of plot for Transport. Dropping Uncategorized does not relieve it (Personal
+ * still sets a $12,000 ceiling and Transport stays at 3.4px) and dropping Personal barely
+ * helps (6.2px, because the $3,279 unclassified spike then sets the ceiling). Only a
+ * per-series scale or a log scale touches it, and per-panel wins because it fixes the
+ * compression WITHOUT CHANGING WHAT A PIXEL MEANS: inside a panel, dollars stay dollars, and
+ * the axis is floored at zero so a pixel is the same number of dollars all the way down.
+ *
+ * WHAT MAKES THIS FORM SAFE IS THE TAXONOMY BEING LOCKED AT THREE CATEGORIES, which makes
+ * the grid permanently four panels — one row on a desktop, and small enough to hold in one
+ * glance. THE RECOMMENDATION INVERTS AT SUBCATEGORY DEPTH: there are dozens of those, and
+ * dozens of panels is a contact sheet, not a chart.
+ *
+ * FOUR SERIES, NO CAP AND NO FOLD. No top-N — the window grows every month, so a top-N would
+ * silently re-rank and a category would leave the chart with nothing to say it had. No
+ * "Other" fold either: it would collide with the real `Personal/Others` subcategory, and a
+ * chart naming one thing two ways is the defect the colour map exists for one file over.
+ *
+ * IT ADDS NO SPEND PAYLOAD. The series are a slice of the `/api/spending/trends` array the
+ * view has already fetched for the stacked bar below, so the two charts on this page cannot
+ * disagree about a shared month. What this component fetches for itself is the window rule
+ * and the undated count — both of which are footnote, not series.
+ *
+ * NOT A REPLACEMENT FOR THE STACKED BAR. That chart answers "what did I spend in March";
+ * this one answers "where is this going". They are ordered coarse-to-fine on the page —
+ * trajectory, then the per-month detail — and they run in OPPOSITE DIRECTIONS, which is
+ * accepted: the per-panel caption states every panel's direction in words, so the bar chart
+ * beside it cannot silently mislead. The stacked bar is not flipped.
+ */
+export default function SpendTrend({ trend }) {
+  const [win, setWin] = useState(null);
+  const [undated, setUndated] = useState(null);
+  useEffect(() => { get("/api/spending/window").then(setWin).catch(() => setWin(null)); }, []);
+  useEffect(() => { get("/api/spending/undated").then(setUndated).catch(() => setUndated(null)); }, []);
+
+  // NO WINDOW, NO CHART. `_window_shape` returns a null `start`/`end` when no source is
+  // material or no month is drawable, and every dated month then falls in `before` — there
+  // is nothing to draw and, more to the point, nothing the footnote could truthfully say
+  // about a range that does not exist. Rendering nothing is the honest branch; a chart of
+  // every month would be exactly the undisclosed leading-months defect the window exists for.
+  if (!win || !win.start || !win.end || !trend || !trend.series) return null;
+  // THE WINDOW MINUS ITS GAPS, and the subtraction is not optional. `_window_shape` states the
+  // arithmetic as `drawn = dated_total - before - after - gaps`, and the footnote below counts
+  // gap money as off-chart — so drawing a gap month would make that sentence false. A gap is a
+  // month inside the window where some material source reported nothing, which means its total
+  // is missing a source rather than low: plotted, it is a dip the ledger never had, and it is
+  // exactly the defect the window rule exists to keep off this chart.
+  //
+  // DROPPED, NOT ANNOTATED. What the chart should SHOW about a gap is out of scope here (the
+  // endpoint's docstring says so); what it must not do is draw one silently. Empty on today's
+  // ledger, so this is the branch no fixture reaches — `charts.spec.js` annotates that on every
+  // run rather than letting a green suite read as coverage.
+  const gaps = new Set(win.gaps);
+  const rows = trend.series.filter(
+    (r) => r.ym >= win.start && r.ym <= win.end && !gaps.has(r.ym));
+  if (rows.length === 0) return null;
+
+  /**
+   * PANEL ORDER: spend inside the window, descending, with Uncategorized pinned last.
+   *
+   * Derived rather than typed, so a category that grows past another is not left sitting
+   * where a literal put it. Uncategorized is pinned out of that ordering because it is not
+   * a category anyone chose — it is residue, and residue belongs at the end however much of
+   * it there is. (On today's ledger it outspends Transport, so this pin is doing work.)
+   *
+   * Re-ranking is safe HERE in a way it is not for a top-N: every panel is drawn whatever
+   * its rank, so the order is a reading aid rather than a filter, and nothing can leave the
+   * chart by sliding down it.
+   */
+  const total = (g) => rows.reduce((a, r) => a + Number(r[g] ?? 0), 0);
+  // `catName(null)` rather than the literal: what is being pinned last is the NULL category,
+  // and that name is `api.js`' to say. The string is a JSON key on this payload — the compute
+  // layer has to name the null before it serializes — so the two words have to agree, and
+  // asking the function is how they do.
+  const residue = (g) => (g === catName(null) ? 1 : 0);
+  const groups = [...trend.groups].sort((a, b) => residue(a) - residue(b) || total(b) - total(a));
+
+  const material = win.sources.filter((s) => s.material);
+  // The material share and the dated total are both sums over the payload's own per-source
+  // figures — never a typed count and never a typed range. Typed, the line says "two of
+  // three sources", which is wrong on this very payload: there are four sources and three of
+  // them are material. The flags are the only thing that knows which.
+  const share = material.reduce((a, s) => a + s.share, 0);
+  const dated = win.sources.reduce((a, s) => a + s.total_sgd, 0);
+  // Three-way, not two: a gap month is a third kind of off-chart money and the endpoint
+  // splits it out precisely so this line can add it back in. Empty today, and silently wrong
+  // the day it is not if this only summed `before` and `after`.
+  const outside = win.excluded.before.total_sgd + win.excluded.after.total_sgd
+    + win.excluded.gaps.total_sgd;
+
+  return (
+    <div className="card" style={{ marginTop: 16 }}>
+      <h3>Spend Trend by Category</h3>
+      <div className="trendgrid">
+        {groups.map((g) => <Panel key={g} name={g} rows={rows} />)}
+      </div>
+      {/* THE FOOTNOTE IS BENEATH THE WHOLE GRID, not per panel: all three lines are facts
+          about the chart rather than about a category, and four copies of them would be
+          four times the prose and no more disclosure. */}
+      <div className="trendnote">
+        <div>
+          {monthName(win.start)} – {monthName(win.end)}: every month in which all{" "}
+          {material.length} material sources report — {material.length} of{" "}
+          {win.sources.length}, carrying {fmt(share * 100, 1)}% of dated spend between them. It
+          opens the month after the last of them began reporting and stops short of the
+          ledger's partial current month. {sgd(outside)} of dated spend,{" "}
+          {fmt((outside / dated) * 100, 1)}% of it, falls outside the window and is not drawn
+          here.
+        </div>
+        {/* DEPTH, AND WHY IT IS PROSE RATHER THAN A LINK. There is no drill-down in v1 and
+            not for time: a per-point target is 19.2px of spacing at the 1100 viewport against
+            the app's own 24px floor, the transactions view has no date filter to receive one,
+            a panel target would need the app's first cross-tab navigation and would land on a
+            different window — and the Uncategorized panel cannot drill at all, because the
+            category filter has no null match. Its honest destination is Classify: that row
+            needs classifying, not inspecting. So the two destinations are named, not wired. */}
+        <div>
+          Subcategory detail lives in By Category; unclassified rows in Classify.
+        </div>
+        {/* Guarded on the count, not rendered empty: undated spend is n=0/$0 today, and a line
+            that reads "excludes S$0 across 0 transactions" is noise standing where a real
+            disclosure will one day be. `ByCategory` guards the same figure the same way. */}
+        {undated && undated.n > 0 && (
+          <div>
+            Excludes {sgd(undated.total_sgd)} across {undated.n} undated
+            transaction{undated.n === 1 ? "" : "s"}, which carry no date and so fall in no month.
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * One panel: a caption, and a line with no y-axis under it.
+ *
+ * THE CAPTION IS LOAD-BEARING. DROP IT AND THE CHART LIES. Newest is at the LEFT, so every
+ * panel reads backwards against every other time axis a reader has ever seen — Transport's
+ * line RISES left-to-right while its number has FALLEN, and Personal's falls while its
+ * number has risen. And a panel has no y-axis at all, so the slope is the panel's entire
+ * visual content. What makes that legible rather than misleading is this header stating the
+ * latest value and the signed delta IN WORDS, where neither depends on which way the reader
+ * happens to read the line. Anything that moves the caption out of the panel, or demotes the
+ * delta into the muted line below it, breaks that and must not be done casually.
+ *
+ * THE PANEL HEADERS ARE ALSO THE KEY. There is no `<ChartKey>` under this grid, deliberately:
+ * a key would restate four names and four colours written immediately above four charts.
+ * `inventory.spec.js` names the files that must carry one, and this is not one of them.
+ *
+ * TWO LINES RATHER THAN ONE, and the number is why. At the gated 1100 viewport the card is
+ * 809px inner and four columns leave a panel ~192px wide; chip + "Uncategorized" + a latest
+ * value + a delta measures ~195px on one line, so a single-line caption wraps *sometimes*,
+ * which would leave the four plots in a row starting at different heights. Splitting it puts
+ * the delta beside the name — where the direction claim belongs — and the latest value beside
+ * the demoted min–max.
+ */
+function Panel({ name, rows }) {
+  const colour = categoryColour(name);
+  const vals = rows.map((r) => Number(r[name] ?? 0));
+  const oldest = vals[0];
+  const latest = vals[vals.length - 1];
+  const lo = Math.min(...vals);
+  const hi = Math.max(...vals);
+  // First month of the window to last, which is what "latest, and how it got there" means on
+  // a panel whose only other content is a slope. A zero opening month has no percentage —
+  // Transport's is $258.95 so this cannot fire on today's window, but the window grows.
+  //
+  // THE MAGNITUDES DO NOT REPRODUCE THE ONES IN THE SPEC, and that is the data rather than the
+  // formula. The spec quotes Transport at -68% and Personal at +39% from a prototype run
+  // against the live ledger months before the fixture was captured; first-to-last over the
+  // committed window gives -80% and +30%. What the spec was making a claim about is the SIGNS
+  // against the SLOPES — "Transport is negative and slopes up, Personal is positive and slopes
+  // down" — and this reproduces both exactly, which is the half that matters: it is the
+  // mismatch between them that the caption exists to resolve.
+  const delta = oldest ? (latest - oldest) / oldest : null;
+  const signed = delta == null ? "—"
+    : (delta >= 0 ? "+" : "−") + fmt(Math.abs(delta) * 100, 0) + "%";
+
+  // NEWEST AT THE LEFT, done by reversing the data rather than by `<XAxis reversed>`: the
+  // tooltip, the ticks and the line then all read one array in one order, and there is no
+  // second place for the direction to be set differently.
+  const points = [...rows].reverse().map((r) => ({ ym: r.ym, v: Number(r[name] ?? 0) }));
+
+  return (
+    <div className="trendpanel">
+      {/* ONE CAPTION, TWO LINES — see the docstring for why it cannot be one. `.tp-cap` exists
+          so the four parts are one element in the DOM as well as one idea on the page. */}
+      <div className="tp-cap">
+        <div className="tp-head">
+        <span className="chip" style={{ background: colour }} />
+        <span className="tp-name">{name}</span>
+        {/* MUTED, NOT RED/GREEN. `cls()` would paint a rise green, and on a spending chart
+            "up" is not good news — the app's pos/neg pair means something else everywhere
+            it is used. The sign glyph carries the direction on its own. */}
+        <span className="tp-delta">{signed}</span>
+      </div>
+        <div className="tp-sub">
+          <span className="tp-latest">{sgd(latest)}</span>
+          <span className="tp-range">{sgd(lo)} – {sgd(hi)}</span>
+        </div>
+      </div>
+      <ResponsiveContainer width="100%" height={PANEL_H}>
+        <LineChart data={points} margin={{ top: 6, right: 6, left: 6, bottom: 0 }}>
+          {/* HIDDEN, NOT ABSENT. The scale is the whole feature — this is what makes the
+              panel's own maximum its ceiling — but four sets of dollar ticks in a 185px
+              column would cost more width than the lines they label. Floored at zero so a
+              pixel is a fixed number of dollars inside the panel; `'auto'` at both ends
+              would exaggerate every wiggle into a mountain. */}
+          <YAxis hide domain={[0, "auto"]} />
+          {/* DECLARED AND HIDDEN, because the tooltip's label reads off it: without an x-axis
+              recharts has no idea the row's identity is `ym` and the tooltip is headed by an
+              array index. The two months a reader actually needs are DOM under the plot —
+              see `.tp-axis` below. */}
+          <XAxis dataKey="ym" hide />
+          {/* ADDITIVE ONLY — nothing exists solely in here. The month it names is between two
+              ticks that are drawn, and the value it prints is a point on a line whose latest
+              and whose min–max are both in the caption above. */}
+          <Tooltip formatter={(v) => [sgd(v), name]}
+                   labelFormatter={monthName}
+                   contentStyle={{ background: "#161b22", border: "1px solid #2b333d" }}
+                   itemStyle={{ color: "#d7dde4" }} labelStyle={{ color: "#d7dde4" }} />
+          {/* `linear` AND NO SMOOTHING: these are ten monthly totals, not a sampled signal,
+              and a monotone curve would invent values between months that no row supports.
+              No rolling window either — a trailing-12 needs twelve honest months and the
+              window has ten, so it would draw zero points.
+
+              Uncategorized is DASHED, from the map. Grey alone is the weaker half of "this is
+              residue rather than a category anyone chose" — it fails the palette validator's
+              chroma floor precisely because grey carries no identity — and the dash is the
+              secondary encoding that makes the accepted failure legal. It is drawn rather
+              than hidden: a single $3,259 unclassified row must not silently vanish from the
+              largest unclassified month in the window. */}
+          <Line type="linear" dataKey="v" stroke={colour} strokeWidth={2}
+                strokeDasharray={CATEGORY_DASH[name]} dot={false}
+                activeDot={{ r: 3, fill: colour, stroke: "none" }} />
+        </LineChart>
+      </ResponsiveContainer>
+      {/* THE ENDPOINTS, AS DOM UNDER THE PLOT RATHER THAN AS AXIS TICKS — `ChartKey`'s reason,
+          at a smaller scale. A recharts `<XAxis>` is a chart child and takes its height out of
+          the 140px drawing, and at this width it also clips: the ticks sit at the data points,
+          the first data point is at the plot's left edge, and a centred 40px label there is
+          half outside the SVG. Two ordinary spans pushed apart cannot clip, cost the plot
+          nothing, and put the newest month on the left where the newest point is.
+
+          THEY ARE HERE TO SHOW THE REVERSAL, which is the one thing the caption above cannot:
+          it says the number has fallen, and only this says that the falling end is the one on
+          the left. Two rather than ten — ten months of ticks is unreadable in a 185px column,
+          and the months in between are the tooltip's. 11px is the app's single type minimum,
+          at iOS HIG's 11pt. */}
+      <div className="tp-axis">
+        <span>{monthTick(points[0].ym)}</span>
+        <span>{monthTick(points[points.length - 1].ym)}</span>
+      </div>
+    </div>
+  );
+}

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -454,7 +454,7 @@ button { min-height: 24px; }
 .barrow > .chip, .barrow > .nm, .barrow > .val { position: relative; }
 /* One swatch, two lists. The donut's rows and a multi-series key are the same thing — a
    colour standing for a series — so they take one rule rather than two identical ones. */
-.barrow .chip, .chartkey .chip { flex: none; width: 8px; height: 8px; border-radius: 2px; }
+.barrow .chip, .chartkey .chip, .tp-head .chip { flex: none; width: 8px; height: 8px; border-radius: 2px; }
 .barrow .nm { flex: 1 1 auto; min-width: 0; color: var(--txt); font-size: 13px;
   overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .barrow .val { flex: none; color: var(--mut); font-size: 13px; font-variant-numeric: tabular-nums; }
@@ -464,6 +464,64 @@ button { min-height: 24px; }
    it. No media query: a key is worth the same on a desktop that has no hover state either. */
 .chartkey { display: flex; flex-wrap: wrap; gap: 4px 14px; margin-top: 8px; padding: 0 8px; }
 .ck-item { display: inline-flex; align-items: center; gap: 6px; color: var(--mut); font-size: 12px; }
+
+/* ─── the spend trend's small multiples ─────────────────────────────────────────────────
+   Four panels, one row, no new breakpoint. `auto-fit` at a 185px floor with a 14px gap gives
+   4 → 2 → 1 at nine of the ten viewports, which is the whole reason the floor is 185 and not
+   220. At 220 the gated 1100 viewport draws three panels and an orphan: the card is 809px
+   inner there (1100 less the 200px rail, `.main`'s 2x28 and the card's own 2x16 plus border)
+   and 809 holds three 220px tracks with room to spare and four only at 185.
+
+   THE TENTH IS 844x390 AND IT DRAWS THE ORPHAN ANYWAY. A rotated phone takes the phone shell
+   on the `(max-height: 500px)` guard, so the rail leaves the flow — but this pane's gutter
+   follows WIDTH, and 844 is above the phone tier, so it keeps the 28px desktop padding. That
+   pairing exists at no other viewport and lands the card on 754px inner: three 185px tracks,
+   not four. NO FLOOR FIXES IT — one big enough to make 754 draw two makes 809 draw three, and
+   809 is the width the 185-over-220 argument turns on. The alternative is a breakpoint, which
+   this rule is specced not to add, so the orphan is accepted at exactly that viewport and
+   `charts.spec.js` names it rather than tolerating a third rung in general.
+
+   THE FLOOR IS A BARE `185px`, NOT `min(185px, 100%)` — and the difference to `.grid2`'s
+   track floor is that this one never binds. The narrowest pane in the suite gives this card
+   298px of inner width at 360, well clear of 185, so `auto-fit` collapses to one full-width
+   track on its own and there is no width in the tier where a hard floor could overflow the
+   pane. `.grid2`'s 420px floor DID overflow a 362px pane, which is what that `min()` is for.
+
+   AT 390 THE CHART STAYS, one column, ~35px per point — better than the desktop row's 25px.
+   The donut's phone treatment does not transfer: that deletion is about REDUNDANCY, not size
+   — the list beneath restated every one of its numbers — and nothing else on this page
+   carries trajectory. */
+.trendgrid { display: grid; grid-template-columns: repeat(auto-fit, minmax(185px, 1fr)); gap: 14px; }
+/* `min-width: 0` because a grid item's default `min-width: auto` refuses to shrink below its
+   content, and a `ResponsiveContainer` inside one measures the track it was given — so
+   without this the panel that holds the widest caption would push the row wider than the
+   card and take the pane's horizontal-overflow ratchet off zero. */
+.trendpanel { min-width: 0; }
+/* The caption, on two lines: chip · name · delta, then the latest value with min–max demoted
+   beside it. Two rather than one because at the 1100 viewport a panel is ~192px and the four
+   parts measure ~195px on one line — a caption that wraps only sometimes would leave the
+   four plots in a row starting at different heights. See `SpendTrend.jsx`, which says why
+   the caption is load-bearing in the first place. */
+.tp-cap { min-width: 0; }
+.tp-head { display: flex; align-items: center; gap: 6px; min-width: 0; }
+.tp-name { flex: 1 1 auto; min-width: 0; font-size: 13px; font-weight: 600; color: var(--txt);
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.tp-delta { flex: none; font-size: 12px; color: var(--mut); font-variant-numeric: tabular-nums; }
+.tp-sub { display: flex; align-items: baseline; gap: 6px; margin: 2px 0 4px; min-width: 0; }
+.tp-latest { flex: 1 1 auto; font-size: 14px; font-weight: 600; color: var(--txt);
+  font-variant-numeric: tabular-nums; }
+.tp-range { flex: none; font-size: 11px; color: var(--mut); font-variant-numeric: tabular-nums; }
+/* The panel's x-axis, as DOM under the plot rather than as a chart child — `.chartkey`'s
+   reason at a smaller scale, plus one this chart has on its own: an axis tick sits at its data
+   point, the first point is at the plot's left edge, and a centred label there is half outside
+   the SVG. `space-between` puts the newest month under the newest point. */
+.tp-axis { display: flex; justify-content: space-between; margin-top: 2px;
+  color: var(--mut); font-size: 11px; font-variant-numeric: tabular-nums; }
+/* The disclosure block under the whole grid — three lines, two of them unconditional. 12px
+   and muted, the same treatment `ByCategory`'s undated line already carries, because it is
+   the same kind of sentence. */
+.trendnote { display: flex; flex-direction: column; gap: 4px; margin-top: 14px;
+  color: var(--mut); font-size: 12px; line-height: 1.5; }
 /* `textarea` joins the rule it was always missing from: it is styled nowhere else in the
    app, so it rendered UA-default — a white box on a dark modal — at every width. */
 input, select, textarea { background: var(--panel2); border: 1px solid var(--line); color: var(--txt);

--- a/web/tests/charts.spec.js
+++ b/web/tests/charts.spec.js
@@ -1,10 +1,12 @@
 /**
  * Charts on a phone: the donuts are deleted and the list becomes the chart.
  *
- * Six chart surfaces across five views. Below 640px three of them lose chrome — the donut
- * itself, and one chart's value labels — and one is halved to six bars. Everything else the
- * charts needed turned out to belong at *every* width: the multi-series key, the reserved
- * band under the bars, and the two containers that could collapse to nothing.
+ * Six chart surfaces across five views, plus the spend trend's four panels — which are one
+ * surface by decision and four by measurement, and are gated at the bottom of this file.
+ * Below 640px three of the six lose chrome — the donut itself, and one chart's value labels
+ * — and one is halved to six bars. Everything else the charts needed turned out to belong at
+ * *every* width: the multi-series key, the reserved band under the bars, the two containers
+ * that could collapse to nothing, and the trend's whole grid.
  *
  * WHY THE DONUT GOES, since it is the one thing here that is not a defect. At percentage
  * radii in a one-column `.grid2` it renders at ⌀216px, larger than desktop's 180px, so this
@@ -30,13 +32,20 @@
 import { expect, test } from "@playwright/test";
 import { PHONE_TIER_BELOW, VIEWPORTS } from "./viewports.js";
 import { openView } from "./support/app.js";
-import { readFixture } from "./fixtures/index.js";
+import { readFixture, sharedAxisSpanPx } from "./fixtures/index.js";
 // The declared map itself, not a copy of it — see the `one palette` describe below for why
 // a table of hexes in this file would be the defect rather than the gate. `palette.js` is
 // plain data with no React or recharts import, which is what makes it importable here.
-import { categoryColour } from "../src/palette.js";
+import { CATEGORY_DASH, categoryColour } from "../src/palette.js";
+// The app's own formatters, for the same reason the map is imported rather than restated:
+// a caption asserted against a second `toLocaleString` call is asserting the spec file's
+// formatting, and `api.js` is plain functions with no React import.
+import { catName, fmt, monthName, monthTick, sgd } from "../src/api.js";
 
 const viewportOf = (projectName) => VIEWPORTS.find((v) => v.name === projectName);
+
+/** A declared hex as the `rgb(r, g, b)` string `getComputedStyle` hands back. */
+const rgb = (hex) => `rgb(${[1, 3, 5].map((i) => parseInt(hex.slice(i, i + 2), 16)).join(", ")})`;
 
 /** Every view that draws a donut, and how many it draws. */
 const DONUT_VIEWS = [
@@ -216,9 +225,11 @@ test.describe("one palette", () => {
    * in the suite is a second palette, and the failure it would then be blind to is precisely
    * the one it exists to catch.
    */
-  const rgb = (hex) => `rgb(${[1, 3, 5].map((i) => parseInt(hex.slice(i, i + 2), 16)).join(", ")})`;
-
   test("Spending › Overview colours its three surfaces by name", async ({ page, baseURL }) => {
+    // THREE IS WHAT THIS TEST READS, NOT WHAT THE VIEW DRAWS. The spend trend added two more
+    // colour-by-name surfaces to this page — each panel's caption chip and the line it names —
+    // and they are asserted against the same map in the spend-trend describe below, beside the
+    // rest of that card's claims. Restating them here would be a second copy of one assertion.
     await openView(page, baseURL, "Spending › Overview");
     await barsSettled(page);
 
@@ -402,3 +413,336 @@ test.describe("Portfolio › Options", () => {
       }
     });
 });
+
+/**
+ * The spend-trend small multiples on Spending › Overview — four panels, four scales.
+ *
+ * WHY PER-PANEL SCALING IS THE SUBJECT OF A TEST rather than a styling detail. The four
+ * series span ~150× on real data, so under one shared y-axis the smallest of them is drawn
+ * flat on the floor: `sharedAxisSpanPx` in the fixture module computes that counterfactual from
+ * the committed payload and it comes out under 3px of a 140px plot — the same function
+ * `inventory.spec.js` uses to assert the payload has not quietly lost the spread. Per-panel scaling is the
+ * whole feature, and "the line is not flat" is the only thing that says it is working —
+ * a chart that regressed to a shared axis would still draw four panels, four colours and
+ * four captions, and would still pass every other gate in this file.
+ *
+ * THE CAPTION IS LOAD-BEARING AND IS GATED AS SUCH. Newest is at the LEFT, so every panel
+ * reads backwards — Transport's line rises left-to-right while its delta is negative — and
+ * a panel has no y-axis at all. The header states the latest value and the signed delta in
+ * words; drop it and the chart lies. See `SpendTrend.jsx`, which says the same thing at the
+ * header it describes.
+ *
+ * WHAT IS DERIVED RATHER THAN TYPED. The footnote's window line is computed here the same
+ * way the component computes it — from `/api/spending/window`'s material-source flags — and
+ * compared against the rendered text. A typed "two of three sources" is right on today's
+ * ledger and wrong at three of four, which is exactly what the payload holds.
+ */
+test.describe("Spending › Overview — the spend trend", () => {
+  // `styles.css`'s `.trendgrid`, and `SpendTrend.jsx`'s `PANEL_H`. Not shared constants: a
+  // spec file cannot import a module that imports React or CSS, so the two sides
+  // cross-reference in comments the way `640`'s four sites and `NEG_LABEL_BAND` do.
+  const PANEL_FLOOR = 185, PANEL_GAP = 14, PANEL_H = 140;
+
+  /**
+   * The window slice the chart draws: the trends rows inside `[start, end]`, MINUS the gap
+   * months, ascending.
+   *
+   * The subtraction is the endpoint's own arithmetic — `drawn = dated_total - before - after -
+   * gaps` — and it is what makes the footnote's "falls outside the window and is not drawn
+   * here" true of gap money as well as of the leading and trailing months. `gaps` is empty on
+   * the committed payload, so this clause is inert here and annotated as uncovered below
+   * rather than passing for a reason that has nothing to do with the code.
+   */
+  function windowed() {
+    const trends = readFixture("spending-trends.json");
+    const win = readFixture("spending-window.json");
+    const gaps = new Set(win.gaps);
+    const rows = trends.series.filter(
+      (r) => r.ym >= win.start && r.ym <= win.end && !gaps.has(r.ym));
+    return { trends, win, rows };
+  }
+
+  /**
+   * One expectation per panel, keyed by name. `latest` is the LAST row — newest.
+   *
+   * KEYED RATHER THAN ORDERED, because the panels' order is its own claim and is asserted as
+   * one below: comparing a name-keyed caption against a positional expectation is how a
+   * reordering passes as a mismatch four panels deep, in a suite whose whole colour gate
+   * exists because two surfaces read one array at two different `i`.
+   */
+  function expected() {
+    const { trends, rows } = windowed();
+    return Object.fromEntries(trends.groups.map((name) => {
+      const vals = rows.map((r) => Number(r[name] ?? 0));
+      return [name, {
+        name,
+        latest: vals[vals.length - 1],
+        oldest: vals[0],
+        lo: Math.min(...vals),
+        hi: Math.max(...vals),
+        total: vals.reduce((a, b) => a + b, 0),
+      }];
+    }));
+  }
+
+  /**
+   * The order the panels are drawn in: in-window spend descending, Uncategorized pinned last.
+   *
+   * Derived here the way `SpendTrend.jsx` derives it, not typed — and the pin is doing work
+   * on this payload, where unclassified spend outranks Transport. It is residue rather than
+   * a category anyone chose, so it goes last however much of it there is.
+   */
+  function expectedOrder() {
+    const want = expected();
+    const residue = (name) => (name === catName(null) ? 1 : 0);
+    return Object.values(want)
+      .sort((a, b) => residue(a.name) - residue(b.name) || b.total - a.total)
+      .map((p) => p.name);
+  }
+
+  /**
+   * Wait until the lines have finished drawing themselves — `barsSettled`'s reason, for a
+   * `<Line>`, and NOT its mechanism.
+   *
+   * A bar animates its geometry, so sampling `d` twice is the end of the animation. A line
+   * does not: recharts draws a line by holding `d` constant and animating `stroke-dasharray`
+   * from "nothing visible" to "all of it", so a `d` sample is stable on the first frame and a
+   * settle written that way returns instantly and measures a half-drawn chart. The dash IS
+   * the animation here, which is also why it is the thing the dash-pattern gate has to read.
+   */
+  async function linesSettled(page) {
+    await page.evaluate(() => { delete window.__lines; });
+    await page.waitForFunction(() => {
+      const now = [...document.querySelectorAll(".trendpanel .recharts-line .recharts-curve")]
+        .map((p) => p.getAttribute("stroke-dasharray") + p.getAttribute("d")).join("|");
+      const was = window.__lines;
+      window.__lines = now;
+      return now.length > 0 && was === now;
+    }, null, { polling: 200 });
+  }
+
+  test("draws one panel per category, captioned with its latest value and signed delta",
+    async ({ page, baseURL }, testInfo) => {
+      const { win: w } = windowed();
+      if (w.gaps.length === 0) {
+        testInfo.annotations.push({
+          type: "not-covered-by-fixtures",
+          description: "the window has no gap months on the live ledger, so the clause that " +
+            "drops them from the drawn series is exercised only in its no-op branch",
+        });
+      }
+      await openView(page, baseURL, "Spending › Overview");
+      await linesSettled(page);
+      const panels = page.locator(".main .trendpanel");
+      const want = expected();
+
+      await expect.soft(panels, "one panel per spend category, no cap and no fold")
+        .toHaveCount(Object.keys(want).length);
+
+      const drawn = await panels.evaluateAll((els) => els.map((el) => ({
+        name: el.querySelector(".tp-name").textContent,
+        chip: getComputedStyle(el.querySelector(".chip")).backgroundColor,
+        latest: el.querySelector(".tp-latest").textContent,
+        delta: el.querySelector(".tp-delta").textContent,
+        range: el.querySelector(".tp-range").textContent,
+        stroke: getComputedStyle(el.querySelector(".recharts-line .recharts-curve")).stroke,
+        dash: getComputedStyle(el.querySelector(".recharts-line .recharts-curve")).strokeDasharray,
+        axis: [...el.querySelectorAll(".tp-axis span")].map((s) => s.textContent),
+      })));
+
+      expect.soft(drawn.map((p) => p.name), "the panels are the payload's own groups, ordered "
+        + "by in-window spend with unclassified residue last").toEqual(expectedOrder());
+
+      for (const panel of drawn) {
+        const w = want[panel.name];
+        // The colour comes from the name-keyed map on BOTH surfaces of a panel — the chip in
+        // the caption and the line it names. A caption with its own palette is the same
+        // defect `one palette` above exists for, one card further down the page.
+        expect.soft(panel.chip, `${w.name}: the caption's chip is off the map`)
+          .toBe(rgb(categoryColour(w.name)));
+        expect.soft(panel.stroke, `${w.name}: the line is off the map`)
+          .toBe(rgb(categoryColour(w.name)));
+
+        expect.soft(panel.latest, `${w.name}: the caption's latest value is not the newest month`)
+          .toBe(sgd(w.latest));
+        // The SIGN is what the caption exists for, and it is the half a reader cannot get
+        // from the slope: newest is at the left, so a falling line is a rising number.
+        const rising = w.latest >= w.oldest;
+        expect.soft(panel.delta.startsWith(rising ? "+" : "−"),
+          `${w.name}: the delta is ${panel.delta} against ${w.oldest} → ${w.latest}`).toBe(true);
+        expect.soft(panel.range, `${w.name}: min–max is demoted, not dropped`)
+          .toContain(sgd(w.lo));
+        expect.soft(panel.range, `${w.name}: min–max is demoted, not dropped`)
+          .toContain(sgd(w.hi));
+      }
+
+      // Grey is the weaker half of "this is residue, not a category anyone chose" — it fails
+      // the palette validator's chroma floor precisely because grey carries no identity. The
+      // dash is the secondary encoding that makes the accepted failure legal; `palette.js`
+      // declares it as `CATEGORY_DASH` and this is its first consumer.
+      //
+      // ASSERTED AFTER `linesSettled`, WHICH IS NOT A DETAIL. recharts owns this attribute
+      // while the line is drawing itself — it rewrites `stroke-dasharray` into the declared
+      // pattern repeated up to the visible length plus a gap the length of the whole path,
+      // and a line with no declared pattern gets a two-segment version of the same trick. Both
+      // are transient and both are numeric, so a sample taken mid-animation cannot tell a
+      // dashed line from a solid one. Once the draw ends the attribute is the declared value
+      // or nothing at all, which is the only frame where this claim is checkable.
+      //
+      // The expected string is built from `CATEGORY_DASH` rather than typed, for the reason
+      // the colours are read off the map: a literal here is a second declaration of the same
+      // decision, free to disagree with the first.
+      // NEWEST AT THE LEFT, which is the claim the caption cannot make on its own: the caption
+      // says the number has fallen, and only this says the falling end is the one on the left.
+      // Asserted per panel because it is per panel — one reversed panel in a row of four is
+      // worse than four, and nothing else in the card would look wrong.
+      const { win } = windowed();
+      for (const panel of drawn) {
+        expect.soft(panel.axis, `${panel.name}: the panel does not read newest-first`)
+          .toEqual([monthTick(win.end), monthTick(win.start)]);
+      }
+
+      for (const panel of drawn) {
+        const declared = CATEGORY_DASH[panel.name];
+        expect.soft(panel.dash, declared
+          ? `${panel.name}: the declared "${declared}" did not survive`
+          : `${panel.name}: is dashed and should not be`)
+          .toBe(declared ? declared.split(" ").map((n) => n + "px").join(", ") : "none");
+      }
+    });
+
+  test("gives every series its own scale, so none is flattened onto the floor",
+    async ({ page, baseURL }, testInfo) => {
+      await openView(page, baseURL, "Spending › Overview");
+      await linesSettled(page);
+
+      const geom = await page.locator(".main .trendpanel").evaluateAll((els) => els.map((el) => {
+        const curve = el.querySelector(".recharts-line .recharts-curve");
+        const plot = el.querySelector(".recharts-surface").getBoundingClientRect();
+        const box = curve.getBBox();
+        return { name: el.querySelector(".tp-name").textContent, span: box.height, plot: plot.height };
+      }));
+
+      // The counterfactual the per-panel decision was taken on, from the fixture module rather
+      // than recomputed here: `inventory.spec.js` asserts the payload still carries the spread
+      // and this prints what it costs, and the pair says nothing unless both read one function.
+      const { trends, win } = windowed();
+      const shared = sharedAxisSpanPx(trends, win, PANEL_H);
+      testInfo.annotations.push({
+        type: "why-per-panel",
+        description: `under one shared axis ${shared.name} would draw ` +
+          `${shared.px.toFixed(1)}px of a ${PANEL_H}px plot`,
+      });
+      expect.soft(shared.px, "the fixture no longer carries the spread this form exists for")
+        .toBeLessThan(5);
+
+      for (const panel of geom) {
+        // A THIRD OF THE PLOT, not a pixel floor: what "legible" means here is that the
+        // series' own variation is a shape rather than a line, and the four panels differ
+        // by 150× in magnitude while agreeing on that. Measured, the tightest is Housing at
+        // ~44% and the loosest Uncategorized at ~99%.
+        expect.soft(panel.span / panel.plot, `${panel.name}: its line spans ` +
+          `${panel.span.toFixed(1)}px of a ${panel.plot.toFixed(1)}px plot`)
+          .toBeGreaterThan(0.3);
+      }
+    });
+
+  test("reflows 4 → 2 → 1 at a 185px floor, with one named third rung",
+    async ({ page, baseURL }, testInfo) => {
+    await openView(page, baseURL, "Spending › Overview");
+    await linesSettled(page);
+
+    const geom = await page.locator(".main .trendgrid").evaluate((grid) => {
+      const style = getComputedStyle(grid);
+      const panels = [...grid.querySelectorAll(".trendpanel")];
+      return {
+        inner: grid.getBoundingClientRect().width,
+        gap: parseFloat(style.columnGap),
+        columns: new Set(panels.map((p) => Math.round(p.getBoundingClientRect().left))).size,
+        chart: panels.map((p) =>
+          Math.round(p.querySelector(".recharts-responsive-container").getBoundingClientRect().height)),
+      };
+    });
+
+    // The column count is not asserted per viewport but DERIVED from the rule and checked
+    // against the width the card actually got, so the same expectation holds at all ten and
+    // a shell change that moved the card's inner width cannot quietly satisfy a literal.
+    const fits = Math.floor((geom.inner + PANEL_GAP) / (PANEL_FLOOR + PANEL_GAP));
+    const want = Math.min(4, Math.max(1, fits));
+    expect.soft(geom.gap, "the gap is the floor's other half — 185/14 gives 4 → 2 → 1").toBe(PANEL_GAP);
+    expect.soft(geom.columns, `${Math.round(geom.inner)}px of grid should hold ${want} columns`)
+      .toBe(want);
+    // THE THIRD RUNG IS THE POINT OF 185 OVER 220, and it survives at nine viewports out of
+    // ten. Three columns leaves three panels and an orphan; at a 220px floor that is what the
+    // gated 1100 viewport draws, where the card is 809px inner because the grid above it is
+    // single-column there. At 185 that viewport draws four.
+    //
+    // ROTATED PHONE IS THE ONE EXCEPTION, AND IT IS THE SHELL'S DOING RATHER THAN THE GRID'S.
+    // 844x390 takes the phone shell on the `(max-height: 500px)` guard, so the 200px rail
+    // leaves the flow — but `.main`'s gutter follows WIDTH, and 844 is above the phone tier,
+    // so the pane keeps its 28px desktop padding. That combination exists at no other
+    // viewport and lands the card on ~754px inner, which is three 185px tracks and not four.
+    // No floor fixes it: a floor big enough to make 754 draw two makes 809 draw three, and
+    // 809 is the width the whole 185-over-220 argument turns on. The alternative is a
+    // breakpoint, which this rule is specced not to add.
+    //
+    // ASSERTED AS AN EQUIVALENCE RATHER THAN SKIPPED. The claim is that the orphan happens at
+    // exactly one named viewport: a shell or gutter change that produced a second one fails
+    // here, and so does one that quietly took this one away.
+    expect.soft(want === 3, `three panels and an orphan at ${Math.round(geom.inner)}px of card`)
+      .toBe(testInfo.project.name === "rotated-phone");
+    for (const h of geom.chart) {
+      expect.soft(h, "the panel plot is 140px — SpendTrend.jsx's PANEL_H").toBe(PANEL_H);
+    }
+  });
+
+  test("derives its footnote from the window payload rather than typing it",
+    async ({ page, baseURL }, testInfo) => {
+      await openView(page, baseURL, "Spending › Overview");
+      const lines = await page.locator(".main .trendnote > div").allTextContents();
+      const { win } = windowed();
+
+      const material = win.sources.filter((s) => s.material);
+      const share = material.reduce((a, s) => a + s.share, 0);
+      const dated = win.sources.reduce((a, s) => a + s.total_sgd, 0);
+      const outside = win.excluded.before.total_sgd + win.excluded.after.total_sgd
+        + win.excluded.gaps.total_sgd;
+
+      const window_ = lines[0] ?? "";
+      // THE RANGE, THE COUNT AND THE SHARE ARE ALL READ OFF THE PAYLOAD. "two of three
+      // sources" is what a typed line says, and it is wrong on this very fixture — there are
+      // four sources and three of them are material.
+      expect.soft(window_, "the window line does not carry its own range")
+        .toContain(`${material.length} of ${win.sources.length}`);
+      expect.soft(window_, "the material share is derived from the flags")
+        .toContain(fmt(share * 100, 1) + "%");
+      // The money outside the window is computed from the DATED total: `summary()`'s
+      // total_sgd includes undated rows, and subtracting against it would absorb undated
+      // spend into this figure. That is `undated()`'s to report, on the third line.
+      expect.soft(window_, "the off-chart money is not stated").toContain(sgd(outside));
+      expect.soft(window_, "the off-chart share is not stated")
+        .toContain(fmt((outside / dated) * 100, 1) + "%");
+      for (const ym of [win.start, win.end]) {
+        expect.soft(window_, `the window line does not name ${ym}`).toContain(monthName(ym));
+      }
+
+      // Depth: the two places the chart deliberately does not go. No links — the app has no
+      // cross-tab navigation, and adding one here would be its first.
+      expect.soft(lines[1] ?? "", "the depth line names neither destination").toContain("By Category");
+      expect.soft(lines[1] ?? "", "the depth line names neither destination").toContain("Classify");
+
+      const undated = readFixture("spending-undated.json");
+      if (undated.n > 0) {
+        expect.soft(lines[2] ?? "", "the undated line is missing at a non-zero count")
+          .toContain(sgd(undated.total_sgd));
+      } else {
+        expect.soft(lines, "the undated line is guarded on a non-zero count").toHaveLength(2);
+        testInfo.annotations.push({
+          type: "not-covered-by-fixtures",
+          description: "undated spend is n=0/$0 on the live ledger, so the third footnote " +
+            "line is exercised only in its absent branch",
+        });
+      }
+    });
+});
+

--- a/web/tests/fixtures/index.js
+++ b/web/tests/fixtures/index.js
@@ -64,15 +64,46 @@ export function fixtureFor(pathAndQuery) {
 
 
 /**
- * The four pathological rows the fixtures exist to carry, each with the reason it is
+ * The spend trend's counterfactual: how many pixels the SMALLEST of the four series would get
+ * if all four shared one y-axis floored at zero, in a panel plot 140px tall
+ * (`SpendTrend.jsx`'s PANEL_H).
+ *
+ * Exported because two things need it and they need it for opposite reasons. The pathological
+ * row below asserts the fixtures still CARRY the spread — a window whose four series happened
+ * to agree in magnitude would pass "no series is flattened onto the floor" under a shared axis
+ * too, which is the one way that gate goes quietly vacuous. `charts.spec.js` prints the same
+ * number as the annotation beside what each panel actually drew. Two copies of this arithmetic
+ * could disagree, and the pair only means anything if they cannot.
+ *
+ * `scripts/capture_web_fixtures.py` carries the third — deliberately, and for the reason every
+ * pathological row is asserted twice: that one fails at the source, the moment a recapture
+ * would have dropped the spread. Move the 5px threshold in one and move it in the other.
+ */
+export function sharedAxisSpanPx(trends, window, plotPx = 140) {
+  const rows = trends.series.filter((r) => r.ym >= window.start && r.ym <= window.end);
+  const spans = trends.groups.map((name) => {
+    const vals = rows.map((r) => Number(r[name] ?? 0));
+    return { name, lo: Math.min(...vals), hi: Math.max(...vals) };
+  });
+  const ceiling = Math.max(...spans.map((s) => s.hi));
+  const worst = spans.reduce((a, b) => (b.hi - b.lo < a.hi - a.lo ? b : a));
+  return { name: worst.name, px: ((worst.hi - worst.lo) / ceiling) * plotPx };
+}
+
+/**
+ * The five pathological rows the fixtures exist to carry, each with the reason it is
  * here. `inventory.spec.js` asserts every one of them, so these are load-bearing checks
  * rather than commentary: the moment a recapture drops one, the suite says so.
  *
  * Every one of these came out of planning, and each of them either broke a measurement
  * or would have. Fixtures that were merely *plausible* would not contain any of them.
  *
- * `scripts/capture_web_fixtures.py` asserts the same four at capture time, so a
+ * `scripts/capture_web_fixtures.py` asserts the same five at capture time, so a
  * recapture cannot quietly drop one. Move a threshold here and move it there.
+ *
+ * `fixture` IS ONE FILE OR SEVERAL. Four of these are a claim about one payload; the
+ * fifth is a claim about two together, because the spread that decides the spend trend's
+ * whole form only exists inside the window a second endpoint defines.
  */
 export const PATHOLOGICAL = [
   {
@@ -108,6 +139,22 @@ export const PATHOLOGICAL = [
     holds: (body) => {
       const longest = body.reduce((m, r) => Math.max(m, (r.merchant ?? "").length), 0);
       return { ok: longest >= 65, saw: `longest merchant is ${longest} chars` };
+    },
+  },
+  {
+    name: "the ~150x spread inside the spend-trend window",
+    // What makes the spend trend small multiples rather than one chart. Four series in the
+    // same window differ by two orders of magnitude, so under a single y-axis floored at
+    // zero the smallest of them is drawn flat: this computes that counterfactual and holds
+    // it under 5px of the 140px plot the panels actually get. A recapture that flattened the
+    // spread — a quiet month, a reclassification — would leave `charts.spec.js`'s "none is
+    // flattened onto the floor" gate passing against data where a shared axis would have
+    // passed it too, which is the one way that gate can go quietly vacuous.
+    fixture: ["spending-trends.json", "spending-window.json"],
+    holds: (trends, win) => {
+      const { name, px } = sharedAxisSpanPx(trends, win);
+      return { ok: px < 5,
+               saw: `${name} would draw ${px.toFixed(1)}px of a 140px plot under a shared axis` };
     },
   },
   {

--- a/web/tests/inventory.spec.js
+++ b/web/tests/inventory.spec.js
@@ -83,11 +83,22 @@ test("no chart renders the library's own legend", () => {
   expect(offenders, "render the key as DOM — `ChartKey` in `charts.jsx`").toEqual([]);
 });
 
-test("both multi-series charts carry a DOM key", () => {
+test("every multi-series chart that needs a DOM key carries one", () => {
   // The counterpart of the gate above: forbidding `<Legend>` is satisfied by having no key
   // at all, which is exactly the state `NetWorth` shipped in — two coloured lines named only
   // in a tooltip that touch never opens. Named files rather than a count, because "multi-
   // series" is not greppable and a third one arriving should have to be added here by hand.
+  //
+  // AND A THIRD ONE HAS ARRIVED, DELIBERATELY WITHOUT A KEY. `SpendTrend.jsx` draws four
+  // series and is not on this list, which is what "needs" in the title is carrying: it draws
+  // them as small multiples, one series per panel, and every panel's header states that
+  // series' colour, name, latest value and signed delta directly above its own plot. A key
+  // under that grid would restate four names and four colours written four times immediately
+  // above it. The panel headers ARE the key, and `charts.spec.js` asserts them as one — chip
+  // against the map, caption against the payload — so the claim this gate exists to hold is
+  // held there rather than dropped. What must not happen is that file appearing here quietly:
+  // if it ever renders a `<ChartKey>`, this list is wrong in the direction that matters and
+  // the exact equality below is what says so.
   //
   // Comments stripped, like its two siblings — and here the direction of the mistake is the
   // interesting one. The `<Legend>` gate forbids a construct, so a prose mention would fail it
@@ -98,7 +109,8 @@ test("both multi-series charts carry a DOM key", () => {
     .filter((f) => /<ChartKey[\s/>]/.test(stripComments(fs.readFileSync(f, "utf8"))))
     .map((f) => path.relative(WEB, f))
     .sort();
-  expect(keyed, "a multi-series chart with no key is anonymous on touch").toEqual(wanted);
+  expect(keyed, "a multi-series chart with no key is anonymous on touch — unless every series "
+    + "is captioned at its own panel, which is `SpendTrend.jsx` and only that").toEqual(wanted);
 });
 
 test("no spending surface indexes the positional palette", () => {
@@ -259,10 +271,15 @@ test.describe("the fixtures carry the pathological rows they exist for", () => {
   // Fixtures that were merely *plausible* are what produced the error these exist to
   // prevent: the top-line-items card measured 415px against invented rows during
   // planning and 519px against real ones. Each case below names why it is here.
+  //
+  // `fixture` is one file or several, spread into `holds` in the order it lists them: the
+  // spend trend's spread is a claim about the trends payload *inside* the window a second
+  // endpoint defines, and neither file states it alone.
   for (const c of PATHOLOGICAL) {
     test(c.name, () => {
-      const { ok, saw } = c.holds(readFixture(c.fixture));
-      expect(ok, `${c.fixture}: ${saw}`).toBe(true);
+      const files = [].concat(c.fixture);
+      const { ok, saw } = c.holds(...files.map(readFixture));
+      expect(ok, `${files.join(" + ")}: ${saw}`).toBe(true);
     });
   }
 });


### PR DESCRIPTION
Closes #100.

Small multiples on Spending › Overview — one panel per spend category, each on its own
y-axis, drawing raw monthly totals over the window #94 defines. A full-width **sibling**
card between the two-column grid and the monthly stacked bar, so the page reads tiles →
grid → trajectory → per-month detail. It replaces nothing: the stacked bar still answers
"what did I spend in March" on the same page.

## Why per-panel scaling

The four series span ~150× on real data, so under one shared axis the smallest is drawn
flat. `sharedAxisSpanPx` computes that counterfactual from the committed payload and
Transport comes out at **2.7px of a 140px plot**. Dropping Uncategorized does not relieve
it and dropping Personal barely does — only a per-series or a log scale touches it, and
per-panel wins because it fixes the compression **without changing what a pixel means**:
the axis is floored at zero, so inside a panel dollars stay dollars.

Safe only because the taxonomy is locked at three categories. **The recommendation inverts
at subcategory depth.**

## The caption is load-bearing

Newest is at the **left**, so every panel reads backwards — Transport's line rises
left-to-right while its number has fallen — and a panel has no y-axis at all, so the slope
is its entire visual content. The header states the latest value and the signed delta in
words. Two endpoint months sit under each plot as DOM rather than as recharts ticks: an
axis tick sits at its data point, the first point is at the plot's left edge, and a centred
label there is half outside the SVG.

The panel headers are also the key. `inventory.spec.js`'s gate is renamed so this file is
*deliberately not on its list* rather than missing from it.

## The footnote is derived, never typed

The window line reads `/api/spending/window`'s material-source flags: typed, it says "two
of three sources", which is wrong on the very payload that ships with it — four sources,
three material. The off-chart money is computed from the **dated** total; the undated line
is guarded on a non-zero count.

## Two things worth a reviewer's eye

**The "no third rung" claim holds at nine viewports, not ten.** 844×390 draws three panels
and an orphan: a rotated phone drops the 200px rail on the height guard but keeps the 28px
desktop gutter, leaving **754px** of card where the 1100 viewport gives **809px**. No floor
fixes both — one big enough to make 754 draw two makes 809 draw three, and 809 is what the
whole 185-over-220 argument turns on — and the only other lever is a breakpoint the rule is
specced not to add. Shipped the specced floor, pinned the orphan to that **named** viewport
in the test so a second one fails, and recorded the arithmetic in `RESPONSIVE.md`.

**Two additions beyond the literal spec.** The endpoint-month labels under each plot (§E is
silent on the x-axis, but without them nothing on screen says which end is *now*), and panel
ordering derived from in-window spend with residue pinned last rather than the spec's listed
order taken as literal. Both are argued in-file; both are yours to veto.

## Review findings already applied

Code review caught a real bug: **gap months were drawn while the footnote counted their money
as off-chart**. Now `drawn = window − gaps`, matching `_window_shape`'s own arithmetic. Inert
today (`gaps: []`) and annotated as an unexercised branch on every run.

Also folded in: `monthName`/`monthTick` moved to `api.js` so the suite asserts rendered labels
against the app's own formatter, and the shared-axis counterfactual reduced from three copies
to one exported function.

## Tests

A fifth pathological fixture row asserts the spread itself, in the suite and at capture time
both — a window whose four series happened to agree in magnitude would pass "no series is
flattened onto the floor" under a shared axis too, which is the one way that gate goes
quietly vacuous.

`make test-web`: **1,415 passed, 477 skipped, 0 failed.**

https://claude.ai/code/session_01SZnu4XhdqwpjbNvfGntypf


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a spending trend visualization to Spending Overview.
  - View independently scaled trend panels for each spending category, including direction, latest values, ranges, tooltips, and category-specific styling.
  - Trend charts now adapt responsively across desktop, tablet, and mobile layouts.
  - Added clear reporting-window, source-coverage, and excluded-spend disclosures.

- **Documentation**
  - Updated responsive design and testing documentation with spending trend behavior and validation details.
  - Expanded web-test coverage and fixture validation for trend charts and pathological data cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->