### PR TITLE
fix(web): a failed trends payload took the whole view down

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@
 # the only ones that arrive with nobody having run anything locally — but it gates every PR.
 #
 # Two jobs, split by what they can tell you and how fast: `python` answers in ~2 minutes,
-# `web` runs the 1497-assertion viewport suite and takes ~10. Neither needs a secret; the
+# `web` runs 1,497 Playwright tests and takes ~10. Neither needs a secret; the
 # suite serves every API call from web/tests/fixtures and the Python tests build their own
 # throwaway database.
 name: CI

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@
 # the only ones that arrive with nobody having run anything locally — but it gates every PR.
 #
 # Two jobs, split by what they can tell you and how fast: `python` answers in ~2 minutes,
-# `web` runs 1,497 Playwright tests and takes ~10. Neither needs a secret; the
+# `web` runs 1,500 Playwright tests and takes ~10. Neither needs a secret; the
 # suite serves every API call from web/tests/fixtures and the Python tests build their own
 # throwaway database.
 name: CI

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -315,5 +315,5 @@ no-op or, worse, merges without waiting:
 **CI runs more than the local default.** `make test-web` and `pytest -m "not pg"` are the
 fast local loop; CI runs the whole thing — the 33 `pg`-marked tests against a real Postgres
 service container (same image, credentials and port 5544 as `docker-compose.yml`, so no env
-var is needed), plus all 1,497 Playwright tests. The Postgres-only SQL and the production
+var is needed), plus all 1,500 Playwright tests. The Postgres-only SQL and the production
 vite build are exactly what a psycopg or vite bump breaks.

