### PR TITLE
feat(portfolio): date the fold's own accumulators (#147)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -29,7 +29,8 @@ _Avoid_: holding (reserve for the current non-zero units specifically), lot
 **Dated accumulator**:
 A position's own record of what changed and *when*, kept beside the undated running totals it
 mirrors: a **unit event** per unit change (signed quantity, plus whether the leg moved stock
-rather than trading it) and a **cost event** per purchase (money paid, units bought). A running
+rather than trading it) and a **cost event** per cost-basis addition (money paid; units bought on
+normal buys, or the re-split cost-basis quantity after a switch rebase). A running
 total answers only "where did this end"; reading an *intermediate* state of the fold — which peak
 capital-at-risk and the corporate-action carry both need — requires a date to hang each change
 on. Every series ends exactly where the scalar it mirrors ends.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -26,6 +26,22 @@ The running state of one (funding bucket, security) pair: units held, cost, cash
 Building it up by replaying transactions in order is the **position fold**.
 _Avoid_: holding (reserve for the current non-zero units specifically), lot
 
+**Dated accumulator**:
+A position's own record of what changed and *when*, kept beside the undated running totals it
+mirrors: a **unit event** per unit change (signed quantity, plus whether the leg moved stock
+rather than trading it) and a **cost event** per purchase (money paid, units bought). A running
+total answers only "where did this end"; reading an *intermediate* state of the fold — which peak
+capital-at-risk and the corporate-action carry both need — requires a date to hang each change
+on. Every series ends exactly where the scalar it mirrors ends.
+_Avoid_: lot (a lot is a purchase the book identifies and sells against; these are the fold's own
+arithmetic, dated), history (the ledger is the history — this is the fold's reading of it)
+
+**Stock-moving leg**:
+A unit change that moved stock rather than trading it — a custody transfer, a fund-switch
+arrival, a gift. An equal-and-opposite *pair* of them is one internal move and contributes no net
+units on any date, which is why a dated replay has to tell one from a trade.
+_Avoid_: transfer (only some stock-moving legs are transfers, and only some transfers pair)
+
 **Consolidated ticker row**:
 The Holdings table's fold of every position sharing one canonical ticker into a single row — the
 only place the app answers "how much of this name do I own, across every bucket". Units, cost,

--- a/portfolio/performance.py
+++ b/portfolio/performance.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import datetime as dt
 import logging
 from collections import defaultdict
+from typing import NamedTuple
 
 from sqlalchemy import text
 
@@ -22,6 +23,37 @@ log = logging.getLogger(__name__)
 def _f(x):
     """float(x), passing None through unchanged — for nullable numeric fields."""
     return float(x) if x is not None else None
+
+
+class UnitEvent(NamedTuple):
+    """One dated change to a position's unit count. `qty` is signed; `moves_stock` says whether
+    the leg moved stock rather than trading it (STOCK_MOVING_LEG), which is what tells a
+    stock-moving leg from a trade. `action` is the raw ledger string it was decided from — kept
+    beside the decision because the fold retains no other copy of it (`meta` holds only the last
+    row per position), so dropping it would throw the evidence away."""
+    date: dt.date
+    qty: float
+    action: str
+    moves_stock: bool
+
+
+class CostEvent(NamedTuple):
+    """One dated addition to a position's cost basis: `cost` is the money paid, `qty` the
+    units it bought. The dated mirror of the `buy_cost` / `buy_qty` running totals."""
+    date: dt.date
+    cost: float
+    qty: float
+
+
+def _book_buy(acc, day, cost, qty):
+    """Book one purchase into an accumulator: the three running totals and the dated cost event
+    that mirrors them. The same buy arrives from two ledgers (`_apply_txn` for the broker CSVs,
+    `cdp_cost` for cdp-stocks), so it is booked in one place — a dated series that agrees with
+    its scalars on one path and not the other is worse than no series at all."""
+    acc["invested"] += cost
+    acc["buy_cost"] += cost
+    acc["buy_qty"] += qty
+    acc["cost_events"].append(CostEvent(day, cost, qty))
 
 
 def cdp_transactions(session=None):
@@ -65,12 +97,12 @@ def cdp_cost(session=None):
         cash = float(amount or 0)                # buys negative (cash out), sells positive
         if abs(cash) < 1e-9:
             continue
-        g = out.setdefault(ticker, {"flows": [], "invested": 0.0, "buy_cost": 0.0, "buy_qty": 0.0})
-        g["flows"].append((d or dt.date.today(), cash))
+        g = out.setdefault(ticker, {"flows": [], "invested": 0.0, "buy_cost": 0.0,
+                                    "buy_qty": 0.0, "cost_events": []})
+        day = d or dt.date.today()
+        g["flows"].append((day, cash))
         if cash < 0:
-            g["invested"] += -cash
-            g["buy_cost"] += -cash
-            g["buy_qty"] += float(qty or 0)      # bought qty for avg-cost
+            _book_buy(g, day, -cash, float(qty or 0))    # qty bought, for avg-cost
     return out
 
 # actions where qty*price is real cash paid/received (CPF/SRS CSVs use 'open market' etc.)
@@ -86,6 +118,17 @@ ZERO_CASH = {"transfer_in", "transfer_out", "gift_in", "gifted stock in", "gifte
 # cash for — the ESR-LOGOS (UD1U) rights issues at 0.49 / 0.595 / 0.408, C38U, O5RU, S51. A
 # zero-priced row is a bonus or consolidation (D05's 280 bonus shares). Only the first costs money.
 PRICED_CORP_ACTION = {"corp action", "corp_action"}
+# The subset of the above that moves stock rather than trading it: the four CDP transfer
+# spellings, the FSM compound legs, fund-switch arrivals and gifts. #143 §9 rule 4 matches an
+# equal-and-opposite PAIR of these as one internal move contributing no net units at any date, so
+# a dated replay has to be able to pick one out of the series. Built from CDP_TRANSFER rather than
+# re-listing its spellings: a fifth spelling should land in one place, not two. Resolved here,
+# once, rather than left for every reader to re-derive — re-deriving a rule that already exists is
+# how the options P/L went wrong. Every member but `transfer out` is also in ZERO_CASH; that one
+# is a standing gap in ZERO_CASH (classify() calls it `unknown`), not a disagreement introduced
+# here — the leg moves stock either way.
+STOCK_MOVING_LEG = CDP_TRANSFER | {"open/transfer_in", "sell/transfer_out", "sell/transfer",
+                                   "gift_in", "gifted stock in", "gifted stock out", "switch_in"}
 # a fund fee paid by redeeming units (Endowus). No cash leaves the investor's pocket, so the
 # unit drop already carries the whole cost through market value — booking a cash outflow too
 # would charge the fee twice.
@@ -185,16 +228,22 @@ def _carry_corporate_actions(corp_actions, pos, meta):
                 pos[kt]["flows"].extend([fl for fl in pos[kf]["flows"] if fl[1] < 0])
                 for fld in ("invested", "buy_cost"):
                     pos[kt][fld] += pos[kf][fld]
+                # the carried cost replays at the dates it was actually paid; qty carries as
+                # zero because buy_qty does not, and the rebase below re-splits it anyway.
+                pos[kt]["cost_events"].extend(
+                    CostEvent(e.date, e.cost, 0.0) for e in pos[kf]["cost_events"])
                 switched.add(kt)
             elif pos[kt]["invested"] < 1e-6:        # non-cash conversion: successor starts empty
                 pos[kt]["flows"].extend(pos[kf]["flows"])
                 for fld in ("invested", "buy_cost", "buy_qty", "proceeds"):
                     pos[kt][fld] += pos[kf][fld]
+                pos[kt]["cost_events"].extend(pos[kf]["cost_events"])
             else:
                 continue
             for fld in ("invested", "buy_cost", "buy_qty", "proceeds"):
                 pos[kf][fld] = 0.0
             pos[kf]["flows"] = []
+            pos[kf]["cost_events"] = []
     # a switched holding rebased its units (predecessor units != successor units), so its carried
     # buy_qty is meaningless. The position was never sold for cash (only fee nibbles), so treat the
     # whole current holding as carrying the full invested cost: cost_basis = invested, realised = 0.
@@ -202,6 +251,26 @@ def _carry_corporate_actions(corp_actions, pos, meta):
         if pos[k]["units"] > 1e-6:
             pos[k]["buy_cost"] = pos[k]["invested"]
             pos[k]["buy_qty"] = pos[k]["units"]
+            _rebase_cost_events(pos[k])
+
+
+def _rebase_cost_events(p):
+    """Re-split a position's dated cost series across the scalars it mirrors, keeping every
+    original date and weighting by each event's own cost.
+
+    The switch rebase above rewrites `buy_cost` / `buy_qty` wholesale rather than incrementing
+    them, so the series has to be rewritten with it or the two stop agreeing. Weighting by cost
+    is what the rebase asserts anyway: the whole holding carries the full invested cost at one
+    average, so every dated slice of it does too.
+
+    Stated for whoever replays this: the quantities that come out are a re-split, not units
+    anybody observed on those dates — the predecessor's units were a different instrument. They
+    are true at the terminus and an even smear before it."""
+    tot = sum(e.cost for e in p["cost_events"])
+    if tot <= 1e-9:
+        return
+    p["cost_events"] = [CostEvent(e.date, p["buy_cost"] * e.cost / tot,
+                                  p["buy_qty"] * e.cost / tot) for e in p["cost_events"]]
 
 
 def _apply_txn(p, r, today):
@@ -217,9 +286,7 @@ def _apply_txn(p, r, today):
         p["fees"] += fee
         p["flows"].append((r["trade_date"] or today, cash))
         if cash < 0:
-            p["invested"] += -cash
-            p["buy_cost"] += -cash
-            p["buy_qty"] += float(r["qty_signed"])
+            _book_buy(p, r["trade_date"] or today, -cash, float(r["qty_signed"]))
         else:
             p["proceeds"] += cash
     elif kind == "uncosted":
@@ -281,33 +348,32 @@ def _build_row(k, p, m, fx, price, today):
     }
 
 
-def fold_positions(txns, divs, cdp, corp_actions, options, fx, price, today=None):
-    """Pure fold: accumulate per-(funding_bucket, security) positions from already-fetched
-    inputs and emit one output row each. No DB or session — every input is plain data, so the
-    cost-basis rules (transfer double-count, CDP cost attach, dividend income, corporate-action
-    carry, switch rebasing, options income) are all testable with fabricated rows.
+def _accumulate_positions(txns, divs, cdp, corp_actions, today):
+    """Accumulate per-(funding_bucket, security) positions from the fold's inputs. Returns
+    `(pos, meta)` — the raw accumulators and the last-seen metadata row per position.
 
-      txns  — mapping rows: account_id, account, funding_bucket, security_id, canonical_ticker,
-              name, market, asset_type, currency, trade_date, action, qty_signed, price, fees.
-      divs  — mapping rows: account_id, security_id, pay_date, gross.
-      cdp   — {ticker: {flows, invested, buy_cost, buy_qty}} from cdp_cost().
-      corp_actions — iterable of (from_ticker, to_ticker, type) (carry types only).
-      options — {ticker: {pl_sgd, ...}} realized options income per underlying.
-      fx / price — latest FX map and latest close per security_id. today defaults to today.
-    """
-    today = today or dt.date.today()
+    Split out of fold_positions() so the accumulators are reachable without going through
+    _build_row(): each one carries a dated `unit_events` / `cost_events` series beside the
+    undated running totals, and peak capital-at-risk (#143 §9) and the dated corporate-action
+    carry (§12) both need to replay those in date order. Nothing reads them yet."""
     # group per (bucket, security): transfers within a bucket (e.g. CDP->FSM) keep the cost
     # together, so a position transferred into FSM still carries its original CDP purchase cost.
     pos = defaultdict(lambda: {"units": 0.0, "flows": [], "invested": 0.0, "proceeds": 0.0,
                                 "income": 0.0, "buy_cost": 0.0, "buy_qty": 0.0, "fees": 0.0,
-                                "uncosted_units": 0.0, "accounts": set()})
+                                "uncosted_units": 0.0, "accounts": set(),
+                                "unit_events": [], "cost_events": []})
     meta = {}
     _unknown_actions = set()
     for r in txns:
         k = (r["funding_bucket"], r["security_id"])
         meta[k] = r
         p = pos[k]
