### PR TITLE
feat(web): the spend trend, four panels and four scales (#100)

### DIFF
--- a/RESPONSIVE.md
+++ b/RESPONSIVE.md
@@ -5,8 +5,8 @@ carries most of it.
 
 **The regression trigger is the suite, and the command is `make test-web`.** Ten named viewports ×
 thirteen views, run against a production build through vite's preview server with every API call
-served from committed fixtures: **1,345 passed, 470 skipped, 0 failed, ~7.5 minutes on an unloaded
-machine**, as of #47. The skips are structural rather than disabled tests — a gate
+served from committed fixtures: **1,431 passed, 477 skipped, 0 failed, ~9 minutes on an unloaded
+machine**, as of #100. The skips are structural rather than disabled tests — a gate
 whose subject does not render at a viewport skips there, which is what makes "no card-per-row at 640
 and above" and "the desktop table is untouched" separate claims from their positive halves.
 `web/TESTING.md` says what each spec claims. The table-inventory grep this file used to ask a human
@@ -166,7 +166,7 @@ person still looks at, and "—" means the suite has all of it.
 | Portfolio › Transactions | **B** below 640 · **A** on `Date` from 640 to 1024 | — *(telling two same-day trades apart is an [open call](#open-calls), not a check)* |
 | Portfolio › SecurityDetail | txn history **B** · dividend history **B** · options history **A**, pinning the merged two-line `Contract` cell — and **B, A, A** above 640, since the tier gives both histories the pin on `Date` · `← Holdings` is `a.backlink`, a ≥44px target below the tier and the only way back — it was 17px until #47, see [Observations](#observations) | the dividend history renders for no fixture (PLTR has none) — its wrapper is the one thing in the tier no fixture reaches, and `pinned.spec.js` annotates that on every run |
 | Net Worth | editor floor · line chart carries a DOM `.chartkey`, not `<Legend>` · Breakdown and History `.contained` **below 1024**, not unconditionally · row grid unchanged | readable — the editors' remaining criterion |
-| Spending › Overview | donut dropped below 640, the list is the chart · stacked bar chart's `<Legend>` is a `.chartkey` · Top Line Items **B** below 640, **A** on `Category` from 640 to 1024 | — *(the stacked bar chart was unreachable while `/api/spending/trends` was captured as a **500**; **#35** fixed the endpoint, the fixture holds a real chart, and `charts.spec.js` asserts its key in the DOM. The view's hscroll residual did not move — the chart is a full-width card holding a percentage-width container, and that number was always the `.grid2` track floor)* |
+| Spending › Overview | donut dropped below 640, the list is the chart · stacked bar chart's `<Legend>` is a `.chartkey` · Top Line Items **B** below 640, **A** on `Category` from 640 to 1024 · **spend trend** a full-width sibling card between the grid and the stacked bar: `.smallmult` reflows **4 → 2 → 1** with no media query and no new breakpoint, 140px panels, and it **stays at 390** — one column there is ~35px per point against desktop's ~27 | — *(the stacked bar chart was unreachable while `/api/spending/trends` was captured as a **500**; **#35** fixed the endpoint, the fixture holds a real chart, and `charts.spec.js` asserts its key in the DOM. The view's hscroll residual did not move — the chart is a full-width card holding a percentage-width container, and that number was always the `.grid2` track floor. The trend does not move it either: its own floor is `min(185px, 100%)`, the same percentage guard, and its header row is `flex: none` numbers around an ellipsing name so its min-content is ~100px)* |
 | Spending › By Category | donut dropped below 640 · Categories **A** with the name column pinned, keeping its own `▸`/`▾` and the `.rowtap` flash *instead of* the persistent `›` · drilled transactions **B**, **outside the `.grid2` entirely** rather than merely outside the table | whether three levels of drill read as one structure once the third leaves the grid |
 | Spending › Classify | editor floor · `.fillpane`/`.grow` become blocks below 640 so the page scrolls as one, `.scroll` deliberately untouched · ⇅ Reorder `display: none`, so the reorder modal is unreachable below the tier by design · `RuleModal` on `svh`, its control rows wrap, `CatSelect` capped at `max-width: 100%`, `MatchTable` `.contained` | readable · `MatchTable` renders only after a POST the GET-captured fixtures do not carry — `editors.spec.js` annotates that gap |
 | Spending › Recurring | monitor **A** · candidates **A** | the monitor never mounts — the owner tracks nothing, so `/api/spending/recurring` is `[]` and its pin is eyes-only (`pinned.spec.js` annotates it) · the **two nested scroll regions**, which is the feel check |
@@ -221,6 +221,18 @@ reconciliation unless marked otherwise.
   ~45px → ~88px. Right direction, wrong magnitude in both readings: the cell already carried more
   than the bare buttons, so the floor cost **18px** rather than the 43px predicted. Paid in scroll
   distance inside a pinned table, which is what the forecast said it would be.
+- **The spend trend's rung at 844×390 — the one viewport a flat `auto-fit` grid gets wrong.**
+  `rotated-phone` is the only viewport at or above 640 with **no 200px rail** — the shell moves to
+  the drawer on the `(max-height: 500px)` guard while `.main` keeps its 28px landscape gutter — so
+  its card is ~756px inner. That is past three 185px tracks (583) and short of four (782), and a
+  single `auto-fit` grid therefore draws **three panels and an orphan** there: exactly the failure
+  the 185px floor was chosen over 220px to avoid, arriving at a different viewport than the one the
+  floor was measured at. **A flat grid cannot promise "no third rung"** — the number of tracks that
+  fit is monotone in the floor, so every rung is reachable at some width. `.smallmult` therefore
+  grids the panels in **pairs**: an outer floor of 384 (= 185 + 14 + 185) and an inner one of 185,
+  which makes the rungs 4, 2 and 1 and 3 inexpressible, with no media query and no second number.
+  Recorded rather than folded into the per-view row because it is the measurement that chose the
+  structure, and a reader who sees two nested grids will otherwise flatten them.
 - **The drawer's row height at 844×390 — 39px** (`Settings`, the dim one, 37.5px), against **44px**
   for the same rows at 390×844. Predicted ~38px. This is the residual the tablet tier's height guard
   creates and the one place two of that tier's decisions pull against each other: the shell travels

--- a/RESPONSIVE.md
+++ b/RESPONSIVE.md
@@ -221,18 +221,19 @@ reconciliation unless marked otherwise.
   ~45px → ~88px. Right direction, wrong magnitude in both readings: the cell already carried more
   than the bare buttons, so the floor cost **18px** rather than the 43px predicted. Paid in scroll
   distance inside a pinned table, which is what the forecast said it would be.
-- **The spend trend's rung at 844×390 — the one viewport a flat `auto-fit` grid gets wrong.**
-  `rotated-phone` is the only viewport at or above 640 with **no 200px rail** — the shell moves to
-  the drawer on the `(max-height: 500px)` guard while `.main` keeps its 28px landscape gutter — so
-  its card is ~756px inner. That is past three 185px tracks (583) and short of four (782), and a
-  single `auto-fit` grid therefore draws **three panels and an orphan** there: exactly the failure
-  the 185px floor was chosen over 220px to avoid, arriving at a different viewport than the one the
-  floor was measured at. **A flat grid cannot promise "no third rung"** — the number of tracks that
-  fit is monotone in the floor, so every rung is reachable at some width. `.smallmult` therefore
-  grids the panels in **pairs**: an outer floor of 384 (= 185 + 14 + 185) and an inner one of 185,
-  which makes the rungs 4, 2 and 1 and 3 inexpressible, with no media query and no second number.
-  Recorded rather than folded into the per-view row because it is the measurement that chose the
-  structure, and a reader who sees two nested grids will otherwise flatten them.
+- **The spend trend's card at 844×390 — ~756px inner, the widest card in the app below 1024.**
+  `rotated-phone` is the only viewport at or above 640 with **no 200px rail**: the shell moves to
+  the drawer on the `(max-height: 500px)` guard while `.main` keeps its 28px landscape gutter. That
+  is the measurement that chose `.smallmult`'s structure — 756 sits between three 185px tracks and
+  four, so a flat `auto-fit` grid draws three panels and an orphan there. **The rule is in
+  `styles.css` at `.smallmult` and is asserted by `charts.spec.js`; this entry is only the number**,
+  recorded because it is the width no other card in the tier reaches and the next full-width card
+  will want it.
+  **It is also the one place the build reads #92 §E against itself.** That section asks for a 185px
+  floor, a 14px gap *and* "no third rung", and a single `auto-fit` grid cannot deliver all three —
+  the tracks that fit are monotone in the floor, so every rung is reachable at some width. The floor
+  and the gap are unchanged; the grid is nested one level so a row holds 4, 2 or 1. Written down
+  here because it reads as a deviation from that line and is not one from the outcome.
 - **The drawer's row height at 844×390 — 39px** (`Settings`, the dim one, 37.5px), against **44px**
   for the same rows at 390×844. Predicted ~38px. This is the residual the tablet tier's height guard
   creates and the one place two of that tier's decisions pull against each other: the shell travels

--- a/web/TESTING.md
+++ b/web/TESTING.md
@@ -145,7 +145,7 @@ coordinates the rejected layout passes. It also carries the group header — the
 and the chevron carve-out, which is the only place pattern A's affordance rule is deliberately not
 applied.
 
-`tests/charts.spec.js` — the six chart surfaces. Below 640 the donuts are not rendered and the
+`tests/charts.spec.js` — the seven chart surfaces. Below 640 the donuts are not rendered and the
 `.barrow` list beneath them becomes the chart, which is the one gate here that asserts an *absence*:
 `display: none` starves a `ResponsiveContainer` to 0×0, so a hidden chart and a collapsed chart are
 the same DOM and the treatment has to be a hook rather than a rule. Everything else it checks holds at
@@ -168,9 +168,31 @@ against the map declared in `src/palette.js`, which it **imports rather than res
 hexes in the suite is a second palette, and the drift it would be blind to is the one it exists to
 catch.
 
+It also carries the **spend trend**, the view's fourth chart surface and the first small-multiples
+one: four panels on four scales, drawn newest-at-the-left. Five gates, and every number in them is
+recomputed from the two committed fixtures rather than typed — the panel names are the trends
+payload's own `groups`, the drawn months are `spending-window.json`'s `start`/`end`, and the
+footnote's material-source count, source name and outside-the-window money are re-derived here from
+the same flags the component reads, because a literal would be a second copy of the window rule.
+The per-panel scaling is asserted as the thing it exists to prevent: each drawn curve's vertical
+extent is measured as a share of its own plot, so a series flattened onto a shared floor scores a
+few percent where a scaled one scores tens. Placement is asserted as document order — tiles, grid,
+trend, stacked bar — rather than as pixel tops, which one viewport could satisfy by accident. The
+rung gate counts the **distinct left edges of the panels**, which is the rendered outcome, not a
+computed track string: `auto-fit` reports collapsed repetitions as `0px` and the grid is nested in
+pairs, so either level's track list describes the mechanism instead of what a reader sees. And a
+third rung is asserted to be impossible, which is a real claim rather than a restatement of the
+CSS — `rotated-phone` is 844px wide with no rail and lands in the 3 band, which is what put the
+pair wrapper there.
+
 `tests/inventory.spec.js` — the checks that read files rather than pixels: the table count, the
-single donut implementation, that no chart renders a `<Legend>` and that both multi-series charts
-carry a `<ChartKey>`, that **no source file names a net-worth catalogue item code** — the New
+single donut implementation, that no chart renders a `<Legend>`, that the two multi-series charts
+that need one carry a `<ChartKey>` **and that the spend trend deliberately does not** — it is small
+multiples, so each series has a panel whose header already names it, shows its colour and states its
+direction, and a second key would both restate that and break the single-`.chartkey` count on
+Spending › Overview; the same gate asserts that header still carries its chip, name and delta, since
+a `<ChartKey>` sneaking in would be caught by the list but a header stripped bare would leave the
+chart anonymous with nothing failing, that **no source file names a net-worth catalogue item code** — the New
 Snapshot form's headings and rows are derived from the catalogue's `band`, and the codes are read
 out of the fixture so a recapture cannot leave the gate asserting a stale list (`srs` is held out,
 because one word is a code, a band value *and* a funding bucket, so the claim is about the other

--- a/web/src/modules/spending/ByCategory.jsx
+++ b/web/src/modules/spending/ByCategory.jsx
@@ -61,6 +61,11 @@ export default function SpendByCategory() {
 
   // counted spend with no txn_date falls outside every year window, so name it once here —
   // otherwise the per-year totals silently undershoot the all-time Overview total.
+  //
+  // NOT THE ONLY SURFACE THAT SAYS THIS ANY MORE. `SpendTrend.jsx`'s footnote carries the
+  // same guard on the same payload, and says "fall in no **month**" where this one says
+  // "no year" — its window is months, this one's is the year in the `<select>`. Two
+  // sentences on purpose; change one and read the other.
   useEffect(() => {
     get("/api/spending/undated").then(setUndated).catch(() => setUndated(null));
   }, []);

--- a/web/src/modules/spending/Overview.jsx
+++ b/web/src/modules/spending/Overview.jsx
@@ -7,13 +7,24 @@ import { get, sgd, fmt, catName } from "../../api.js";
 import { ChartKey, Donut } from "../../charts.jsx";
 import { categoryColour } from "../../palette.js";
 import { Cards, RowCard, usePhone } from "../../cards.jsx";
+import SpendTrend from "./SpendTrend.jsx";
 
 export default function SpendOverview() {
   const [sum, setSum] = useState(null);
   const [trend, setTrend] = useState(null);
+  // The spend trend's window and its footnote. Two more calls rather than a wider trends
+  // payload, and that is the decision rather than an accident: a windowed trends call would
+  // put a date in its own fixture key, and a date in a fixture key drifts every month — the
+  // recapture writes a different key, the old one goes dead and the unmatched-paths gate
+  // fails. The trend chart slices the array below instead, so one payload feeds both charts
+  // on this page and they cannot disagree about a month they share.
+  const [win, setWin] = useState(null);
+  const [undated, setUndated] = useState(null);
   const phone = usePhone();
   useEffect(() => { get("/api/spending/summary").then(setSum).catch(() => setSum({ error: true })); }, []);
   useEffect(() => { get("/api/spending/trends").then(setTrend).catch(() => setTrend({ groups: [], series: [] })); }, []);
+  useEffect(() => { get("/api/spending/window").then(setWin).catch(() => setWin(null)); }, []);
+  useEffect(() => { get("/api/spending/undated").then(setUndated).catch(() => setUndated(null)); }, []);
   if (!sum) return <div className="loading">Loading…</div>;
   if (sum.error) return <div className="loading">API not reachable.</div>;
 
@@ -98,6 +109,17 @@ export default function SpendOverview() {
           )}
         </div>
       </div>
+      {/* THE TREND SITS BETWEEN THE GRID AND THE STACKED BAR, and the order is the point:
+          tiles -> grid[donut | top line items] -> trend -> stacked bar. Trajectory precedes
+          the per-month detail chart, so coarse-to-fine survives. It does NOT replace the
+          stacked bar below — that one still answers "what did I spend in March", which is a
+          different question and the reason both are on this page.
+
+          THE TWO CHARTS RUN IN OPPOSITE DIRECTIONS AND THAT IS ACCEPTED. The trend is drawn
+          newest-at-the-left; the stacked bar is left-to-right and is NOT flipped. What makes
+          that safe is the trend's per-panel caption, which states every panel's direction in
+          words — so an adjacent left-to-right bar cannot silently mislead. */}
+      <SpendTrend trend={trend} win={win} undated={undated} />
       {trend && trend.series.length > 0 && (
         <div className="card" style={{ marginTop: 16 }}>
           <h3>Monthly Spend by Category</h3>

--- a/web/src/modules/spending/Overview.jsx
+++ b/web/src/modules/spending/Overview.jsx
@@ -12,12 +12,16 @@ import SpendTrend from "./SpendTrend.jsx";
 export default function SpendOverview() {
   const [sum, setSum] = useState(null);
   const [trend, setTrend] = useState(null);
-  // The spend trend's window and its footnote. Two more calls rather than a wider trends
-  // payload, and that is the decision rather than an accident: a windowed trends call would
-  // put a date in its own fixture key, and a date in a fixture key drifts every month — the
-  // recapture writes a different key, the old one goes dead and the unmatched-paths gate
-  // fails. The trend chart slices the array below instead, so one payload feeds both charts
-  // on this page and they cannot disagree about a month they share.
+  // The spend trend's window and its footnote, fetched HERE rather than inside the chart,
+  // because that is where every other payload on this view is fetched and the charts under
+  // it are renderers. `trend` is the case that makes it more than a convention: the stacked
+  // bar and the trend draw the same array, and a chart that fetched its own copy would be
+  // two requests that can disagree about a month they share.
+  //
+  // Two calls rather than one windowed trends call, and that is the decision rather than an
+  // accident: a windowed key embeds a date that drifts every month, so a recapture writes a
+  // *different* fixture key, the old one goes dead and the unmatched-paths gate fails. The
+  // trend slices the array below instead.
   const [win, setWin] = useState(null);
   const [undated, setUndated] = useState(null);
   const phone = usePhone();

--- a/web/src/modules/spending/SpendTrend.jsx
+++ b/web/src/modules/spending/SpendTrend.jsx
@@ -1,8 +1,7 @@
 import React from "react";
 import { ResponsiveContainer, LineChart, Line, XAxis, YAxis, Tooltip } from "recharts";
-import { sgd, fmt } from "../../api.js";
+import { sgd, fmt, catName } from "../../api.js";
 import { categoryColour, CATEGORY_DASH } from "../../palette.js";
-import { usePhone } from "../../cards.jsx";
 
 /**
  * The spend trend on Spending › Overview: small multiples, four panels, four scales.
@@ -61,17 +60,21 @@ const dayName = (iso) => new Date(iso + "T00:00:00Z")
   .toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric", timeZone: "UTC" });
 
 /**
- * The signed change across the drawn window, oldest to newest, as the header prints it.
+ * The signed change across the drawn window, oldest to newest, as the header PRINTS it —
+ * a label, not a number. Named for that: nothing downstream may do arithmetic on it.
  *
  * A percentage, because that is what makes a $52 move in Transport comparable with a $1,700
  * move in Personal — which is the whole reason four panels with four scales need a caption
  * at all. From a zero start there is no percentage to state, so it states the money instead
  * rather than printing an infinity or silently dropping the caption.
  *
- * U+2212 MINUS, not a hyphen: it is the character the app's other signed labels use, and it
- * lines up in a tabular-nums column where a hyphen does not.
+ * U+2212 MINUS, AND THIS IS THE ONLY PLACE IN `web/src` THAT WRITES A SIGN ITSELF. Every
+ * other negative in the app comes out of `fmt()`, i.e. out of `toLocaleString`, which hands
+ * back an ASCII hyphen — so there is no house character to match here, and the pairing that
+ * matters is the local one: `+` and `−` are the same width in this font where `+` and `-`
+ * are not, and the two signs sit in the same 12px slot of four headers read together.
  */
-function delta(first, last) {
+function deltaLabel(first, last) {
   const sign = last >= first ? "+" : "−";
   if (first === 0) return sign + sgd(Math.abs(last - first));
   return sign + fmt(Math.abs((last - first) / first) * 100, 0) + "%";
@@ -81,18 +84,35 @@ function delta(first, last) {
 const pairs = (xs) => xs.reduce((a, x, i) => (i % 2 ? a[a.length - 1].push(x) : a.push([x]), a), []);
 
 export default function SpendTrend({ trend, win, undated }) {
-  // Desktop hover only, and additive only: the tooltip repeats the month and the amount,
-  // and nothing in this chart exists in it alone. Touch has no hover, so a tooltip is not a
-  // place a fact can live — which is the same reasoning the donut is deleted on.
-  const phone = usePhone();
   if (!trend || !win || !win.start || !win.end) return null;
 
-  // The window is a rule, and this is the whole of applying it: the months the endpoint says
-  // are drawable, in the order the payload gives them. There is no window control, by
-  // decision — the grounds for excluding a month are data defects, so a control that let a
-  // reader select them back in would re-open a settled decision as an affordance and make
-  // the load-bearing delta captions user-authored.
-  const inWindow = trend.series.filter((r) => r.ym >= win.start && r.ym <= win.end);
+  // THE WINDOW IS A RULE, AND `gaps` IS PART OF IT — the range alone is not the rule. A
+  // drawable month is one at or after `start`, before the partial tail, AND one in which
+  // every material source reported; `_window_shape` puts the months that fail the last
+  // clause in `gaps`, and they sit *inside* `[start, end]`. Slicing on the range alone would
+  // draw an ingestion gap as a collapse in spending — which is the single failure this whole
+  // endpoint exists to prevent — and would then double-count it, because the footnote below
+  // adds `excluded.gaps` to the money it says is off the chart. Empty on today's ledger, so
+  // nothing in the suite can reach this branch; `charts.spec.js` annotates that on every run.
+  //
+  // WHAT A HOLE LOOKS LIKE once a month is dropped is deliberately out of scope (spec §B) —
+  // the line joins its neighbours. That is the unspecified half; drawing the gap as a real
+  // point is the specified-and-wrong half, and this is the clause that settles it.
+  //
+  // There is no window control, by decision: the grounds for excluding a month are data
+  // defects, so a control that let a reader select them back in would re-open a settled
+  // decision as an affordance and make the load-bearing delta captions user-authored.
+  const gaps = new Set(win.gaps || []);
+  const inWindow = trend.series.filter(
+    (r) => r.ym >= win.start && r.ym <= win.end && !gaps.has(r.ym));
+
+  // TWO POINTS, the same floor the composition chart takes: below it a line renders no
+  // segment and the header's first-versus-last delta has nothing to compare. The card is
+  // then absent rather than explaining itself, and that is the decision rather than an
+  // oversight — the net-worth chart writes copy at this threshold because it is the only
+  // thing in its cell, where this page still has the stacked bar, the donut and the tiles
+  // covering the same months. A card whose whole content is "not enough months to draw a
+  // trajectory" is a row of page length restating what the tiles above already show.
   if (inWindow.length < 2) return null;
 
   // NEWEST AT THE LEFT, which is why the header below is load-bearing rather than
@@ -102,10 +122,26 @@ export default function SpendTrend({ trend, win, undated }) {
   const oldest = inWindow[0];
   const newest = inWindow[inWindow.length - 1];
 
-  // THE PAYLOAD'S OWN ORDER, not a re-sort. Sorting by spend would re-rank the panels
-  // silently as the window grows — the same defect that rules out a top-N cap — and
-  // `_trend_shape` already sorts Uncategorized last, which is where the residue belongs.
-  const groups = trend.groups;
+  // PANEL ORDER: the drawn window's spend, descending, with the residue pinned last —
+  // Personal · Housing · Transport · Uncategorized on today's ledger, which is the order the
+  // spec names. Derived rather than typed, and both halves are load-bearing.
+  //
+  // Descending, because the payload's own order is ALPHABETICAL (`_trend_shape` sorts the
+  // group strings) and alphabetical is not a ranking of anything a reader is looking for —
+  // it put Housing first purely because H precedes P. This is not the re-ranking the spec
+  // rules out: that argument is about a top-N *cap*, which silently drops a series as the
+  // window grows. Four panels that are all always drawn cannot drop one, so the worst a
+  // re-sort can do is swap two adjacent panels, and the header on each one names it.
+  //
+  // The pin is separate because spend does not produce it: over this window Uncategorized
+  // outspends Transport 4.6x, so sorting alone puts the residue third. It goes last for the
+  // reason `_trend_shape` stacks it last — it is not a category anyone chose. `catName(null)`
+  // rather than the literal: that function is the app's one place that names the null
+  // category, and a second spelling here is a second name for one thing.
+  const residue = catName(null);
+  const spend = (g) => inWindow.reduce((a, r) => a + (Number(r[g]) || 0), 0);
+  const groups = [...trend.groups].sort(
+    (a, b) => (a === residue) - (b === residue) || spend(b) - spend(a));
 
   const material = win.sources.filter((s) => s.material);
   // The source whose first line is the latest among the material ones: the window starts the
@@ -118,8 +154,14 @@ export default function SpendTrend({ trend, win, undated }) {
     ? `, and the window starts the month after the last of them first reported`
       + ` (${startedBy.source}, ${dayName(startedBy.first_txn)})`
     : "";
+  // THREE BUCKETS, EACH OPTIONAL. `gaps` is the third kind of off-chart money and the newest
+  // key on the payload — the spec's own printed example carries only `before` and `after` —
+  // so a reader who checks this against the spec must not find a chart that throws on a
+  // payload the spec documents. Summed rather than subtracted from a total: the only
+  // subtraction available is `dated - before - after`, which counts every gap month's spend
+  // as drawn, and those months are precisely the ones dropped above.
   const outside = ["before", "after", "gaps"]
-    .reduce((a, k) => a + Number(win.excluded[k].total_sgd), 0);
+    .reduce((a, k) => a + Number(win.excluded?.[k]?.total_sgd || 0), 0);
   // THE DATED TOTAL, which is what the per-source totals sum to. `summary()`'s `total_sgd`
   // includes undated rows, so dividing by that would quietly absorb undated spend into the
   // outside-the-window share — and undated spend is the third footnote line's to report.
@@ -158,7 +200,7 @@ export default function SpendTrend({ trend, win, undated }) {
                 {/* Not `cls()`, deliberately: the app's pos/neg tokens mean gain and loss,
                     and spending more is neither. A green "−68%" on Transport would be this
                     card making a judgement it has no budget model to make. */}
-                <span className="delta">{delta(Number(oldest[g]) || 0, Number(newest[g]) || 0)}</span>
+                <span className="delta">{deltaLabel(Number(oldest[g]) || 0, Number(newest[g]) || 0)}</span>
               </div>
               {/* Min-max, demoted: it is the panel's range, which the reader needs only
                   once they have decided the slope is worth reading. */}
@@ -176,13 +218,19 @@ export default function SpendTrend({ trend, win, undated }) {
                       collide at 27px of spacing. */}
                   <XAxis dataKey="ym" hide />
                   <YAxis hide domain={[0, "auto"]} />
-                  {!phone && (
-                    <Tooltip
-                      formatter={(v) => [sgd(v), g]}
-                      labelFormatter={monthName}
-                      contentStyle={{ background: "#161b22", border: "1px solid #2b333d" }}
-                      itemStyle={{ color: "#d7dde4" }} labelStyle={{ color: "#d7dde4" }} />
-                  )}
+                  {/* ADDITIVE ONLY, AND THEREFORE UNGATED. It repeats the month and the
+                      amount; nothing in this chart exists in it alone, so a device with no
+                      hover loses nothing by never opening it. Not behind `usePhone()`: the
+                      hook decides whether a surface is RENDERED, and the donut is deleted
+                      below 640 because the list under it restates every row — a cost this
+                      tooltip does not have. The stacked bar directly below is ungated for
+                      the same reason, and two adjacent charts disagreeing about it would be
+                      the defect. */}
+                  <Tooltip
+                    formatter={(v) => [sgd(v), g]}
+                    labelFormatter={monthName}
+                    contentStyle={{ background: "#161b22", border: "1px solid #2b333d" }}
+                    itemStyle={{ color: "#d7dde4" }} labelStyle={{ color: "#d7dde4" }} />
                   {/* `linear`, no smoothing: a curve invents a shape between two months that
                       were each measured. Colour comes from the name-keyed map, and the dash
                       from the map beside it — grey alone is the weaker half of "residue
@@ -235,7 +283,14 @@ export default function SpendTrend({ trend, win, undated }) {
         </div>
         {/* Guarded on the count, and invisible today at n=0/$0. Undated spend is in no month,
             so it is in no panel — and it is not part of the money the first line calls
-            "outside the window" either, which is computed from the dated total. */}
+            "outside the window" either, which is computed from the dated total.
+
+            THE SAME SENTENCE IS IN `ByCategory.jsx`, and the two are deliberately not one
+            component. That one says "fall in no **year**", because its window is a year
+            picked from a `<select>`; this one says "no **month**", because the panels are
+            months. Same rows, same guard, two different reasons they are missing — which is
+            what a shared component would have to erase. Change the wording here and read
+            that one, the way `catName` in `api.js` is read against the compute layer. */}
         {undated && undated.n > 0 && (
           <div>
             Excludes {sgd(undated.total_sgd)} across {undated.n} undated

--- a/web/src/modules/spending/SpendTrend.jsx
+++ b/web/src/modules/spending/SpendTrend.jsx
@@ -1,0 +1,248 @@
+import React from "react";
+import { ResponsiveContainer, LineChart, Line, XAxis, YAxis, Tooltip } from "recharts";
+import { sgd, fmt } from "../../api.js";
+import { categoryColour, CATEGORY_DASH } from "../../palette.js";
+import { usePhone } from "../../cards.jsx";
+
+/**
+ * The spend trend on Spending › Overview: small multiples, four panels, four scales.
+ *
+ * WHY PER-PANEL SCALING, since it is the one decision the whole form rests on. Measured on
+ * a throwaway prototype against real data, it is a ~150x spread across the four series:
+ * Personal sets a ~$12,000 ceiling and Transport never leaves the floor at 3.4px. Dropping
+ * Uncategorized does not relieve it, and dropping Personal barely does — the $3,279
+ * unclassified spike then sets the ceiling and Transport reaches 6.2px. Only a per-series
+ * or a log scale touches it, and per-series wins because it fixes the compression *without
+ * changing what a pixel means*: inside a panel, dollars stay dollars.
+ *
+ * THIS FORM IS SAFE ONLY BECAUSE THE TAXONOMY IS LOCKED AT THREE CATEGORIES, which makes
+ * the grid permanently four panels. The recommendation inverts at subcategory depth — a
+ * reader cannot hold forty scales in their head, and forty panels is not a chart.
+ *
+ * IT ADDS NO PAYLOAD. The series is the `/api/spending/trends` array the view already
+ * fetches, sliced to the window; the stacked bar below draws the same array unsliced, so
+ * the two charts on this page cannot disagree about a month they share. The window and
+ * everything the footnote says about it comes from `/api/spending/window` — derived from
+ * that payload's material-source flags, never typed, because a typed count says "two of
+ * three sources" and is wrong the moment a fourth source exists.
+ *
+ * IT IS A SIBLING CARD, NOT A GRID CHILD. `unconditional.spec.js` asserts every `.grid2` in
+ * the app has exactly two children, which is what makes "never three columns" a property of
+ * the CSS rather than of the data; putting the trend in the grid would break that and give
+ * it a half-width cell, which is the one shape small multiples cannot use.
+ *
+ * NO SHARED KEY, so `charts.spec.js`'s single-`.chartkey` count on this view still holds:
+ * the panel headers *are* the key, and a key underneath would restate four things written
+ * immediately above it.
+ */
+
+/**
+ * The plot height inside a panel, and the reason the panel is 140px.
+ *
+ * `.smallmult .panel` in `styles.css` is `height: 140px`, and 140 is 16 (the header line) +
+ * 2 + 14 (the demoted min-max line) + 4 + this. The two numbers are one decision written in
+ * two files because one of them has to be a prop, and it has to be pixels: a percentage
+ * height inside a wrapper that merely happens to carry pixels is the shape that starves a
+ * `ResponsiveContainer` to 0x0, which `charts.spec.js`'s collapse gate has already caught
+ * twice in this app. Move one, move the other; `charts.spec.js` measures the 140.
+ */
+const PLOT_H = 104;
+
+/** The panel's own margins. Small: the panel has no axes, so nothing needs room. */
+const PLOT_MARGIN = { top: 4, right: 4, bottom: 4, left: 4 };
+
+/** "2025-09" -> "Sep 2025". en-US explicitly rather than the reader's locale: the footnote
+    below is prose the suite reads back, so its month labels have to be one thing. */
+const monthName = (ym) => new Date(ym + "-01T00:00:00Z")
+  .toLocaleDateString("en-US", { month: "short", year: "numeric", timeZone: "UTC" });
+
+/** "2025-08-21" -> "Aug 21, 2025", for the source that sets the window's start. */
+const dayName = (iso) => new Date(iso + "T00:00:00Z")
+  .toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric", timeZone: "UTC" });
+
+/**
+ * The signed change across the drawn window, oldest to newest, as the header prints it.
+ *
+ * A percentage, because that is what makes a $52 move in Transport comparable with a $1,700
+ * move in Personal — which is the whole reason four panels with four scales need a caption
+ * at all. From a zero start there is no percentage to state, so it states the money instead
+ * rather than printing an infinity or silently dropping the caption.
+ *
+ * U+2212 MINUS, not a hyphen: it is the character the app's other signed labels use, and it
+ * lines up in a tabular-nums column where a hyphen does not.
+ */
+function delta(first, last) {
+  const sign = last >= first ? "+" : "−";
+  if (first === 0) return sign + sgd(Math.abs(last - first));
+  return sign + fmt(Math.abs((last - first) / first) * 100, 0) + "%";
+}
+
+/** The groups in twos, which is what the outer grid lays out. See the pair wrapper below. */
+const pairs = (xs) => xs.reduce((a, x, i) => (i % 2 ? a[a.length - 1].push(x) : a.push([x]), a), []);
+
+export default function SpendTrend({ trend, win, undated }) {
+  // Desktop hover only, and additive only: the tooltip repeats the month and the amount,
+  // and nothing in this chart exists in it alone. Touch has no hover, so a tooltip is not a
+  // place a fact can live — which is the same reasoning the donut is deleted on.
+  const phone = usePhone();
+  if (!trend || !win || !win.start || !win.end) return null;
+
+  // The window is a rule, and this is the whole of applying it: the months the endpoint says
+  // are drawable, in the order the payload gives them. There is no window control, by
+  // decision — the grounds for excluding a month are data defects, so a control that let a
+  // reader select them back in would re-open a settled decision as an affordance and make
+  // the load-bearing delta captions user-authored.
+  const inWindow = trend.series.filter((r) => r.ym >= win.start && r.ym <= win.end);
+  if (inWindow.length < 2) return null;
+
+  // NEWEST AT THE LEFT, which is why the header below is load-bearing rather than
+  // decorative. Reversed here rather than with recharts' `reversed` axis prop so the
+  // tooltip, the line and the array all read the same direction.
+  const rows = [...inWindow].reverse();
+  const oldest = inWindow[0];
+  const newest = inWindow[inWindow.length - 1];
+
+  // THE PAYLOAD'S OWN ORDER, not a re-sort. Sorting by spend would re-rank the panels
+  // silently as the window grows — the same defect that rules out a top-N cap — and
+  // `_trend_shape` already sorts Uncategorized last, which is where the residue belongs.
+  const groups = trend.groups;
+
+  const material = win.sources.filter((s) => s.material);
+  // The source whose first line is the latest among the material ones: the window starts the
+  // month after it, so it is the one that answers "why does it start there".
+  const startedBy = material.reduce(
+    (a, b) => (a && a.first_txn >= b.first_txn ? a : b), null);
+  // Built here rather than inline, so the sentence is one readable string and not a template
+  // literal wrapped across a JSX line — which carries its own indentation into the DOM.
+  const started = startedBy
+    ? `, and the window starts the month after the last of them first reported`
+      + ` (${startedBy.source}, ${dayName(startedBy.first_txn)})`
+    : "";
+  const outside = ["before", "after", "gaps"]
+    .reduce((a, k) => a + Number(win.excluded[k].total_sgd), 0);
+  // THE DATED TOTAL, which is what the per-source totals sum to. `summary()`'s `total_sgd`
+  // includes undated rows, so dividing by that would quietly absorb undated spend into the
+  // outside-the-window share — and undated spend is the third footnote line's to report.
+  const dated = win.sources.reduce((a, s) => a + Number(s.total_sgd), 0);
+
+  return (
+    <div className="card" style={{ marginTop: 16 }}>
+      <h3>Spend Trend by Category</h3>
+      <div className="smallmult">
+        {pairs(groups).map((pair, i) => (
+        /* THE PAIR WRAPPER IS THE "NO THIRD RUNG" RULE, and it is layout rather than
+           meaning — see `.smallmult` in `styles.css` for the measurement that forced it.
+           A single `auto-fit` grid cannot skip a rung, and one of the ten viewports
+           (`rotated-phone`, the only one at or above 640 with no rail) lands in the 3 band
+           and draws three panels and an orphan. Pairs make the rungs 4, 2 and 1 with no
+           media query and no second floor. Chunked by two generally rather than hard-coded
+           to the four this taxonomy has: an odd tail is one panel in a half-width pair,
+           which is the honest rendering rather than a crash. */
+        <div className="smallmult-pair" key={i}>
+        {pair.map((g) => {
+          const values = inWindow.map((r) => Number(r[g]) || 0);
+          const colour = categoryColour(g);
+          return (
+            <div className="panel" key={g}>
+              {/* THE HEADER IS THE CAPTION, AND IT IS LOAD-BEARING — DO NOT DEMOTE IT.
+                  The window is drawn newest-at-the-left, so every panel reads backwards:
+                  a category that is falling slopes *upward*. A panel also has no y-axis at
+                  all, so the slope is the entire visible content of the panel and there is
+                  nothing else on the card that says which way it went. Drop the latest
+                  value or the signed delta and the chart lies — quietly, and in the
+                  direction a reader is least able to check. */}
+              <div className="panelhead">
+                <span className="chip" style={{ background: colour }} />
+                <span className="nm">{g}</span>
+                <span className="val">{sgd(newest[g])}</span>
+                {/* Not `cls()`, deliberately: the app's pos/neg tokens mean gain and loss,
+                    and spending more is neither. A green "−68%" on Transport would be this
+                    card making a judgement it has no budget model to make. */}
+                <span className="delta">{delta(Number(oldest[g]) || 0, Number(newest[g]) || 0)}</span>
+              </div>
+              {/* Min-max, demoted: it is the panel's range, which the reader needs only
+                  once they have decided the slope is worth reading. */}
+              <div className="panelrange">
+                {sgd(Math.min(...values))}–{sgd(Math.max(...values))}
+              </div>
+              <ResponsiveContainer width="100%" height={PLOT_H}>
+                <LineChart data={rows} margin={PLOT_MARGIN}>
+                  {/* Both axes exist and neither is drawn. The y-axis is the point of the
+                      chart — it is this panel's own scale, which is what stops Transport
+                      being flattened onto the floor — and `hide` is about the chrome, not
+                      about the scale. Zero-based so that within a panel a pixel is still a
+                      fixed number of dollars; `hide` on the x-axis keeps the month as the
+                      tooltip's label without spending a tick row on ten labels that would
+                      collide at 27px of spacing. */}
+                  <XAxis dataKey="ym" hide />
+                  <YAxis hide domain={[0, "auto"]} />
+                  {!phone && (
+                    <Tooltip
+                      formatter={(v) => [sgd(v), g]}
+                      labelFormatter={monthName}
+                      contentStyle={{ background: "#161b22", border: "1px solid #2b333d" }}
+                      itemStyle={{ color: "#d7dde4" }} labelStyle={{ color: "#d7dde4" }} />
+                  )}
+                  {/* `linear`, no smoothing: a curve invents a shape between two months that
+                      were each measured. Colour comes from the name-keyed map, and the dash
+                      from the map beside it — grey alone is the weaker half of "residue
+                      rather than a category anyone chose", because `#6e7681` fails the
+                      validator's chroma floor precisely by carrying no identity. */}
+                  {/* No dots: ten points at ~27px of desktop spacing is a dotted line, not
+                      a marked one, and the panel has no per-point affordance to hang them
+                      on. `isAnimationActive={false}` because a 104px plot's grow-in is
+                      noise four times over — and because an animating path is a path whose
+                      geometry a gate reads mid-flight, which is what `barsSettled` exists
+                      to work around for the chart below. */}
+                  <Line type="linear" dataKey={g} stroke={colour} strokeWidth={2}
+                        strokeDasharray={CATEGORY_DASH[g]} dot={false}
+                        activeDot={{ r: 3, fill: colour, stroke: colour }}
+                        isAnimationActive={false} />
+                </LineChart>
+              </ResponsiveContainer>
+            </div>
+          );
+        })}
+        </div>
+        ))}
+      </div>
+      {/* THE FOOTNOTE, BENEATH THE WHOLE GRID RATHER THAN PER PANEL — it is one statement
+          about one window. Three lines, two of them unconditional. Every number in the first
+          is derived from `/api/spending/window`'s flags: the count of material sources, the
+          source that sets the start, and the money that falls outside. None of it is typed,
+          because a typed "two of three sources" is wrong at three of four and right only
+          among the material ones — which is the entire reason that endpoint exists. */}
+      <div className="chartfoot">
+        <div>
+          <b>Window: {monthName(win.end)} back to {monthName(win.start)}</b>
+          {" "}— {inWindow.length} months, newest at the left.{" "}
+          {material.length} of {win.sources.length} statement sources carry enough spend to be
+          material{started}, so no month is drawn from before every material
+          source was reporting into it.{" "}
+          {sgd(outside)} of counted spend — {dated ? fmt((outside / dated) * 100, 0) : "0"}% of the
+          dated total — falls outside it.
+        </div>
+        {/* Depth, because the chart has no drill-down in v1 and every destination fails
+            structurally: a per-point target is 19.2px of spacing at the gated 1100 viewport
+            against the app's own 24px floor, the transactions view has no date filter to
+            receive one, a panel target needs the app's first cross-tab navigation and would
+            land on a different window — and the Uncategorized panel cannot drill at all,
+            because the category filter has no null to match. So the honest answer is to name
+            where the detail already lives. */}
+        <div>
+          Subcategory detail lives in <b>By Category</b>; the rows behind the Uncategorized panel
+          are classified in <b>Classify</b>, which is what that spend needs rather than inspection.
+        </div>
+        {/* Guarded on the count, and invisible today at n=0/$0. Undated spend is in no month,
+            so it is in no panel — and it is not part of the money the first line calls
+            "outside the window" either, which is computed from the dated total. */}
+        {undated && undated.n > 0 && (
+          <div>
+            Excludes {sgd(undated.total_sgd)} across {undated.n} undated
+            transaction{undated.n === 1 ? "" : "s"}, which carry no date and so fall in no month here.
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -454,7 +454,7 @@ button { min-height: 24px; }
 .barrow > .chip, .barrow > .nm, .barrow > .val { position: relative; }
 /* One swatch, two lists. The donut's rows and a multi-series key are the same thing — a
    colour standing for a series — so they take one rule rather than two identical ones. */
-.barrow .chip, .chartkey .chip { flex: none; width: 8px; height: 8px; border-radius: 2px; }
+.barrow .chip, .chartkey .chip, .panelhead .chip { flex: none; width: 8px; height: 8px; border-radius: 2px; }
 .barrow .nm { flex: 1 1 auto; min-width: 0; color: var(--txt); font-size: 13px;
   overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .barrow .val { flex: none; color: var(--mut); font-size: 13px; font-variant-numeric: tabular-nums; }
@@ -464,6 +464,72 @@ button { min-height: 24px; }
    it. No media query: a key is worth the same on a desktop that has no hover state either. */
 .chartkey { display: flex; flex-wrap: wrap; gap: 4px 14px; margin-top: 8px; padding: 0 8px; }
 .ck-item { display: inline-flex; align-items: center; gap: 6px; color: var(--mut); font-size: 12px; }
+
+/* ── the spend trend's small multiples ──
+   Four panels, one per spend category, each on its own scale. The grid is the whole of the
+   responsive story and it adds NO NEW BREAKPOINT: `auto-fit` on a 185px floor gives 4 -> 2 ->
+   1 by itself, at every width the app supports, which is why there is no media query here and
+   no entry in the phone block at the foot of this file.
+
+   185, NOT 220, AND THE NUMBER WAS MEASURED. At the gated 1100 viewport the card is 809px
+   inner, because the two-column grid above it is single-column there; four 220px tracks plus
+   three gaps need 922, so a 220 floor draws three panels and an orphan on the row a reader is
+   most likely to be on. 185 needs 782 and fits, and it is what makes "no third rung" true
+   rather than lucky — `charts.spec.js` recomputes the expected track count from the measured
+   width at all ten viewports rather than tabulating one per project.
+
+   `min(185px, 100%)` FOR THE REASON `.grid2` USES IT: a bare floor is a hard minimum that
+   `auto-fit` cannot collapse below, so on a 330px card the single track would still be 185
+   only by luck and any larger floor would scroll the pane sideways by the difference. The
+   percentage resolves against the grid container, so the floor gives way where there is no
+   room and is exactly 185 everywhere else.
+
+   TWO GRIDS RATHER THAN ONE, AND THE REASON IS A MEASUREMENT. "No third rung" is not
+   something a single `auto-fit` grid can promise: the number of tracks that fit is monotone
+   in the floor, so every rung between 4 and 1 is reachable at some width, and one of the ten
+   viewports lands in the 3 band. `rotated-phone` (844x390) is the only viewport at or above
+   640 with NO 200px rail — the shell moves to the drawer on a `(max-height: 500px)` guard
+   while `.main` keeps its 28px landscape gutter — so its card is ~756px inner, which is past
+   three 185px tracks (583) and short of four (782). A flat grid draws three panels and an
+   orphan there, which is precisely the failure the 185 floor was chosen over 220 to avoid.
+
+   So the panels are grided in PAIRS: the outer grid's floor is 384 = 185 + 14 + 185, one
+   pair, and the inner grid splits a pair into two. The rungs are then 4 (two pairs abreast),
+   2 (one pair per row) and 1 (a pair collapsed), and 3 is not expressible. The geometry is
+   identical to the flat grid wherever the flat grid was right: both levels are `1fr` tracks
+   with the same 14px gap, so four abreast are four equal quarters with three equal gaps.
+   Still no media query, still one floor, still no new breakpoint. `charts.spec.js` asserts
+   the rung by counting the distinct left edges of the panels themselves — the rendered
+   outcome — rather than a computed track string, which is a statement about the mechanism.
+
+   140px PANELS, and the height is shared with `SpendTrend.jsx`: 16 for the header line, 2, 14
+   for the demoted min-max line, 4, and 104 of plot, which is the `PLOT_H` the chart is given
+   in pixels. It has to be pixels — a percentage height inside a flex child is what starves a
+   `ResponsiveContainer` to 0x0 — so the two numbers are one decision written in two files and
+   each names the other. `overflow: hidden` is the guard that a header which somehow wrapped
+   eats itself rather than the plot. */
+.smallmult { display: grid; grid-template-columns: repeat(auto-fit, minmax(min(384px, 100%), 1fr)); gap: 14px; }
+.smallmult-pair { display: grid; grid-template-columns: repeat(auto-fit, minmax(min(185px, 100%), 1fr)); gap: 14px; }
+.smallmult .panel { height: 140px; overflow: hidden; }
+/* The caption, and it carries the panel's entire meaning — the series is drawn newest-at-the-
+   left, so the slope reads backwards and a panel has no y-axis to read instead. Nothing here
+   wraps: the name ellipses and the two numbers are `flex: none`, so the header stays one 16px
+   line at the 185px floor and the plot below it keeps its declared height. */
+.panelhead { display: flex; align-items: center; gap: 6px; font-size: 12px; line-height: 16px; }
+.panelhead .nm { flex: 1 1 auto; min-width: 0; color: var(--txt); font-weight: 600;
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.panelhead .val { flex: none; color: var(--txt); font-variant-numeric: tabular-nums; }
+/* Muted rather than green/red on purpose: the app's `.pos`/`.neg` mean gain and loss, and
+   spending more of your own money is neither. */
+.panelhead .delta { flex: none; color: var(--mut); font-variant-numeric: tabular-nums; }
+.panelrange { font-size: 11px; line-height: 14px; margin: 2px 0 4px; color: var(--mut);
+  font-variant-numeric: tabular-nums; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+/* The disclosure block under a chart: prose, so it wraps like prose and needs no tier. 12px is
+   above the app's 11px type minimum, and `<b>` is the only emphasis — this is a paragraph, not
+   a control. */
+.chartfoot { margin-top: 14px; display: flex; flex-direction: column; gap: 6px;
+  color: var(--mut); font-size: 12px; line-height: 1.45; }
+.chartfoot b { color: var(--txt); font-weight: 600; }
 /* `textarea` joins the rule it was always missing from: it is styled nowhere else in the
    app, so it rendered UA-default — a white box on a dark modal — at every width. */
 input, select, textarea { background: var(--panel2); border: 1px solid var(--line); color: var(--txt);

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -494,7 +494,12 @@ button { min-height: 24px; }
    orphan there, which is precisely the failure the 185 floor was chosen over 220 to avoid.
 
    So the panels are grided in PAIRS: the outer grid's floor is 384 = 185 + 14 + 185, one
-   pair, and the inner grid splits a pair into two. The rungs are then 4 (two pairs abreast),
+   pair, and the inner grid splits a pair into two. THE 384 IS NOT A SECOND FLOOR — it is the
+   185 written for two panels and their gap, and it moves the day 185 does. There is still
+   one panel floor, one gap and no breakpoint; what the second grid adds is a constraint on
+   how many panels a row may hold, which is the thing a floor alone cannot express. The spec
+   describes this grid as one `auto-fit` on 185/14 and that reads as one element; it is two,
+   deliberately, and RESPONSIVE.md's Observations carries the measurement that chose it. The rungs are then 4 (two pairs abreast),
    2 (one pair per row) and 1 (a pair collapsed), and 3 is not expressible. The geometry is
    identical to the flat grid wherever the flat grid was right: both levels are `1fr` tracks
    with the same 14px gap, so four abreast are four equal quarters with three equal gaps.

--- a/web/tests/charts.spec.js
+++ b/web/tests/charts.spec.js
@@ -1,10 +1,14 @@
 /**
  * Charts on a phone: the donuts are deleted and the list becomes the chart.
  *
- * Six chart surfaces across five views. Below 640px three of them lose chrome — the donut
- * itself, and one chart's value labels — and one is halved to six bars. Everything else the
- * charts needed turned out to belong at *every* width: the multi-series key, the reserved
- * band under the bars, and the two containers that could collapse to nothing.
+ * Seven chart surfaces across five views, and the newest of them is four plots rather than
+ * one — the spend trend's small multiples, which get a describe of their own at the foot of
+ * this file. Below 640px three surfaces lose chrome — the donut itself, and one chart's
+ * value labels — and one is halved to six bars. THE TREND LOSES NEITHER, and that is a
+ * decision rather than an omission: the donut goes because the list under it restates every
+ * row, and nothing else on Spending › Overview carries trajectory at all. Everything else
+ * the charts needed turned out to belong at *every* width: the multi-series key, the
+ * reserved band under the bars, and the two containers that could collapse to nothing.
  *
  * WHY THE DONUT GOES, since it is the one thing here that is not a defect. At percentage
  * radii in a one-column `.grid2` it renders at ⌀216px, larger than desktop's 180px, so this
@@ -35,6 +39,14 @@ import { readFixture } from "./fixtures/index.js";
 // a table of hexes in this file would be the defect rather than the gate. `palette.js` is
 // plain data with no React or recharts import, which is what makes it importable here.
 import { categoryColour } from "../src/palette.js";
+// The two formatters the app renders money and month labels through, imported for the same
+// reason the palette is: a restated `S$1,234` in this file is a second formatter, and the
+// mismatch it would then be blind to is the one it exists to catch. `api.js` touches
+// `window` only inside function bodies, so it imports cleanly into node.
+import { sgd } from "../src/api.js";
+
+/** A palette hex as the `rgb(r, g, b)` string `getComputedStyle` hands back. */
+const rgbOf = (hex) => `rgb(${[1, 3, 5].map((i) => parseInt(hex.slice(i, i + 2), 16)).join(", ")})`;
 
 const viewportOf = (projectName) => VIEWPORTS.find((v) => v.name === projectName);
 
@@ -216,8 +228,6 @@ test.describe("one palette", () => {
    * in the suite is a second palette, and the failure it would then be blind to is precisely
    * the one it exists to catch.
    */
-  const rgb = (hex) => `rgb(${[1, 3, 5].map((i) => parseInt(hex.slice(i, i + 2), 16)).join(", ")})`;
-
   test("Spending › Overview colours its three surfaces by name", async ({ page, baseURL }) => {
     await openView(page, baseURL, "Spending › Overview");
     await barsSettled(page);
@@ -236,9 +246,9 @@ test.describe("one palette", () => {
     expect.soft(listed.length, "the donut's list drew no rows").toBeGreaterThan(0);
     for (const row of listed) {
       expect.soft(row.chip, `${row.name}: the donut list's chip is off the map`)
-        .toBe(rgb(categoryColour(row.name)));
+        .toBe(rgbOf(categoryColour(row.name)));
       expect.soft(row.fill, `${row.name}: the donut list's track is off the map`)
-        .toBe(rgb(categoryColour(row.name)));
+        .toBe(rgbOf(categoryColour(row.name)));
     }
 
     // The stacked bar's key and its bars, each against the map — not against each other.
@@ -259,7 +269,7 @@ test.describe("one palette", () => {
       .toBe(readFixture("spending-trends.json").groups.length);
     for (const item of named) {
       expect.soft(item.chip, `${item.name}: the key's chip is off the map`)
-        .toBe(rgb(categoryColour(item.name)));
+        .toBe(rgbOf(categoryColour(item.name)));
     }
     const fills = await page.locator(".main .recharts-bar").evaluateAll((series) =>
       series.map((el) => {
@@ -269,7 +279,7 @@ test.describe("one palette", () => {
     expect.soft(fills, "one bar series per key item").toHaveLength(named.length);
     for (const [i, fill] of fills.entries()) {
       expect.soft(fill, `${named[i].name}: the bar fill is off the map`)
-        .toBe(rgb(categoryColour(named[i].name)));
+        .toBe(rgbOf(categoryColour(named[i].name)));
     }
   });
 
@@ -287,7 +297,7 @@ test.describe("one palette", () => {
     expect.soft(marked.length, "the category table drew no rows").toBeGreaterThan(0);
     for (const row of marked) {
       expect.soft(row.colour, `${row.name}: the row marker is off the map`)
-        .toBe(rgb(categoryColour(row.name)));
+        .toBe(rgbOf(categoryColour(row.name)));
     }
 
     // Same view, same names, the other surface on it.
@@ -298,7 +308,7 @@ test.describe("one palette", () => {
       })));
     for (const row of listed) {
       expect.soft(row.chip, `${row.name}: the donut list's chip is off the map`)
-        .toBe(rgb(categoryColour(row.name)));
+        .toBe(rgbOf(categoryColour(row.name)));
     }
   });
 });
@@ -399,6 +409,207 @@ test.describe("Portfolio › Options", () => {
             "window exercises the no-band branch; the 24-month window above the tier carries " +
             "the three losses that exercise the band",
         });
+      }
+    });
+});
+
+/**
+ * The spend trend: four panels, four scales, and a caption that is the chart's content.
+ *
+ * Everything asserted here is derived from the two committed fixtures rather than typed —
+ * the panel names are `spending-trends.json`'s own `groups`, the window is
+ * `spending-window.json`'s `start`/`end`, and the footnote's numbers are recomputed here
+ * from the same flags the component reads. A literal in this file would be a second copy of
+ * the rule, and the drift it would then be blind to is the one it exists to catch.
+ */
+test.describe("Spending › Overview — the spend trend", () => {
+  const trends = () => readFixture("spending-trends.json");
+  const win = () => readFixture("spending-window.json");
+  /** The months the chart may draw: the trends array sliced to the window, ascending. */
+  const drawn = () => trends().series.filter((r) => r.ym >= win().start && r.ym <= win().end);
+
+  const card = (page) => page.locator(".main .card").filter({ has: page.locator(".smallmult") });
+  const panels = (page) => card(page).locator(".smallmult .panel");
+
+  test("draws one panel per group, between the grid and the stacked bar", async ({ page, baseURL }) => {
+    await openView(page, baseURL, "Spending › Overview");
+    const groups = trends().groups;
+    await expect.soft(panels(page)).toHaveCount(groups.length);
+    // The panel headers ARE the key, so the names have to be the payload's own group
+    // strings — the same ones the stacked bar feeds to `<Bar dataKey>`.
+    await expect.soft(panels(page).locator(".panelhead .nm")).toHaveText(groups);
+
+    // Placement: tiles → grid[donut | top line items] → trend → stacked bar. Asserted as
+    // document order rather than as pixel tops, which would also be satisfied by a card
+    // that merely happens to lay out there at one viewport.
+    const order = await page.evaluate(() => {
+      const trend = document.querySelector(".main .smallmult");
+      if (!trend) return ["no trend card"];
+      // The view root, reached from the card itself rather than by position under `.main` —
+      // the section's tab strip is `.main`'s first child, so an index into it would be
+      // counting tabs.
+      const kids = [...trend.closest(".card").parentElement.children];
+      return kids.map((el) =>
+        el.classList.contains("tiles") ? "tiles"
+          : el.classList.contains("grid2") ? "grid2"
+            : el.querySelector(".smallmult") ? "trend"
+              // The stacked bar is the card carrying the view's one `.chartkey`; the trend
+              // adds none, which is the claim the single-key count on this view rests on.
+              : el.querySelector(".chartkey") ? "stacked"
+                : el.tagName.toLowerCase());
+    });
+    expect.soft(order, "the trend belongs between the two-column grid and the stacked bar")
+      .toEqual(["tiles", "grid2", "trend", "stacked"]);
+
+    // The caption, which is load-bearing: newest is at the LEFT, so the slope reads
+    // backwards and the header is the only thing that says which way the category moved.
+    const rows = drawn();
+    const newest = rows[rows.length - 1];
+    for (const g of groups) {
+      const head = panels(page).filter({ hasText: g }).locator(".panelhead");
+      await expect.soft(head.locator(".chip"), `${g}: no chip in the header`).toBeVisible();
+      await expect.soft(head.locator(".val"), `${g}: the header must carry the latest month`)
+        .toHaveText(sgd(newest[g]));
+      await expect.soft(head.locator(".delta"), `${g}: the header must carry a signed delta`)
+        .toHaveText(/^[+−]/);
+    }
+  });
+
+  test("gives every panel its own scale rather than the shared floor", async ({ page, baseURL }) => {
+    // THE WHOLE REASON THE CHART IS SMALL MULTIPLES. On one shared linear axis Transport is
+    // 3.4px of plot against Personal's ceiling — a flat line on the floor. Per panel it uses
+    // its own range, so this measures the drawn curve's vertical extent as a share of its
+    // own plot: a flattened series scores a few percent, a scaled one scores tens.
+    await openView(page, baseURL, "Spending › Overview");
+    const extents = await panels(page).evaluateAll((els) => els.map((el) => {
+      const curve = el.querySelector(".recharts-line .recharts-curve");
+      const name = el.querySelector(".panelhead .nm").textContent;
+      if (!curve) return { name, share: 0 };
+      const ys = [...curve.getAttribute("d").matchAll(/[ML,](-?[\d.]+),(-?[\d.]+)/g)]
+        .map((m) => parseFloat(m[2]));
+      const plot = el.querySelector(".recharts-responsive-container").getBoundingClientRect().height;
+      return { name, share: (Math.max(...ys) - Math.min(...ys)) / plot };
+    }));
+    for (const p of extents) {
+      expect.soft(p.share, `${p.name}: the series is flattened onto the panel floor`)
+        .toBeGreaterThan(0.25);
+    }
+  });
+
+  test("reflows 4 → 2 → 1 on a 185px floor with a 14px gap and 140px panels",
+    async ({ page, baseURL }) => {
+      await openView(page, baseURL, "Spending › Overview");
+      const grid = await card(page).locator(".smallmult").evaluate((el) => {
+        const boxes = [...el.querySelectorAll(".panel")].map((p) => p.getBoundingClientRect());
+        const gaps = [el, ...el.querySelectorAll(".smallmult-pair")].flatMap((n) => {
+          const cs = getComputedStyle(n);
+          return [Math.round(parseFloat(cs.columnGap)), Math.round(parseFloat(cs.rowGap))];
+        });
+        return {
+          width: el.getBoundingClientRect().width,
+          gaps: [...new Set(gaps)],
+          // THE RENDERED RUNG, not the computed track string. `auto-fit` reports the
+          // repetitions it collapsed as `0px`, and the grid is nested in pairs, so the
+          // track list of either level is a statement about the mechanism rather than
+          // about what a reader sees. How many columns of panels there are is the number
+          // of distinct left edges the panels occupy.
+          columns: new Set(boxes.map((b) => Math.round(b.left))).size,
+          heights: boxes.map((b) => Math.round(b.height)),
+        };
+      });
+      expect.soft(grid.gaps, "every gap in the grid is 14px — see `.smallmult` in styles.css")
+        .toEqual([14]);
+      // The rungs, computed from the measured width rather than tabulated per viewport:
+      // four panels need 4×185 + 3×14, and a pair needs 185 + 14 + 185.
+      const want = grid.width >= 4 * 185 + 3 * 14 ? 4 : grid.width >= 2 * 185 + 14 ? 2 : 1;
+      expect.soft(grid.columns, `${Math.round(grid.width)}px of grid should hold ${want} per row`)
+        .toBe(want);
+      // A THIRD RUNG IS THE FAILURE THE 185 FLOOR WAS CHOSEN OVER 220 TO AVOID — three
+      // panels and an orphan. A single `auto-fit` grid cannot promise this; the pair
+      // wrapper is what makes 3 inexpressible. `rotated-phone` is the viewport that proves
+      // it is not theoretical: no rail at 844px wide puts its card in the 3 band.
+      expect.soft([1, 2, 4], `no third rung — ${grid.columns} panels per row`)
+        .toContain(grid.columns);
+      for (const h of grid.heights) {
+        expect.soft(h, "panels are 140px tall — see `.smallmult .panel` in styles.css").toBe(140);
+      }
+    });
+
+  test("derives its footnote from the window payload rather than typing it",
+    async ({ page, baseURL }, testInfo) => {
+      await openView(page, baseURL, "Spending › Overview");
+      const w = win();
+      const foot = card(page).locator(".chartfoot");
+
+      // Every number below is recomputed here from the payload's own flags. "two of three
+      // sources" typed into the component is wrong at three of four and right only among
+      // the material ones, which is the failure this whole endpoint exists to prevent.
+      const material = w.sources.filter((s) => s.material);
+      expect(material.length, "the fixture has no material source — this gate would be vacuous")
+        .toBeGreaterThan(0);
+      const outside = ["before", "after", "gaps"]
+        .reduce((a, k) => a + w.excluded[k].total_sgd, 0);
+      // The DATED total, which is what the sources sum to — the summary's total_sgd carries
+      // undated rows and subtracting it would absorb them into the outside-the-window money.
+      const dated = w.sources.reduce((a, s) => a + s.total_sgd, 0);
+
+      const line = foot.locator("> div").first();
+      await expect.soft(line, "the window's month count").toContainText(`${drawn().length} months`);
+      await expect.soft(line, "how many sources are material, and of how many")
+        .toContainText(`${material.length} of ${w.sources.length}`);
+      await expect.soft(line, "the money outside the window").toContainText(sgd(outside));
+      await expect.soft(line, "and what share of the dated total that is")
+        .toContainText(`${Math.round((outside / dated) * 100)}%`);
+
+      // Depth: the two surfaces a panel makes a reader want, since the chart itself has no
+      // drill-down in v1.
+      await expect.soft(foot, "where subcategory detail lives").toContainText("By Category");
+      await expect.soft(foot, "where unclassified rows are handled").toContainText("Classify");
+
+      const undated = readFixture("spending-undated.json");
+      const line3 = foot.locator("> div").nth(2);
+      if (undated.n > 0) {
+        await expect.soft(line3, "the undated line").toContainText(sgd(undated.total_sgd));
+      } else {
+        await expect.soft(line3, "the undated line is guarded on a non-zero count")
+          .toHaveCount(0);
+        testInfo.annotations.push({
+          type: "not-covered-by-fixtures",
+          description:
+            "spending-undated.json is n=0/$0 on the live ledger, so the footnote's third " +
+            "line is exercised only in its absent branch",
+        });
+      }
+    });
+
+  test("draws Uncategorized grey and dashed, and every colour off the map",
+    async ({ page, baseURL }) => {
+      await openView(page, baseURL, "Spending › Overview");
+      const lines = await panels(page).evaluateAll((els) => els.map((el) => {
+        const curve = el.querySelector(".recharts-line .recharts-curve");
+        const cs = curve && getComputedStyle(curve);
+        return {
+          name: el.querySelector(".panelhead .nm").textContent,
+          stroke: cs && cs.stroke,
+          dash: cs ? cs.strokeDasharray : "",
+          chip: getComputedStyle(el.querySelector(".panelhead .chip")).backgroundColor,
+        };
+      }));
+      expect.soft(lines.length, "no panels drew").toBe(trends().groups.length);
+      for (const p of lines) {
+        expect.soft(p.stroke, `${p.name}: the panel's line is off the map`)
+          .toBe(rgbOf(categoryColour(p.name)));
+        expect.soft(p.chip, `${p.name}: the panel's chip is off the map`)
+          .toBe(rgbOf(categoryColour(p.name)));
+      }
+      // Grey alone is the weaker half of "residue rather than a category anyone chose" —
+      // `#6e7681` fails the validator's chroma floor precisely because grey carries no
+      // identity, and the dash is the secondary encoding that says so.
+      const residue = lines.find((p) => p.name === "Uncategorized");
+      expect.soft(residue.dash, "Uncategorized must be dashed — see CATEGORY_DASH")
+        .toMatch(/\d/);
+      for (const p of lines.filter((x) => x !== residue)) {
+        expect.soft(p.dash, `${p.name}: only Uncategorized is dashed`).toMatch(/^(none)?$/);
       }
     });
 });

--- a/web/tests/charts.spec.js
+++ b/web/tests/charts.spec.js
@@ -43,7 +43,7 @@ import { categoryColour } from "../src/palette.js";
 // reason the palette is: a restated `S$1,234` in this file is a second formatter, and the
 // mismatch it would then be blind to is the one it exists to catch. `api.js` touches
 // `window` only inside function bodies, so it imports cleanly into node.
-import { sgd } from "../src/api.js";
+import { sgd, catName } from "../src/api.js";
 
 /** A palette hex as the `rgb(r, g, b)` string `getComputedStyle` hands back. */
 const rgbOf = (hex) => `rgb(${[1, 3, 5].map((i) => parseInt(hex.slice(i, i + 2), 16)).join(", ")})`;
@@ -425,19 +425,47 @@ test.describe("Portfolio › Options", () => {
 test.describe("Spending › Overview — the spend trend", () => {
   const trends = () => readFixture("spending-trends.json");
   const win = () => readFixture("spending-window.json");
-  /** The months the chart may draw: the trends array sliced to the window, ascending. */
-  const drawn = () => trends().series.filter((r) => r.ym >= win().start && r.ym <= win().end);
+  /**
+   * The months the chart may draw: the window's range MINUS its gaps, ascending.
+   *
+   * `gaps` is the clause a range slice loses — a month inside `[start, end]` in which not
+   * every material source reported. It is empty on the committed fixture, so this reduces to
+   * the range here and the branch is annotated as unreachable below rather than left looking
+   * covered.
+   */
+  const drawn = () => trends().series.filter(
+    (r) => r.ym >= win().start && r.ym <= win().end && !win().gaps.includes(r.ym));
+
+  /**
+   * The order the panels must be in: the drawn window's spend descending, with the residue
+   * pinned last. Recomputed from the payload rather than typed, for the reason every other
+   * derived assertion in this describe is — and NOT taken from `groups`, which is the
+   * payload's alphabetical sort and would lock in Housing-before-Personal.
+   */
+  const panelOrder = () => {
+    const rows = drawn();
+    const residue = catName(null);
+    const spend = (g) => rows.reduce((a, r) => a + Number(r[g] || 0), 0);
+    return [...trends().groups].sort(
+      (a, b) => (a === residue) - (b === residue) || spend(b) - spend(a));
+  };
 
   const card = (page) => page.locator(".main .card").filter({ has: page.locator(".smallmult") });
   const panels = (page) => card(page).locator(".smallmult .panel");
 
-  test("draws one panel per group, between the grid and the stacked bar", async ({ page, baseURL }) => {
+  test("draws one panel per group, between the grid and the stacked bar",
+    async ({ page, baseURL }, testInfo) => {
     await openView(page, baseURL, "Spending › Overview");
     const groups = trends().groups;
     await expect.soft(panels(page)).toHaveCount(groups.length);
     // The panel headers ARE the key, so the names have to be the payload's own group
-    // strings — the same ones the stacked bar feeds to `<Bar dataKey>`.
-    await expect.soft(panels(page).locator(".panelhead .nm")).toHaveText(groups);
+    // strings — the same ones the stacked bar feeds to `<Bar dataKey>` — in the spec's
+    // order: spend descending with the residue last, which is Personal · Housing ·
+    // Transport · Uncategorized on this fixture.
+    await expect.soft(panels(page).locator(".panelhead .nm")).toHaveText(panelOrder());
+    await expect.soft(panels(page).locator(".panelhead .nm").last(),
+      "the residue is not a category anyone chose — it sorts last, whatever it spent")
+      .toHaveText(catName(null));
 
     // Placement: tiles → grid[donut | top line items] → trend → stacked bar. Asserted as
     // document order rather than as pixel tops, which would also be satisfied by a card
@@ -463,6 +491,16 @@ test.describe("Spending › Overview — the spend trend", () => {
 
     // The caption, which is load-bearing: newest is at the LEFT, so the slope reads
     // backwards and the header is the only thing that says which way the category moved.
+    if (win().gaps.length === 0) {
+      testInfo.annotations.push({
+        type: "not-covered-by-fixtures",
+        description:
+          "spending-window.json's `gaps` is empty on the live ledger, so the drop-a-gap-month " +
+          "clause in SpendTrend's slice is exercised only in its no-op branch — the panels " +
+          "below are the range and the drawable set at once",
+      });
+    }
+
     const rows = drawn();
     const newest = rows[rows.length - 1];
     for (const g of groups) {
@@ -553,10 +591,18 @@ test.describe("Spending › Overview — the spend trend", () => {
       // undated rows and subtracting it would absorb them into the outside-the-window money.
       const dated = w.sources.reduce((a, s) => a + s.total_sgd, 0);
 
+      // The source that answers "why does it start there": the latest first-transaction
+      // among the material ones, since the window starts the month after it. Re-derived by
+      // argmax here rather than read off a fixed index — `sources` is sorted by spend, not
+      // by date, so the two orders agree on this payload by coincidence.
+      const startedBy = material.reduce((a, b) => (a.first_txn >= b.first_txn ? a : b));
+
       const line = foot.locator("> div").first();
       await expect.soft(line, "the window's month count").toContainText(`${drawn().length} months`);
       await expect.soft(line, "how many sources are material, and of how many")
         .toContainText(`${material.length} of ${w.sources.length}`);
+      await expect.soft(line, "the source whose first line sets the start")
+        .toContainText(startedBy.source);
       await expect.soft(line, "the money outside the window").toContainText(sgd(outside));
       await expect.soft(line, "and what share of the dated total that is")
         .toContainText(`${Math.round((outside / dated) * 100)}%`);

--- a/web/tests/inventory.spec.js
+++ b/web/tests/inventory.spec.js
@@ -83,7 +83,7 @@ test("no chart renders the library's own legend", () => {
   expect(offenders, "render the key as DOM — `ChartKey` in `charts.jsx`").toEqual([]);
 });
 
-test("both multi-series charts carry a DOM key", () => {
+test("every multi-series chart names its series somewhere in the DOM", () => {
   // The counterpart of the gate above: forbidding `<Legend>` is satisfied by having no key
   // at all, which is exactly the state `NetWorth` shipped in — two coloured lines named only
   // in a tooltip that touch never opens. Named files rather than a count, because "multi-
@@ -99,6 +99,26 @@ test("both multi-series charts carry a DOM key", () => {
     .map((f) => path.relative(WEB, f))
     .sort();
   expect(keyed, "a multi-series chart with no key is anonymous on touch").toEqual(wanted);
+
+  // THE THIRD MULTI-SERIES SURFACE, AND WHY THE LIST ABOVE DID NOT GROW FOR IT. The spend
+  // trend draws four series and carries no `<ChartKey>` — deliberately, because it is small
+  // multiples: each series has a panel of its own and that panel's header already names it,
+  // shows its colour and states its direction in words. A key underneath would restate four
+  // things written immediately above it, and it would take the single-`.chartkey` count on
+  // Spending › Overview — which `charts.spec.js` asserts — from a fact to an off-by-one.
+  //
+  // Asserted rather than merely omitted, in both directions: a `<ChartKey>` added here would
+  // be caught by the `toEqual` above, but a panel header stripped of its chip and name would
+  // leave the chart anonymous with nothing failing. So this is the same claim the list makes,
+  // checked where this chart actually makes it.
+  const trend = stripComments(
+    fs.readFileSync(path.join(WEB, "src/modules/spending/SpendTrend.jsx"), "utf8"));
+  expect(/<ChartKey[\s/>]/.test(trend),
+    "the spend trend's panel headers are its key — a second one would restate them").toBe(false);
+  for (const part of ['className="chip"', 'className="nm"', 'className="delta"']) {
+    expect(trend.includes(part),
+      `the spend trend's panel header must carry ${part} — it is the chart's only key`).toBe(true);
+  }
 });
 
 test("no spending surface indexes the positional palette", () => {


### PR DESCRIPTION
Closes #100. Spec: #92 §E, §F and the Testing Decisions' Seam 2.

Small multiples on Spending › Overview: four panels, one per spend category, each on its own
y-axis, drawing raw monthly totals over the window `/api/spending/window` serves. A full-width
**sibling** card between the two-column grid and the monthly stacked bar — tiles → grid → **trend**
→ stacked bar — which it does not replace: that chart still answers "what did I spend in March".

It adds no spend payload. The series is the `/api/spending/trends` array the view already fetches,
sliced to the window, so the two charts on the page cannot disagree about a month they share.

## Why per-panel scaling

A ~150× spread across four series. On one linear axis Personal sets a $12,000 ceiling and Transport
never leaves the floor at 3.4px; dropping Uncategorized does not relieve it, and dropping Personal
barely does (6.2px — the $3,279 unclassified spike then sets the ceiling). Per-panel beats a shared
log scale because it fixes the compression **without changing what a pixel means**: inside a panel,
dollars stay dollars. Safe only because the taxonomy is locked at three categories; the
recommendation inverts at subcategory depth.

## The header is the chart's content

The window is drawn newest-at-the-left, so every panel reads backwards — Transport is −80% and
slopes *up* — and no panel draws a y-axis, so the slope is all there is to see. Chip · name · latest
value · signed delta, min–max demoted. It is also the key: no `<ChartKey>`, because four panels that
each name their own series do not need a fifth thing restating them, and the single-`.chartkey`
count on this view stays a fact.

## The footnote is derived, never typed

The window line recomputes the material-source count, the source that sets the start and the money
outside the window from the payload's own flags — typed, it reads "two of three sources", which is
wrong at three of four. The share is against the **dated** total, so undated spend is not absorbed
into it; the undated line is its own, guarded on a non-zero count.

> **Window: Jun 2026 back to Sep 2025** — 10 months, newest at the left. 3 of 4 statement sources
> carry enough spend to be material, and the window starts the month after the last of them first
> reported (dbs-cc, Aug 21, 2025), so no month is drawn from before every material source was
> reporting into it. S$43,318 of counted spend — 31% of the dated total — falls outside it.

## Reviewed, and three of the findings were defects

Both `/code-review` axes ran. Fixed in `d6d66ac`:

- **Gap months were drawn, and counted twice.** The slice was the window's *range* rather than its
  *rule* — a month in `excluded.gaps`, where a material source did not report, rendered as a real
  point, entered the month count and the delta, **and** was summed into "falls outside it". That
  draws an ingestion gap as a collapse in spending, which is the single failure that endpoint exists
  to prevent. Empty on today's ledger, so no fixture reaches it; the suite annotates the unreachable
  branch rather than looking covered.
- **`excluded.gaps` was read unguarded**, so a payload matching the spec's own printed example threw
  and blanked the card.
- **Panel order was the payload's, which is alphabetical** — Housing led purely because H precedes
  P. Now the drawn window's spend descending with the residue pinned last, which is §E's stated
  Personal · Housing · Transport · Uncategorized. Both halves are needed: Uncategorized outspends
  Transport 4.6× over this window, so sorting alone puts the residue third.

Also: the tooltip is no longer gated on `usePhone()` — it is additive-only and the stacked bar below
it was never gated, so two adjacent charts disagreeing was the defect.

## One deliberate deviation, flagged for review

**§E asks for a 185px floor, a 14px gap *and* "no third rung", and one `auto-fit` grid cannot give
all three** — the tracks that fit are monotone in the floor, so every rung is reachable at some
width. `rotated-phone` (844×390, the only viewport at or above 640 with **no 200px rail**) puts the
card at ~756px, past three 185px tracks (583) and short of four (782): a flat grid draws **three
panels and an orphan** there, which is exactly the failure the 185 floor was chosen over 220 to
avoid, arriving at a different viewport than the one the floor was measured at.

So the panels grid in pairs — outer floor `384 = 185 + 14 + 185`, inner floor 185 — making the rungs
4, 2 and 1 with no media query and no new breakpoint. The floor and the gap are unchanged and 384 is
not a second constant, but it is two elements where the spec line reads as one. Recorded in
`styles.css` and in RESPONSIVE.md's Observations. **If you would rather match §E's literal wording
and accept a 3-plus-orphan row in landscape, it is a one-line revert.**

## Tests

Five new gates in `charts.spec.js`, every number recomputed from the committed fixtures rather than
typed — the panel names and order, the drawn months, and the footnote's source count, source name
and outside-the-window money. Per-panel scaling is asserted as the flattening it prevents: each
curve's vertical extent as a share of its own plot. The rung gate counts the panels' distinct left
edges, the rendered outcome, not a computed track string. `inventory.spec.js`'s key gate now states
why this file is *not* on its list and checks the header that replaces one.

`make test-web`: **1,431 passed · 477 skipped · 0 failed.**

## Note

There is a second open PR for this issue, #117, from a parallel branch.

https://claude.ai/code/session_018EXutNB5PDBWo2TVWoENtG


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a spending-trend card to the Spending Overview.
  - View category-level trends with latest amounts, changes, ranges, tooltips, and independently scaled charts.
  - Trend details identify reporting windows, source coverage, excluded spending, and optional undated transactions.
- **Responsive Design**
  - Added responsive layouts for trend panels across desktop and mobile screen sizes.
- **Bug Fixes**
  - Improved resilience when spending-window or undated-spending data cannot be loaded.
- **Documentation & Tests**
  - Updated responsive and testing documentation and expanded coverage for the new trend charts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->