--- a/web/playwright.config.js
+++ b/web/playwright.config.js
@@ -64,6 +64,15 @@ export default defineConfig({
       testMatch: /composition\.spec\.js/,
       use: { ...devices["Desktop Chrome"], viewport: { width: 1280, height: 800 } },
     },
+    // What a failed payload does to the page that asked for it, on the same reasoning once
+    // more: whether a component survives a payload it cannot read is the same at 360px and at
+    // 1440px. It needs a deliberately-served failure, because every fixture is a capture of a
+    // working database and so none of them is one.
+    {
+      name: "failures",
+      testMatch: /failures\.spec\.js/,
+      use: { ...devices["Desktop Chrome"], viewport: { width: 1280, height: 800 } },
+    },
     ...VIEWPORTS.map((v) => ({
       name: v.name,
       testMatch: /(baseline|unconditional|foundations|shell|pinned|cards|drill|charts|editors|tablet|tap)\.spec\.js/,

--- a/web/src/modules/spending/Overview.jsx
+++ b/web/src/modules/spending/Overview.jsx
@@ -118,7 +118,14 @@ export default function SpendOverview() {
           this same page. `SpendTrend` slices the array already fetched here, so one payload
           feeds both charts and they cannot disagree about a shared month. */}
       <SpendTrend trend={trend} spendWindow={spendWindow} undated={undated} />
-      {trend && trend.series.length > 0 && (
+      {/* `?.` IS LOAD-BEARING AND NOT DEFENSIVE PADDING. The catch above writes
+          `{ error: true }`, which has no `series` — so an unguarded `.length` here throws out
+          of render into the whole-app `ErrorBoundary`, and a failed trends request takes the
+          entire view down instead of one card. That is issue #35's failure mode exactly, and
+          it came back the moment the failure SHAPE changed under a consumer that still
+          assumed the old one. `SpendTrend` above reads the same state and states the failure;
+          this chart has nothing honest to draw without a series, so it renders nothing. */}
+      {trend?.series?.length > 0 && (
         <div className="card" style={{ marginTop: 16 }}>
           <h3>Monthly Spend by Category</h3>
           <ResponsiveContainer width="100%" height={300}>

--- a/web/tests/failures.spec.js
+++ b/web/tests/failures.spec.js
@@ -1,0 +1,88 @@
+/**
+ * What a failed payload does to the page that asked for it.
+ *
+ * WHY THIS FILE EXISTS. Issue #35 was `/api/spending/trends` returning a 500, and what made it
+ * expensive was not the 500 — it was that the frontend's *response* to it was untested, so the
+ * chart silently never mounted and the suite went on passing. The fix set a safe empty payload
+ * on failure. That safety then evaporated the day the failure SHAPE changed: `{ error: true }`
+ * has no `series`, and a consumer still reading `trend.series.length` threw out of render into
+ * the whole-app `ErrorBoundary` — one failed request taking the entire view down. The shape and
+ * its readers have to be checked together or they drift apart again, which is what this is.
+ *
+ * WHY IT IS NOT IN `charts.spec.js`. That file gates what a chart does at ten viewports because
+ * its claims are about width. Nothing here is: whether a component survives a payload it cannot
+ * read is the same at 360px and at 1440px. So this runs at **one** viewport, in a project of
+ * its own, on the reasoning `catalogue.spec.js`, `composition.spec.js`, `ticker.spec.js` and the
+ * inventory project all carry.
+ *
+ * WHY THE SEAM MOVES UP A LAYER. The committed fixtures are captures of a working database, so
+ * by construction none of them is a failure — the harness answers an *uncaptured* path 404, but
+ * every path these views ask for is captured. A failure has to be served deliberately, which is
+ * the same move `catalogue.spec.js` makes for a catalogue the frontend has never seen.
+ *
+ * THE ASSERTION IS ALWAYS "THE PAGE SURVIVES AND SAYS SO", never "the card is gone". A card that
+ * vanishes and a card that was never built are the same DOM, and the difference between them is
+ * the whole point: a reader who cannot see the difference cannot report it.
+ */
+import { expect, test } from "@playwright/test";
+import { mockApi } from "./support/app.js";
+
+/** The whole-app fallback `ErrorBoundary` renders this when a render throws. */
+const crashed = (page) => page.getByText("Something went wrong");
+
+/**
+ * Load the app with the seam installed, fail one path, and open Spending › Overview.
+ *
+ * `loadApp` is deliberately not used and the order matters: it installs `mockApi` itself, and
+ * Playwright matches routes in reverse registration order, so registering the failure after it
+ * is what puts the failure in front of the committed fixture.
+ *
+ * NOT `openView`, AND THE SECOND CLICK IS GONE ON PURPOSE. `openView` settles on an anchor a
+ * crashed render never paints, and the tab strip is part of the shell the `ErrorBoundary`
+ * replaces wholesale — so clicking the Overview tab made the regression surface as a 60-second
+ * timeout complaining about a missing tab, which says nothing about what actually broke. It is
+ * also unnecessary: Spending's own default tab is Overview (`App.jsx`'s `spendTab`), so the
+ * section click IS the navigation. What this waits for instead is EITHER outcome — the view or
+ * the boundary — so the assertion in the test is what reports which one arrived.
+ */
+async function openWithFailure(page, baseURL, path) {
+  await mockApi(page, baseURL);
+  await page.route(`**${path}`, (route) =>
+    route.fulfill({ status: 500, contentType: "application/json", body: JSON.stringify({ detail: "boom" }) }));
+  await page.goto("/");
+  await expect(page.locator(".app")).toBeVisible({ timeout: 20_000 });
+  await page.locator(".navitem", { hasText: /^Spending$/ }).click();
+  await expect(crashed(page).or(page.getByText("Top Line Items")).first())
+    .toBeVisible({ timeout: 20_000 });
+}
+
+test("a failed trends payload costs one card, not the view", async ({ page, baseURL }) => {
+  // THE REGRESSION, WRITTEN DOWN. `{ error: true }` has no `series`, so `trend.series.length`
+  // throws during render and the `ErrorBoundary` eats the page — tiles, donut, top line items
+  // and both charts — for one failed request out of four.
+  await openWithFailure(page, baseURL, "/api/spending/trends");
+
+  await expect(crashed(page), "a failed trends payload took the whole view down").toHaveCount(0);
+  // The three surfaces that do not depend on it are still there, which is what "one card" means.
+  await expect(page.getByText("Top Line Items")).toBeVisible();
+  await expect(page.locator(".main .tiles")).toBeVisible();
+  // And the two that do are absent rather than half-drawn: the stacked bar has no series to
+  // draw, and the trend has no array to slice.
+  await expect(page.getByRole("heading", { name: "Monthly Spend by Category" })).toHaveCount(0);
+  await expect(page.getByTestId("spend-trend-unavailable"),
+    "the trend states the failure rather than vanishing").toBeVisible();
+});
+
+test("a failed window payload is stated, not silently dropped", async ({ page, baseURL }) => {
+  // The spend trend cannot draw without the window — the months it may draw are *derived* from
+  // source coverage, so a missing window is a missing range rather than a missing series. What
+  // it must not do is disappear: the card going quiet is indistinguishable from the feature not
+  // existing, which is the failure this whole map keeps naming.
+  await openWithFailure(page, baseURL, "/api/spending/window");
+
+  await expect(crashed(page)).toHaveCount(0);
+  await expect(page.getByTestId("spend-trend-unavailable")).toBeVisible();
+  // The stacked bar is untouched by the window — it never read it. This is what stops the fix
+  // for one card being a regression in its neighbour.
+  await expect(page.getByRole("heading", { name: "Monthly Spend by Category" })).toBeVisible();
+});


### PR DESCRIPTION
`#120` landed the spend trend, and CodeRabbit's pass on it changed what `/api/spending/trends` writes to state on failure — from a safe empty payload to `{ error: true }`. `SpendTrend` was updated to read the new shape. The stacked bar in the same file was not:

```js
Overview.jsx:28    catch(() => setTrend({ error: true }))
Overview.jsx:121   {trend && trend.series.length > 0 && (
```

`{ error: true }` has no `series`, so a 500 on that one path throws a `TypeError` out of render and the whole-app `ErrorBoundary` replaces Spending › Overview wholesale — tiles, donut, top line items, and both charts gone, for one failed request out of four. That is issue #35's failure mode back on `main`, arriving the way it did the first time: not because the failure was unhandled, but because the failure's **shape** changed under a consumer that still assumed the old one.

## The fix

One character (`trend?.series?.length`), plus a comment saying why the `?.` is load-bearing rather than defensive padding. `SpendTrend` already states the failure in its own card; this chart has nothing honest to draw without a series, so it renders nothing.

## The gate

`web/tests/failures.spec.js` — a new one-viewport `failures` project, on the same reasoning as `catalogue`, `composition`, `ticker` and `inventory`: whether a component survives a payload it cannot read is the same at 360px and at 1440px, so running it ten times only makes ten identical failures out of one.

Two tests, both asserting **the page survives and says so** rather than "the card is gone" — a card that vanishes and a card that was never built are the same DOM, and the difference between them is the point:

- a failed `/trends` costs one card, not the view — the three surfaces that don't read it stay up, and `SpendTrend` states the failure
- a failed `/window` is stated, not silently dropped — and the stacked bar, which never read it, is untouched

The committed fixtures are captures of a working database, so by construction none of them is a failure; the failure is served deliberately, registered **after** `mockApi` because Playwright matches routes in reverse registration order.

Negative control, on this branch: reverting the guard alone fails `a failed trends payload took the whole view down` in ~6s. Restored, it passes.

## Verification

- 1500 Playwright tests passed, 0 failed, 477 skipped
- 416 pytest passed, 40 skipped (the `pg`-marked ones; no local Postgres)

Also carries `docs(ci): say tests, not assertions` — a one-word comment correction in `ci.yml` that was stranded on the merged branch.

Closes #35's regression path.

https://claude.ai/code/session_01KLdXaJQsbZKnH4nMeQeKU6


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Spending views now remain usable when trend or time-window data fails to load.
  * Affected sections show appropriate unavailable states while unrelated content remains visible.
  * Prevented failed trend responses from causing rendering errors.

* **Tests**
  * Added coverage for API failure scenarios and verified the app avoids displaying a global error page.

* **Documentation**
  * Updated the documented Playwright test count to reflect the expanded test suite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->