-        p["units"] += float(r["qty_signed"])
+        qty = float(r["qty_signed"])
+        p["units"] += qty
+        # every row that moves units gets an event, CDP included: CDP units come from the txn
+        # ledger even though their cost arrives from cdp_cost_lot below.
+        p["unit_events"].append(UnitEvent(r["trade_date"] or today, qty, r["action"],
+                                          r["action"] in STOCK_MOVING_LEG))
         p["accounts"].add(r["account"])
         if r["account"] == "CDP":
             continue                                   # CDP cost comes from cdp-stocks below
@@ -330,6 +396,7 @@ def fold_positions(txns, divs, cdp, corp_actions, options, fx, price, today=None
         pos[k]["invested"] += c["invested"]
         pos[k]["buy_cost"] += c["buy_cost"]
         pos[k]["buy_qty"] += c["buy_qty"]
+        pos[k]["cost_events"].extend(c["cost_events"])
         pos[k]["proceeds"] += sum(a for _, a in c["flows"] if a > 0)
 
     bucket_by_acct_id = {r["account_id"]: r["funding_bucket"] for r in txns}
@@ -343,6 +410,30 @@ def fold_positions(txns, divs, cdp, corp_actions, options, fx, price, today=None
 
     _carry_corporate_actions(corp_actions, pos, meta)
 
+    # a series named for its dates should arrive in them: the carry splices a predecessor's
+    # events in at their original dates, mid-series. Stable, so same-day order is arrival order.
+    for p in pos.values():
+        p["unit_events"].sort(key=lambda e: e.date)
+        p["cost_events"].sort(key=lambda e: e.date)
+    return pos, meta
+
+
+def fold_positions(txns, divs, cdp, corp_actions, options, fx, price, today=None):
+    """Pure fold: accumulate per-(funding_bucket, security) positions from already-fetched
+    inputs and emit one output row each. No DB or session — every input is plain data, so the
+    cost-basis rules (transfer double-count, CDP cost attach, dividend income, corporate-action
+    carry, switch rebasing, options income) are all testable with fabricated rows.
+
+      txns  — mapping rows: account_id, account, funding_bucket, security_id, canonical_ticker,
+              name, market, asset_type, currency, trade_date, action, qty_signed, price, fees.
+      divs  — mapping rows: account_id, security_id, pay_date, gross.
+      cdp   — {ticker: {flows, invested, buy_cost, buy_qty, cost_events}} from cdp_cost().
+      corp_actions — iterable of (from_ticker, to_ticker, type) (carry types only).
+      options — {ticker: {pl_sgd, ...}} realized options income per underlying.
+      fx / price — latest FX map and latest close per security_id. today defaults to today.
+    """
+    today = today or dt.date.today()
+    pos, meta = _accumulate_positions(txns, divs, cdp, corp_actions, today)
     out = []
     for k, p in pos.items():
         m = meta.get(k)

--- a/tests/test_performance.py
+++ b/tests/test_performance.py
@@ -108,6 +108,20 @@ class TestCdpCost(unittest.TestCase):
         self.s.commit()
         self.assertEqual(perf.cdp_cost(self.s), {})
 
+    def test_buy_legs_are_carried_dated_as_well_as_summed(self):
+        """The dated mirror of invested/buy_qty (#147): #143 replays these in date order, and
+        a scalar running total has no date to hang itself on. A sale moves neither."""
+        self._add("D05", D(2018, 2, 12), 400, -10764.16, "open market")
+        self._add("D05", D(2020, 3, 19), -400, 12000.0, "open market")
+        self.s.commit()
+        c = perf.cdp_cost(self.s)["D05"]
+        # str() on the date because these rows come back through raw SQL, so SQLite hands back
+        # the ISO text where Postgres hands back a date — the same seam c["flows"] sits on.
+        self.assertEqual([(str(e.date), e.cost, e.qty) for e in c["cost_events"]],
+                         [("2018-02-12", 10764.16, 400.0)])
+        self.assertAlmostEqual(sum(e.cost for e in c["cost_events"]), c["buy_cost"], places=6)
+        self.assertAlmostEqual(sum(e.qty for e in c["cost_events"]), c["buy_qty"], places=6)
+
     def test_zero_amount_rows_are_skipped(self):
         self._add("XXX", D(2020, 1, 1), 0, 0.0, "open market")
         self.s.commit()

--- a/tests/test_performance_fold.py
+++ b/tests/test_performance_fold.py
@@ -27,6 +27,10 @@ def _txn(**over):
 
 
 def _fold(txns, *, divs=None, cdp=None, corp=None, options=None, fx=None, price=None):
+    # Every shape this suite fabricates is also a gate on the dated series the fold keeps beside
+    # its scalars (#147): the criterion is terminal equality on *every* shape, so it is asserted
+    # here rather than only in the tests written for it. See _assert_terminal_equal below.
+    _assert_terminal_equal(_acc(txns, divs=divs, cdp=cdp, corp=corp))
     return perf.fold_positions(txns, divs or [], cdp or {}, corp or [], options or {},
                                fx or {}, price or {}, TODAY)
 
@@ -116,3 +120,163 @@ def test_foreign_currency_converts_at_fx():
                     fx={"HKD": 0.17}, price={10: 12.0}))
     assert r["mv_native"] == 1200.0
     assert r["mv_sgd"] == 204.0                     # 1200 * 0.17
+
+
+# ---------------------------------------------------------------------------
+# Dated accumulators (#147). The fold keeps a dated unit series and a dated cost series
+# beside the undated scalars it already kept, so peak capital-at-risk (#143 §9) and the
+# dated corporate-action carry (§12) can replay them in date order. Nothing reads them yet,
+# so what is provable today is that they mirror the scalars exactly, carry the right dates,
+# and reach no endpoint.
+# ---------------------------------------------------------------------------
+
+def _acc(txns, *, divs=None, cdp=None, corp=None):
+    """The fold's accumulators, before _build_row flattens them into output rows."""
+    return perf._accumulate_positions(txns, divs or [], cdp or {}, corp or [], TODAY)[0]
+
+
+def _cdp(*legs):
+    """A cdp_cost()-shaped group: legs are (date, cash, qty) with cash negative on a buy."""
+    g = {"flows": [], "invested": 0.0, "buy_cost": 0.0, "buy_qty": 0.0, "cost_events": []}
+    for d, cash, qty in legs:
+        g["flows"].append((d, cash))
+        if cash < 0:
+            g["invested"] += -cash; g["buy_cost"] += -cash; g["buy_qty"] += qty
+            g["cost_events"].append(perf.CostEvent(d, -cash, qty))
+    return g
+
+
+def _assert_terminal_equal(pos):
+    """Every dated series ends where the scalar it mirrors ends."""
+    for k, p in pos.items():
+        assert abs(sum(e.qty for e in p["unit_events"]) - p["units"]) < 1e-6, k
+        assert abs(sum(e.cost for e in p["cost_events"]) - p["buy_cost"]) < 1e-6, k
+        assert abs(sum(e.qty for e in p["cost_events"]) - p["buy_qty"]) < 1e-6, k
+
+
+def test_unit_events_are_dated_and_sum_to_units():
+    pos = _acc([_txn(action="buy", qty_signed=100, price=10.0, trade_date=D(2020, 1, 1)),
+                _txn(action="sell", qty_signed=-40, price=15.0, trade_date=D(2021, 1, 1))])
+    p = pos[("cash", 10)]
+    assert [(e.date, e.qty) for e in p["unit_events"]] == [(D(2020, 1, 1), 100.0),
+                                                           (D(2021, 1, 1), -40.0)]
+    _assert_terminal_equal(pos)
+
+
+def test_unit_events_tell_a_stock_moving_leg_from_a_trade():
+    """#143 §9 rule 4 matches equal-and-opposite transfer legs, which means a replay has to
+    recognise one. CDP rows carry units too (their cost arrives separately), so they appear."""
+    pos = _acc([_txn(action="buy", qty_signed=100, price=10.0),
+                _txn(account="CDP", action="sell/transfer_out", qty_signed=-100, price=15.0,
+                     trade_date=D(2020, 3, 28)),
+                _txn(action="transfer in", qty_signed=100, price=15.0, trade_date=D(2020, 3, 19))])
+    p = pos[("cash", 10)]
+    assert [e.moves_stock for e in p["unit_events"]] == [False, True, True]
+    assert [e.action for e in p["unit_events"]] == ["buy", "transfer in", "sell/transfer_out"]
+    _assert_terminal_equal(pos)
+
+
+def test_unit_events_are_in_date_order():
+    pos = _acc([_txn(action="buy", qty_signed=10, price=1.0, trade_date=D(2022, 1, 1)),
+                _txn(action="buy", qty_signed=20, price=1.0, trade_date=D(2020, 1, 1))])
+    dates = [e.date for e in pos[("cash", 10)]["unit_events"]]
+    assert dates == [D(2020, 1, 1), D(2022, 1, 1)]
+
+
+def test_cost_events_carry_the_date_the_cost_and_the_quantity():
+    pos = _acc([_txn(action="buy", qty_signed=100, price=10.0, trade_date=D(2020, 1, 1), fees=7.0),
+                _txn(action="sell", qty_signed=-40, price=15.0, trade_date=D(2021, 1, 1))])
+    p = pos[("cash", 10)]
+    assert [tuple(e) for e in p["cost_events"]] == [(D(2020, 1, 1), 1007.0, 100.0)]
+    _assert_terminal_equal(pos)                      # a sell moves neither cost nor bought qty
+
+
+def test_free_and_uncosted_units_book_no_cost_event():
+    """Bonus shares and a priceless trade move units without moving cost, on both series."""
+    pos = _acc([_txn(action="bonus", qty_signed=280, price=None),
+                _txn(action="buy", qty_signed=100, price=None)])
+    p = pos[("cash", 10)]
+    assert len(p["unit_events"]) == 2 and p["cost_events"] == []
+    _assert_terminal_equal(pos)
+
+
+def test_cdp_cost_attaches_its_legs_dated():
+    """CDP units come from the txn ledger, its cost from cdp_cost_lot — so the cost events
+    arrive from the attach, at the trade dates the CSV carries."""
+    pos = _acc([_txn(account="CDP", action="open market", qty_signed=400, price=None,
+                     trade_date=D(2018, 2, 12))],
+               cdp={"D05": _cdp((D(2018, 2, 12), -10764.16, 400.0))})
+    p = pos[("cash", 10)]
+    assert [tuple(e) for e in p["cost_events"]] == [(D(2018, 2, 12), 10764.16, 400.0)]
+    _assert_terminal_equal(pos)
+
+
+def test_switch_carry_replays_the_predecessors_dates():
+    """§12: the carried cost must land at the date it was actually paid, not at the switch —
+    an undated scalar has no date to hang itself on, which is what puts 0P0001OOJG at
+    '+1512% on capital of 2,984'."""
+    txns = [
+        _txn(security_id=1, canonical_ticker="OLD", asset_type="fund",
+             action="buy", qty_signed=100, price=10.0, trade_date=D(2020, 1, 1)),
+        _txn(security_id=1, canonical_ticker="OLD", asset_type="fund",
+             action="sell", qty_signed=-100, price=11.0, trade_date=D(2021, 1, 1)),
+        _txn(security_id=2, canonical_ticker="NEW", asset_type="fund",
+             action="switch_in", qty_signed=90, price=None, trade_date=D(2021, 1, 1)),
+    ]
+    pos = _acc(txns, corp=[("OLD", "NEW", "switch")])
+    new, old = pos[("cash", 2)], pos[("cash", 1)]
+    # the 2020 purchase, replayed onto NEW at its original date, with qty rebased to NEW's units
+    assert [tuple(e) for e in new["cost_events"]] == [(D(2020, 1, 1), 1000.0, 90.0)]
+    assert old["cost_events"] == []                  # the emptied predecessor keeps no cost
+    _assert_terminal_equal(pos)
+
+
+def test_a_switch_into_a_closed_successor_skips_the_rebase_and_still_agrees():
+    """The rebase only fires on a successor that still holds units, so a switch into one that
+    was since sold out keeps its carried cost dated at zero quantity — which is what buy_qty
+    does too, so the series and the scalar still end in the same place."""
+    txns = [
+        _txn(security_id=1, canonical_ticker="OLD", asset_type="fund", action="buy",
+             qty_signed=100, price=10.0, trade_date=D(2020, 1, 1)),
+        _txn(security_id=1, canonical_ticker="OLD", asset_type="fund", action="sell",
+             qty_signed=-100, price=11.0, trade_date=D(2021, 1, 1)),
+        _txn(security_id=2, canonical_ticker="NEW", asset_type="fund", action="switch_in",
+             qty_signed=90, price=None, trade_date=D(2021, 1, 1)),
+        _txn(security_id=2, canonical_ticker="NEW", asset_type="fund", action="sell",
+             qty_signed=-90, price=12.0, trade_date=D(2022, 1, 1)),
+    ]
+    pos = _acc(txns, corp=[("OLD", "NEW", "switch")])
+    assert [tuple(e) for e in pos[("cash", 2)]["cost_events"]] == [(D(2020, 1, 1), 1000.0, 0.0)]
+    _assert_terminal_equal(pos)
+
+
+def test_non_cash_carry_replays_cost_and_quantity_at_the_original_dates():
+    txns = [
+        _txn(security_id=1, canonical_ticker="C31", action="buy", qty_signed=10071,
+             price=3.73, trade_date=D(2021, 4, 28)),
+        _txn(security_id=1, canonical_ticker="C31", action="sell/transfer_out",
+             qty_signed=-10071, price=None, trade_date=D(2021, 9, 28)),
+        _txn(security_id=2, canonical_ticker="9CI", action="open/transfer_in", qty_signed=2700,
+             price=None, trade_date=D(2021, 9, 28)),
+    ]
+    pos = _acc(txns, corp=[("C31", "9CI", "split")])
+    nine = pos[("cash", 2)]
+    assert [(e.date, e.qty) for e in nine["cost_events"]] == [(D(2021, 4, 28), 10071.0)]
+    _assert_terminal_equal(pos)
+
+
+# /api/positions splats the fold's row wholesale (`{**r, "status": ...}`), so a field added to
+# the row is a field added to the endpoint. This is the whole key set as it shipped before #147.
+ROW_FIELDS = {
+    "bucket", "accounts", "ticker", "name", "market", "asset_type", "currency", "units", "price",
+    "mv_native", "avg_cost", "cost_basis_native", "cost_basis_sgd", "unrealised_pl_sgd",
+    "realised_pl_sgd", "invested_native", "income_native", "fees_sgd", "cost_known",
+    "uncosted_units", "total_pl_native", "invested_sgd", "mv_sgd", "income_sgd", "pl_sgd",
+    "xirr", "simple_return", "options_pl_sgd",
+}
+
+
+def test_the_dated_series_reach_no_output_row():
+    """`No field on any endpoint moves` — the accumulators stay behind _build_row."""
+    r = _only(_fold([_txn(qty_signed=100, price=10.0)], price={10: 12.0}))
+    assert set(r) == ROW_FIELDS


### PR DESCRIPTION
Closes #147. Part of #143 (§9, §12).

A pure **prefactor**: the position fold now records its own accumulator changes **dated**, beside
the undated scalars it already keeps, and **no output moves at all**.

## Why

`_apply_txn`, the `cdp_cost_lot` cost attach and the corporate-action carry all moved
`buy_cost` / `buy_qty` / units as running totals with no date attached. Peak capital-at-risk
(#143 §9) and the dated carry (§12) both replay those same accumulators **in date order** —
reading an intermediate state of the fold, the first thing this app has ever asked of it — and an
undated scalar has no date to hang itself on. That is what puts 0P0001OOJG at
`+1512% on capital of 2,984`.

Make the change easy, then make the easy change.

## What changed

`portfolio/performance.py`:

- **`UnitEvent(date, qty, action, moves_stock)`** and **`CostEvent(date, cost, qty)`**. Unit
  changes carry the date and enough to tell a stock-moving leg from a trade; cost changes carry
  the date, the cost and the quantity.
- **`STOCK_MOVING_LEG`** — derived from `CDP_TRANSFER` rather than re-listing its spellings, so a
  fifth spelling lands in one place. #143 §9 rule 4 matches an equal-and-opposite *pair* of these
  as one internal move; the flag is resolved once in the fold rather than left for every reader
  to re-derive from the action string.
- **`_book_buy()`** — the single place a purchase hits `invested` / `buy_cost` / `buy_qty` plus
  its dated event. The same buy arrives from two ledgers (`_apply_txn` for the broker CSVs,
  `cdp_cost()` for cdp-stocks); a series that agrees with its scalars on one path and not the
  other would be worse than no series.
- **`_accumulate_positions()`** — the accumulation split out of `fold_positions`, so the series
  are reachable without going through `_build_row`. That split is also what keeps them off the
  wire.
- **`_carry_corporate_actions`** replays a predecessor's cost events into the successor **at
  their original dates** and clears the emptied predecessor's. **`_rebase_cost_events`**
  re-splits the series when the switch rebase rewrites `buy_qty` wholesale rather than
  incrementing it.
- Both series are sorted by date at the end of accumulation — the carry splices events in
  mid-series, and a series named for its dates should arrive in them.

`CONTEXT.md` gains **Dated accumulator** and **Stock-moving leg**.

**Nothing reads the events yet.**

## Acceptance criteria

- [x] The fold accumulates a dated unit-event series and a dated cost-event series per position
- [x] The dated cost series is terminal-equal to the scalar `buy_cost` / `buy_qty` it mirrors, on
      every fabricated shape the tier-1 suite exercises
- [x] `cdp_cost()` carries its buy legs dated as well as summed
- [x] **No field on any endpoint moves**
- [x] The existing pytest suite passes unchanged, with no assertion edited

## Verification

- **467 pass** (was 456 — 11 additions, no existing assertion edited). `ruff check .` clean.
- **Byte-identical output**: 3,000 randomized fabricated shapes were replayed through the
  pre-change `fold_positions` (from `ff2a6b0`) and the new one — **3000/3000 identical rows**.
  `/api/positions`, `/api/performance` and `/api/overview` all read only these rows.
- **Terminal equality**: fuzzed to **0 violations** over the same 3,000 shapes, and
  `_assert_terminal_equal` is wired into the suite's own `_fold` helper — so *every* shape the
  tier-1 suite fabricates is a gate, not only the shapes written for this ticket.
- `test_the_dated_series_reach_no_output_row` pins the output row's **whole key set** as it
  shipped before this change. `/api/positions` splats the fold's row wholesale (`{**r, ...}`), so
  that is the durable gate on "no field moves".

## Two things noted rather than changed

- `_rebase_cost_events` produces per-date quantities that are a **re-split, not units anybody
  observed** — the predecessor's units were a different instrument. It is the only honest mirror
  of a scalar rebase that is itself a wholesale rewrite; the docstring states it plainly for
  whoever writes the §9 replay.
- `cdp_cost()` reads through raw SQL, so its dates come back as `str` under SQLite and `date`
  under Postgres. That is the pre-existing seam `flows` already sits on, now shared by
  `cost_events`; latent only, with one DB in production. Left alone rather than papered over.

https://claude.ai/code/session_01T32AmNXF4uf7rK7Qigryr6


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dated records for unit and cost events alongside existing position totals.
  * Improved tracking of purchases, stock movements, corporate actions, and internal transfers across their original dates.
  * Preserved accurate cost and quantity history when positions are carried or rebased.

* **Documentation**
  * Added glossary definitions for dated accumulators and stock-moving legs.

* **Tests**
  * Expanded coverage for event ordering, free units, cost attachment, transfers, corporate actions, and total reconciliation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->