### PR TITLE
Cost truth is a partition of units, not a flag (#148)

### DIFF
--- a/BACKEND.md
+++ b/BACKEND.md
@@ -60,7 +60,39 @@ from `data/cdp-stocks/transactions.csv` via `portfolio/performance.cdp_cost()` a
 into the cash-bucket position. Positions still come from the authoritative
 CDP statements; `alloc_by_account()` gives the per-account MV split for charts.
 
-Result: **31/37** bucket-positions have a known cost basis (XIRR + P/L) — incl. the
-FSM-transferred D05 / O5RU / UD1U. The remaining 6 are the Amundi fund (Endowus units, no
-unit price stored) and Moomoo 9CI/C38U/HMN (free shares from the 2021 CapitaLand
-restructuring — no purchase price).
+CDP cost is matched at **position** level, not per row — a CDP `txn` row is a month-end
+statement diff that routinely aggregates several trade-dated cost lots, and matching per row
+invents shortfalls that do not exist. `performance.cost_partition` carries the detail.
+
+## Cost truth is a partition of units
+
+A boolean cannot say the thing that is actually true of Q01: *17,000 of its 68,000 units
+entered with no recorded cost*. So every entering unit lands in exactly one of three
+conditions, computed after the corporate-action carry and the switch rebasing run and shipped
+as a nested `cost_partition` on every position row:
+
+```json
+"cost_partition": { "units_in": 68000, "costed": 51000, "free": 0,
+                    "unknown": 17000, "unknown_pct": 0.25 }
+```
+
+The three **sum to gross units in** on every position — 73 of 73 in the live book, which totals
+1,574,652 units in: 1,521,274 costed, 545 free, 52,833 unknown. Nested so the counts cannot
+drift apart among ~25 flat siblings and the self-check is visible in one place.
+`tests/test_performance_live.py` holds those figures to the ledger they were measured against.
+
+- **A carried unit is `costed`** — its cost is known, it just came from a predecessor (9CI's
+  2,700 from C31). Likewise a transfer in whose paired transfer out sits in the same position:
+  the cost never left.
+- **`free` units carry a price, not only a count** — `cost_basis = 0.0`, never `null`. They
+  enter `buy_qty` at zero cost, which is what makes AAPL's basis a *measured* zero (and stops
+  D05's 280 bonus shares inflating its cost basis past what was ever invested).
+- **The action string cannot decide free from transferred.** Every unpriced carry-in is
+  `open/transfer_in` on one account, covering a landed corporate-action carry, a real in-specie
+  distribution and two windfalls. That distinction lives in a per-transaction annotation
+  (`portfolio/cost_annotations.py`) defaulting to `unknown` — refuse rather than invent a free
+  lot. `gifted stock in` and `bonus issuance` are mechanical and need no annotation.
+- **`cost_known` is the partition read as a boolean**: false only when *every* entering unit is
+  unknown. Not `unknown == 0`, which would flip C38U to false and delete its 7,756.75 Net.
+  Live, the refusal set is ASTREA6B alone; the caveat set is S51 40.0%, SET 27.9%, Q01 25.0%,
+  C38U 7.5%.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -48,7 +48,9 @@ The Holdings table's fold of every position sharing one canonical ticker into a 
 only place the app answers "how much of this name do I own, across every bucket". Units, cost,
 market value, P/L, dividends and option premiums sum; price and currency pass through (one
 security, one lookup); average cost pools as `Σcost_basis ÷ Σunits`, which is *exact* rather than
-approximate because cost basis is average cost × units. **Derived at render, never stored and
+approximate because cost basis is average cost × units. The cost partition folds by addition —
+each leg's entering units are its own — with `unknown_pct` recomputed over the merged counts
+rather than averaged. **Derived at render, never stored and
 never served** — no endpoint returns one — so it is a presentation of several positions and never
 itself a Position. XIRR is deliberately not folded: an IRR over merged cashflows cannot be
 averaged from its parts, so a consolidated row of two positions shows no return rather than a
@@ -70,10 +72,35 @@ A unit change that is part of the *return*, not an external contribution: units 
 Units redeemed to pay a fee (Endowus). No cash leaves the investor, so the market-value drop
 already carries the cost — booking a cash outflow too would charge the fee twice.
 
-**Uncosted units**:
-Units that landed in a position via a transaction whose price the source never recorded. They
-count toward market value, but their presence makes a money-weighted return meaningless (there
-is no cost to weight against), so it is suppressed.
+**Cost partition**:
+The split of a position's **entering units** — gross units in, so a sale subtracts nothing —
+into exactly three **conditions**, summing to that total. A boolean cannot say the thing that is
+actually true of Q01: 17,000 of its 68,000 units entered with no recorded cost. Shipped nested
+(`cost_partition`) so the counts cannot drift apart among ~25 flat siblings, with `unknown_pct`
+pre-computed. The three:
+
+- **Costed** — real money is recorded against these units: a priced trade, a CDP cost lot, a
+  predecessor's cost carried by a corporate action, or a transfer in whose paired transfer out
+  sits in the same position (the cost never left).
+- **Free** — they cost nothing, and that is measured, not assumed. Free units carry a *price*,
+  not only a count: their cost basis is `0.0`, never null.
+- **Unknown** — the book does not know. The polarity is to refuse rather than invent a free lot.
+
+`cost_known` is this partition read as a boolean: false only when *every* entering unit is
+unknown. Not "no unknown units" — a name with some cost still answers "did I make money on
+this"; only a name with none has to refuse.
+_Avoid_: uncosted units (the retired boolean-era term; it named only the unpriced-trade slice of
+`unknown` and has left the wire), cost-unknown position (a position is rarely all-or-nothing)
+
+**Cost annotation**:
+The free/transferred distinction, per transaction, defaulting to `unknown`. Every unpriced
+carry-in in the book shares one action string, which covers a corporate-action carry, a real
+in-specie distribution and two windfalls at once — so neither the action nor the account can
+decide it, and the knowledge lives beside the code (`portfolio/cost_annotations.py`) rather than
+in the ledger, which has nowhere to put it. Scope is `open/transfer_in` and zero-priced
+`corp action`; `gifted stock in` and `bonus issuance` are mechanical and need none.
+_Avoid_: per-security override (rejected — it breaks the day one ticker holds both a gift lot
+and a real transfer-in)
 
 ### Returns
 

--- a/portfolio/cost_annotations.py
+++ b/portfolio/cost_annotations.py
@@ -1,0 +1,96 @@
+"""Per-transaction cost annotations — the free/transferred distinction the ledger cannot carry.
+
+Every unpriced carry-in in this book is `open/transfer_in` on one account, and that one string
+covers a landed corporate-action carry (9CI 2,700), a real in-specie distribution paid for as
+part of a predecessor (C38U 417), and two windfalls (AAPL 1, HMN 153). The action string
+therefore cannot decide whether the units were free or merely transferred, and neither can the
+account: the broker's export says *transfer* because that is what its system recorded, and
+nothing further is in the ledger to read.
+
+So the knowledge lives here, per transaction, and **defaults to `unknown`** — a row nobody has
+annotated is refused, not assumed free. The conservative polarity is deliberate: inventing a
+free lot silently mints market value at zero cost, while refusing one is visible on screen.
+
+**Per-security was rejected.** It breaks the day a ticker holds both a gift lot and a real
+transfer-in, which is not hypothetical — AAPL is one unit of welcome gift beside nothing, and
+the same shape on a name with a real position would be indistinguishable.
+
+**Scope**: `open/transfer_in` and *zero-priced* `corp action`. A priced `corp action` is a
+rights subscription the holder paid cash for and classifies as `cash` long before it reaches
+here (see `performance.classify`), so the scope check below only has to name the action.
+
+Not every free lot needs a row. `gifted stock in` (AMZN ×3, BABA ×1) and `bonus issuance`
+(D05 cpf ×1) are mechanical — the broker's own word for a gift or a bonus issue is not
+ambiguous — and are read straight off the action string by `performance.FREE_ACTION`.
+
+The key is `(account, canonical ticker, trade_date, action, qty)` rather than `txn.id`, so an
+annotation survives a re-ingest that renumbers the table. It is the loader's dedup key *minus*
+two things, and both matter to whoever writes the next row:
+
+  - **The occurrence counter.** `ingestion/load.py` hashes these five fields plus "nth identical
+    row in this file", precisely because identical lots exist (the two `2-Sep-20 UD1U 11100` SRS
+    buys). So a key here does not distinguish twins: two identical annotatable rows on one day
+    would both take the annotation. None of the three below has a twin, and `unmatched()` says
+    so out loud if that ever changes.
+  - **The raw ticker.** The loader keys the ledger's symbol; this keys the canonical ticker the
+    fold works in, which is what a curator reading a position can actually see.
+"""
+from __future__ import annotations
+
+import datetime as dt
+
+# What an annotation may assert. Anything unannotated is `unknown`. NOT the same set as the
+# fold's own `_condition()`, which has a fourth internal answer (`pending`) for a row whose
+# backing it has yet to resolve — that one is never something a human asserts.
+ANNOTATION_CONDITIONS = ("costed", "free", "unknown")
+
+# Actions an annotation may be written against — see **Scope** above.
+ANNOTATABLE_ACTIONS = frozenset({"open/transfer_in", "corp action", "corp_action"})
+
+# (account, ticker, trade_date, action, qty, condition, why)
+ANNOTATIONS: list[tuple[str, str, dt.date, str, float, str, str]] = [
+    ("Moomoo", "AAPL", dt.date(2022, 12, 28), "open/transfer_in", 1, "free", "welcome gift"),
+    ("Moomoo", "HMN", dt.date(2023, 5, 28), "open/transfer_in", 153, "free",
+     "given as a dividend"),
+    ("FSM", "D05", dt.date(2024, 4, 30), "corp action", 280, "free", "bonus shares"),
+]
+
+
+def _key(account, ticker, trade_date, action, qty):
+    """The five fields `ingestion.load` hashes a txn row on, normalised for lookup."""
+    return (account, ticker, trade_date, action, round(float(qty or 0), 8))
+
+
+def annotation_map() -> dict[tuple, str]:
+    """`{natural key: condition}` — what the fold consults, one entry per annotation."""
+    return {_key(*a[:5]): a[5] for a in ANNOTATIONS}
+
+
+def condition_for(row, annotations: dict[tuple, str]) -> str | None:
+    """The annotated condition for one txn mapping-row, or None when none covers it.
+
+    Out-of-scope actions return None without consulting the map, so an annotation can only
+    ever speak about the rows it was drawn to speak about."""
+    if row["action"] not in ANNOTATABLE_ACTIONS:
+        return None
+    return annotations.get(_key(row["account"], row["canonical_ticker"], row["trade_date"],
+                                row["action"], row["qty_signed"]))
+
+
+def unmatched(txns, annotations: dict[tuple, str]) -> dict[tuple, int]:
+    """Annotation keys that do not match exactly ONE txn row, keyed to the count they matched.
+
+    Both failures are silent otherwise, and both are wrong in the expensive direction. **Zero**
+    is a stale annotation — a re-ingest that moves AAPL's trade date by a day turns a measured
+    free lot back into an `unknown` one, and the position quietly starts refusing a Net it used
+    to answer. **Two or more** annotates a lot nobody looked at, because the key cannot tell
+    twins apart (see the module docstring)."""
+    seen = {k: 0 for k in annotations}
+    for r in txns:
+        if r["action"] not in ANNOTATABLE_ACTIONS:
+            continue
+        k = _key(r["account"], r["canonical_ticker"], r["trade_date"], r["action"],
+                 r["qty_signed"])
+        if k in seen:
+            seen[k] += 1
+    return {k: n for k, n in seen.items() if n != 1}

--- a/portfolio/performance.py
+++ b/portfolio/performance.py
@@ -230,6 +230,14 @@ def _carry_corporate_actions(corp_actions, pos, meta):
                 continue
             if not (pos[kf]["invested"] > 1e-6 and abs(pos[kf]["units"]) < 1e-6):
                 continue                   # predecessor must be a closed position carrying cost
+            # Only pending arrivals present when the predecessor closed can be backed by this
+            # carry. A later unpriced open/transfer is unrelated, even though it has the same
+            # shape. Keep the bounded amount for cost_partition rather than a sticky boolean.
+            close_dates = [e.date for e in pos[kf]["unit_events"] if e.qty < -1e-9]
+            carried = (sum(qty for day, qty in pos[kt]["pending_events"]
+                           if day <= max(close_dates)) if close_dates else 0.0)
+            if carried <= 1e-9:
+                continue
             if typ == "switch":
                 # cash switch (e.g. CPF fund switch): the redemption proceeds were reinvested
                 # into the successor, not withdrawn. Carry the cost basis + the BUY legs only;
@@ -250,9 +258,7 @@ def _carry_corporate_actions(corp_actions, pos, meta):
                 pos[kt]["cost_events"].extend(pos[kf]["cost_events"])
             else:
                 continue
-            # the successor's entering units are backed by the predecessor's cost now — a
-            # carried unit is `costed`, it just came from somewhere else (see cost_partition).
-            pos[kt]["cost_carried"] = True
+            pos[kt]["carried_units"] = max(pos[kt]["carried_units"], carried)
             for fld in ("invested", "buy_cost", "buy_qty", "proceeds"):
                 pos[kf][fld] = 0.0
             pos[kf]["flows"] = []
@@ -328,6 +334,8 @@ def _apply_units(p, r, kind, today, annotations):
             return
         cond = _condition(r, kind, annotations)
         p[f"{cond}_units"] += qty
+        if cond == "pending":
+            p["pending_events"].append((r["trade_date"] or today, qty))
         if cond == "free":
             # free units carry a PRICE, not only a count. avg_cost = buy_cost / buy_qty, so
             # entering them at zero cost is what makes cost_basis a measured 0.0 rather than
@@ -383,18 +391,13 @@ def cost_partition(p):
         and routinely aggregates several trade-dated `cdp_cost_lot` rows (LIW's 24,600 is three
         lots; Z74's 8,500 is 4,000 + 4,500). Matching per row invents shortfalls on LIW, S7OU,
         D05, J2T and Z74 that do not exist.
-      - **A corporate-action carry costs the units it arrived on** — the transfer/switch shape a
-        carry travels in, not every doubtful unit on the name. An unpriced *buy* into a carried
-        holding is still `unknown`; only the carry-shaped arrivals are promoted.
-
-    That last bound is by SHAPE, not by date, and shape is the tighter of the two only until a
-    carried name takes a second unpriced transfer in — which would be promoted too, on cost that
-    never covered it. Bounding by date needs the accumulators to carry one, which is the
-    prefactor in #147; until then this is the honest limit of the rule.
+      - **A corporate-action carry costs the units it arrived on** — pending arrivals through
+        the predecessor's closing event, not every doubtful unit later added to the name. An
+        unpriced buy or later transfer into a carried holding is still `unknown`.
     """
     covered = min(p["pending_units"], p["transfer_out_units"])
     cdp_costed = min(p["cdp_buy_qty"], p["cdp_units_in"])
-    carried = (p["pending_units"] - covered) if p["cost_carried"] else 0.0
+    carried = min(p["pending_units"] - covered, p["carried_units"])
     costed = p["costed_units"] + covered + cdp_costed + carried
     free = p["free_units"]
     unknown = (p["unknown_units"] + (p["pending_units"] - covered - carried)
@@ -489,8 +492,9 @@ def _accumulate_positions(txns, divs, cdp, corp_actions, today, annotations):
                                 "accounts": set(), "unit_events": [], "cost_events": [],
                                 "units_in": 0.0, "costed_units": 0.0, "free_units": 0.0,
                                 "unknown_units": 0.0, "pending_units": 0.0,
+                                "pending_events": [], "carried_units": 0.0,
                                 "transfer_out_units": 0.0, "cdp_units_in": 0.0,
-                                "cdp_buy_qty": 0.0, "cost_carried": False})
+                                "cdp_buy_qty": 0.0})
     meta = {}
     _unknown_actions = set()
     for r in txns:

--- a/portfolio/performance.py
+++ b/portfolio/performance.py
@@ -14,6 +14,7 @@ from typing import NamedTuple
 
 from sqlalchemy import text
 
+from .cost_annotations import annotation_map, condition_for, unmatched
 from .db import fx_map, latest_close, session_scope
 from .money import rate_to_sgd
 
@@ -114,6 +115,15 @@ ZERO_CASH = {"transfer_in", "transfer_out", "gift_in", "gifted stock in", "gifte
              "corp action", "corp_action", "open", "open/transfer_in", "transfer in",
              "sell/transfer_out", "sell/transfer", "stock dividend",
              "switch_in"}      # fund-switch IN leg: units only; cost carries from predecessor
+# The zero-cash actions whose free-ness is not in doubt: the broker's own word for a gift or a
+# bonus issue. `open/transfer_in` and zero-priced `corp action` are deliberately NOT here — one
+# string covers a landed corporate-action carry, a real in-specie distribution and a windfall, so
+# those rows take their condition from portfolio.cost_annotations, defaulting to `unknown`.
+# No scrip spelling is here on purpose: zero `scrip` / `scrip dividend` / `script dividend`
+# rows exist in `txn` (the four live in `cdp_cost_lot` with a negative amount and are already
+# invested), so listing them would be writing a rule the book has no use for — and if one ever
+# did appear, `unknown` is the polarity to meet it with.
+FREE_ACTION = {"gift_in", "gifted stock in", "bonus", "bonus issuance"}
 # 'corp action' is a catch-all in the FSM ledger. A PRICED row is an entitlement the holder paid
 # cash for — the ESR-LOGOS (UD1U) rights issues at 0.49 / 0.595 / 0.408, C38U, O5RU, S51. A
 # zero-priced row is a bonus or consolidation (D05's 280 bonus shares). Only the first costs money.
@@ -240,6 +250,9 @@ def _carry_corporate_actions(corp_actions, pos, meta):
                 pos[kt]["cost_events"].extend(pos[kf]["cost_events"])
             else:
                 continue
+            # the successor's entering units are backed by the predecessor's cost now — a
+            # carried unit is `costed`, it just came from somewhere else (see cost_partition).
+            pos[kt]["cost_carried"] = True
             for fld in ("invested", "buy_cost", "buy_qty", "proceeds"):
                 pos[kf][fld] = 0.0
             pos[kf]["flows"] = []
@@ -273,28 +286,126 @@ def _rebase_cost_events(p):
                                   p["buy_qty"] * e.cost / tot) for e in p["cost_events"]]
 
 
-def _apply_txn(p, r, today):
-    """Fold one non-CDP txn row into its position accumulator `p`. Returns the action
+def _condition(r, kind, annotations):
+    """Which of the three conditions one ENTERING row's units land in — or "pending" when the
+    row only moved units and the fold has yet to see what backed them.
+
+    `costed`  — real money is recorded against these units (a priced trade, a CDP cost lot).
+    `free`    — they cost nothing and that is a measured fact, not an assumption.
+    `unknown` — the book does not know, and refusing beats inventing a free lot.
+    `pending` — a transfer/open-family entry: costed if the position's own transfer out paid
+                for it or a corporate action carries cost onto it, otherwise `unknown`.
+    """
+    if kind == "cash":
+        return "costed"        # priced: real money moved, whatever the action string says.
+                               # Checked BEFORE the annotation, which is what makes the list's
+                               # scope "zero-priced `corp action`" structural rather than a
+                               # promise — a rights subscription can never be annotated free.
+    ann = condition_for(r, annotations)
+    if ann is not None:
+        return ann
+    if kind == "zero":
+        return "free" if r["action"] in FREE_ACTION else "pending"
+    # `classify`'s "unknown" and this one are different words that happen to coincide: there it
+    # means "nobody has classified this action string", here it means "the book does not know
+    # what these units cost". An unclassified action lands in the second BECAUSE of the first.
+    return "unknown"                       # uncosted / cost_in_kind / unclassified
+
+
+def _apply_units(p, r, kind, today, annotations):
+    """Book one txn row's UNITS into the partition counters — every row, CDP included.
+
+    Separate from `_apply_txn` because it runs on rows that one skips: a CDP row carries no
+    cost of its own (that arrives from `cdp_cost_lot`), but its units are as real as any
+    other's, and the CDP->FSM migration's transfer OUT leg is a CDP row while the matching
+    transfer in is an FSM one. Reading only the FSM side saw 205,090 units enter a second time
+    with nothing behind them and called eight positions cost-doubtful that are not."""
+    qty = float(r["qty_signed"])
+    if qty > 0:
+        p["units_in"] += qty                       # GROSS units in; a sale subtracts nothing
+        if r["account"] == "CDP":
+            p["cdp_units_in"] += qty               # matched against the cost pool, not per row
+            return
+        cond = _condition(r, kind, annotations)
+        p[f"{cond}_units"] += qty
+        if cond == "free":
+            # free units carry a PRICE, not only a count. avg_cost = buy_cost / buy_qty, so
+            # entering them at zero cost is what makes cost_basis a measured 0.0 rather than
+            # null — and on a mixed name it dilutes the average exactly as a bonus issue should.
+            # Through _book_buy, not a bare `buy_qty +=`: #147's dated cost series mirrors that
+            # scalar, and a series that agrees with its scalars on one path and not the other is
+            # worse than no series at all. The event is real and its cost is really zero.
+            _book_buy(p, r["trade_date"] or today, 0.0, qty)
+    elif r["action"] in STOCK_MOVING_LEG:
+        # units left without being sold. The cost stayed in the position, so this is the cover a
+        # later transfer in draws on — see cost_partition. Keyed on #147's STOCK_MOVING_LEG
+        # rather than a second list of the same spellings: "moved stock rather than traded it" is
+        # this rule's premise too, and a sixth spelling should land in one place. It is also the
+        # sharper set — it catches `transfer out` (a standing gap in ZERO_CASH) and declines a
+        # negative `corp action`, which removes units in a consolidation and backs nothing.
+        p["transfer_out_units"] += -qty
+
+
+def _apply_txn(p, r, kind, today):
+    """Fold one non-CDP txn row's COST into its position accumulator `p`. Returns the action
     string if it couldn't be classified (caller should warn), else None."""
-    act = r["action"]
     px = _f(r["price"])
+    qty = float(r["qty_signed"])
     fee = abs(float(r["fees"])) if r["fees"] is not None else 0.0   # native ccy, same as px*qty
-    kind = classify(act, px)
     if kind == "cash":
         # fees are a real cost: bigger outflow on a buy, smaller net inflow on a sell
-        cash = -float(r["qty_signed"]) * px - fee
+        cash = -qty * px - fee
         p["fees"] += fee
         p["flows"].append((r["trade_date"] or today, cash))
         if cash < 0:
-            _book_buy(p, r["trade_date"] or today, -cash, float(r["qty_signed"]))
+            _book_buy(p, r["trade_date"] or today, -cash, qty)
         else:
             p["proceeds"] += cash
-    elif kind == "uncosted":
-        if float(r["qty_signed"]) > 0:
-            p["uncosted_units"] += float(r["qty_signed"])
     elif kind == "unknown":
-        return act                                     # don't silently hand out free units
+        return r["action"]                             # don't silently hand out free units
     return None
+
+
+def cost_partition(p):
+    """The three conditions every entering unit lands in, as the nested wire object.
+
+    Nested rather than three more flat siblings among ~25: the counts cannot drift apart when
+    they travel together, and the self-check — costed + free + unknown == units_in — is visible
+    in one place. `unknown_pct` is pre-computed so the frontend does no arithmetic.
+
+    Three resolutions happen here rather than row by row, because none is knowable row by row:
+
+      - **Transfer cover.** A transfer in whose paired transfer out sits in the same position is
+        an internal move; the cost never left, so those units are costed. Anything beyond the
+        cover entered from outside with nothing behind it, and is unknown. Paired by SIZE, not by
+        identity — the ledger carries nothing linking the two legs.
+      - **CDP cost is matched at POSITION level.** A CDP txn row is a month-end statement diff
+        and routinely aggregates several trade-dated `cdp_cost_lot` rows (LIW's 24,600 is three
+        lots; Z74's 8,500 is 4,000 + 4,500). Matching per row invents shortfalls on LIW, S7OU,
+        D05, J2T and Z74 that do not exist.
+      - **A corporate-action carry costs the units it arrived on** — the transfer/switch shape a
+        carry travels in, not every doubtful unit on the name. An unpriced *buy* into a carried
+        holding is still `unknown`; only the carry-shaped arrivals are promoted.
+
+    That last bound is by SHAPE, not by date, and shape is the tighter of the two only until a
+    carried name takes a second unpriced transfer in — which would be promoted too, on cost that
+    never covered it. Bounding by date needs the accumulators to carry one, which is the
+    prefactor in #147; until then this is the honest limit of the rule.
+    """
+    covered = min(p["pending_units"], p["transfer_out_units"])
+    cdp_costed = min(p["cdp_buy_qty"], p["cdp_units_in"])
+    carried = (p["pending_units"] - covered) if p["cost_carried"] else 0.0
+    costed = p["costed_units"] + covered + cdp_costed + carried
+    free = p["free_units"]
+    unknown = (p["unknown_units"] + (p["pending_units"] - covered - carried)
+               + (p["cdp_units_in"] - cdp_costed))
+    units_in = round(p["units_in"], 4)
+    costed, free, unknown = round(costed, 4), round(free, 4), round(unknown, 4)
+    if round(costed + free + unknown, 4) != units_in:
+        log.warning("cost partition does not sum to units in: %s vs %s+%s+%s",
+                    units_in, costed, free, unknown)
+    return {"units_in": units_in, "costed": costed, "free": free, "unknown": unknown,
+            "unknown_pct": round(unknown / units_in, 4) if units_in > 1e-9 else 0.0}
 
 
 def _rn(x, n, mult=1.0):
@@ -312,17 +423,26 @@ def _build_row(k, p, m, fx, price, today):
     flows = list(p["flows"])
     if p["units"] > 1e-6 and px:
         flows.append((today, mv))
-    cost_known = p["invested"] > 1e-6
+    part = cost_partition(p)
+    # `cost_known` is the partition read as a boolean: false only when EVERY entering unit is
+    # unknown. Not `unknown == 0` — that would flip C38U (417 of 6,700 unpriced) to false and
+    # delete its 7,756.75 Net from Holdings, Performance and Overview. A name with SOME cost
+    # still answers "did I make money on this"; only a name with none has to refuse.
+    cost_known = part["units_in"] > 1e-6 and part["unknown"] < part["units_in"] - 1e-6
     # XIRR is only meaningful when every unit that entered has a known cost and the flows
     # span long enough for annualisation to mean something.
     span = (max(d for d, _ in flows) - min(d for d, _ in flows)).days if flows else 0
-    xirr_ok = cost_known and p["uncosted_units"] < 1e-6 and span >= MIN_XIRR_DAYS
+    xirr_ok = cost_known and part["unknown"] < 1e-6 and span >= MIN_XIRR_DAYS
     xirr = _xirr(flows) if xirr_ok else None
     total_pl = (mv + p["proceeds"] + p["income"] - p["invested"]) if cost_known else None
-    simple = (total_pl / p["invested"]) if cost_known else None
-    # cost basis of CURRENT holding (avg cost × held units) + unrealised P/L
+    # a free lot has a cost of zero, so it has no denominator — a percentage return on nothing
+    # is not a smaller number, it is not a number.
+    simple = (total_pl / p["invested"]) if (cost_known and p["invested"] > 1e-6) else None
+    # cost basis of CURRENT holding (avg cost × held units) + unrealised P/L. `is not None`,
+    # not truthiness: a free lot's avg cost is 0.0, which is a measured price and must not be
+    # read as "no answer" (AAPL's basis is zero because the unit was a gift).
     avg_cost = (p["buy_cost"] / p["buy_qty"]) if p["buy_qty"] > 1e-6 else None
-    cost_basis = (avg_cost * p["units"]) if (avg_cost and p["units"] > 1e-6) else None
+    cost_basis = (avg_cost * p["units"]) if (avg_cost is not None and p["units"] > 1e-6) else None
     unreal = (mv - cost_basis) if cost_basis is not None else None
     # realised stock P/L = sell proceeds − cost of the shares sold (buy_cost minus the
     # cost still tied up in the current holding). Closed positions: cost_basis None -> all sold.
@@ -331,37 +451,46 @@ def _build_row(k, p, m, fx, price, today):
         "bucket": k[0], "accounts": sorted(p["accounts"]), "ticker": m["canonical_ticker"],
         "name": m["name"], "market": m["market"], "asset_type": m["asset_type"], "currency": ccy,
         "units": round(p["units"], 4), "price": px, "mv_native": round(mv, 2),
-        "avg_cost": round(avg_cost, 4) if avg_cost else None,
+        "avg_cost": _rn(avg_cost, 4),
         "cost_basis_native": _rn(cost_basis, 2),
         "cost_basis_sgd": _rn(cost_basis, 2, rate),
         "unrealised_pl_sgd": _rn(unreal, 2, rate),
         "realised_pl_sgd": _rn(realised, 2, rate),
         "invested_native": round(p["invested"], 2), "income_native": round(p["income"], 2),
         "fees_sgd": round(p["fees"] * rate, 2), "cost_known": cost_known,
-        "uncosted_units": round(p["uncosted_units"], 4),
+        "cost_partition": part,
         "total_pl_native": round(total_pl, 2) if cost_known else None,
-        "invested_sgd": round(p["invested"] * rate, 2) if cost_known else 0.0,
+        "invested_sgd": round(p["invested"] * rate, 2) if cost_known else None,
         "mv_sgd": round(mv * rate, 2), "income_sgd": round(p["income"] * rate, 2),
         "pl_sgd": round(total_pl * rate, 2) if cost_known else None,
         "xirr": _rn(xirr, 4),
-        "simple_return": round(simple, 4) if cost_known else None,
+        "simple_return": _rn(simple, 4),
     }
 
 
-def _accumulate_positions(txns, divs, cdp, corp_actions, today):
+def _accumulate_positions(txns, divs, cdp, corp_actions, today, annotations):
     """Accumulate per-(funding_bucket, security) positions from the fold's inputs. Returns
     `(pos, meta)` — the raw accumulators and the last-seen metadata row per position.
 
     Split out of fold_positions() so the accumulators are reachable without going through
     _build_row(): each one carries a dated `unit_events` / `cost_events` series beside the
     undated running totals, and peak capital-at-risk (#143 §9) and the dated corporate-action
-    carry (§12) both need to replay those in date order. Nothing reads them yet."""
+    carry (§12) both need to replay those in date order. Nothing reads them yet.
+
+    `annotations` is the curated free/transferred map (portfolio.cost_annotations) the cost
+    partition consults; it arrives as plain data like the corporate actions do."""
     # group per (bucket, security): transfers within a bucket (e.g. CDP->FSM) keep the cost
     # together, so a position transferred into FSM still carries its original CDP purchase cost.
+    # the partition counters ride alongside the cost accumulators: every entering unit is added
+    # to `units_in` exactly once and to exactly one condition, so the two can only disagree if
+    # this loop does — which is what cost_partition's self-check watches for.
     pos = defaultdict(lambda: {"units": 0.0, "flows": [], "invested": 0.0, "proceeds": 0.0,
                                 "income": 0.0, "buy_cost": 0.0, "buy_qty": 0.0, "fees": 0.0,
-                                "uncosted_units": 0.0, "accounts": set(),
-                                "unit_events": [], "cost_events": []})
+                                "accounts": set(), "unit_events": [], "cost_events": [],
+                                "units_in": 0.0, "costed_units": 0.0, "free_units": 0.0,
+                                "unknown_units": 0.0, "pending_units": 0.0,
+                                "transfer_out_units": 0.0, "cdp_units_in": 0.0,
+                                "cdp_buy_qty": 0.0, "cost_carried": False})
     meta = {}
     _unknown_actions = set()
     for r in txns:
@@ -375,9 +504,11 @@ def _accumulate_positions(txns, divs, cdp, corp_actions, today):
         p["unit_events"].append(UnitEvent(r["trade_date"] or today, qty, r["action"],
                                           r["action"] in STOCK_MOVING_LEG))
         p["accounts"].add(r["account"])
+        kind = classify(r["action"], _f(r["price"]))   # classified once; both folds read it
+        _apply_units(p, r, kind, today, annotations)
         if r["account"] == "CDP":
             continue                                   # CDP cost comes from cdp-stocks below
-        unk = _apply_txn(p, r, today)
+        unk = _apply_txn(p, r, kind, today)
         if unk is not None:
             _unknown_actions.add(unk)
 
@@ -397,6 +528,7 @@ def _accumulate_positions(txns, divs, cdp, corp_actions, today):
         pos[k]["buy_cost"] += c["buy_cost"]
         pos[k]["buy_qty"] += c["buy_qty"]
         pos[k]["cost_events"].extend(c["cost_events"])
+        pos[k]["cdp_buy_qty"] += c["buy_qty"]
         pos[k]["proceeds"] += sum(a for _, a in c["flows"] if a > 0)
 
     bucket_by_acct_id = {r["account_id"]: r["funding_bucket"] for r in txns}
@@ -418,7 +550,8 @@ def _accumulate_positions(txns, divs, cdp, corp_actions, today):
     return pos, meta
 
 
-def fold_positions(txns, divs, cdp, corp_actions, options, fx, price, today=None):
+def fold_positions(txns, divs, cdp, corp_actions, options, fx, price, today=None,
+                   annotations=None):
     """Pure fold: accumulate per-(funding_bucket, security) positions from already-fetched
     inputs and emit one output row each. No DB or session — every input is plain data, so the
     cost-basis rules (transfer double-count, CDP cost attach, dividend income, corporate-action
@@ -431,9 +564,13 @@ def fold_positions(txns, divs, cdp, corp_actions, options, fx, price, today=None
       corp_actions — iterable of (from_ticker, to_ticker, type) (carry types only).
       options — {ticker: {pl_sgd, ...}} realized options income per underlying.
       fx / price — latest FX map and latest close per security_id. today defaults to today.
+      annotations — {natural key: condition} from portfolio.cost_annotations; the curated list
+              when omitted. The free/transferred distinction is not in the ledger and cannot be
+              put there, so it arrives as data like the corporate actions do.
     """
     today = today or dt.date.today()
-    pos, meta = _accumulate_positions(txns, divs, cdp, corp_actions, today)
+    annotations = annotation_map() if annotations is None else annotations
+    pos, meta = _accumulate_positions(txns, divs, cdp, corp_actions, today, annotations)
     out = []
     for k, p in pos.items():
         m = meta.get(k)
@@ -469,6 +606,12 @@ def compute(session=None):
         corp_actions = s.execute(text(
             "SELECT from_ticker, to_ticker, type FROM corporate_action "
             "WHERE type IN ('rename','split','consolidation','merger','switch')")).all()
+    # the annotation list is curated against THIS ledger, so its audit belongs here rather than
+    # in the fold, which is a pure function over whatever rows it is handed (a fabricated
+    # two-row book is not missing AAPL's gift; it simply never had one).
+    for k, n in unmatched(txns, annotation_map()).items():
+        log.warning("cost annotation %s matched %d txn rows, expected 1 — a stale annotation "
+                    "silently un-frees a lot; a duplicate annotates one nobody looked at", k, n)
     # options open their own session (see realized_by_ticker); fetched outside the DB block above.
     from .options import realized_by_ticker
     options = realized_by_ticker()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,10 +33,15 @@ build = "npm --prefix web ci && npm --prefix web run build"
 dev = ["ruff>=0.16.3", "pytest>=8"]
 
 [tool.pytest.ini_options]
-# `pg` marks the tests that need a real Postgres (tests/*_pg.py, via tests/pgtest.py) because
-# the SQL they cover is Postgres-only — `to_char` month bucketing has no SQLite equivalent.
-# They skip themselves when no server answers, so the default run is unaffected whether or not
-# `make db-up` has been run; `-m "not pg"` deselects them outright.
+# `pg` marks the tests that need a real Postgres. Two kinds, both skipping themselves when no
+# server answers, so the default run is unaffected whether or not `make db-up` has been run;
+# `-m "not pg"` deselects them outright.
+#   tests/*_pg.py           — via tests/pgtest.py, on a THROWAWAY database, because the SQL they
+#                             cover is Postgres-only (`to_char` month bucketing has no SQLite
+#                             equivalent).
+#   test_performance_live.py — reads the APP database, because what it checks is the ledger
+#                             itself: the cost partition must sum on every real position, and
+#                             #148's measured book totals are a regression guard or nothing.
 markers = ["pg: needs a reachable Postgres (make db-up); skips when there is none"]
 
 [tool.ruff]

--- a/tests/test_performance.py
+++ b/tests/test_performance.py
@@ -12,6 +12,7 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
+from portfolio import cost_annotations as ca
 from portfolio import performance as perf
 from portfolio.models import Base, CdpCostLot
 
@@ -59,6 +60,54 @@ class TestClassify(unittest.TestCase):
         """A new action string must shout, not silently mint free units."""
         self.assertEqual(perf.classify("spin-off", 1.0), "unknown")
         self.assertEqual(perf.classify("", None), "unknown")
+
+
+class TestCostAnnotations(unittest.TestCase):
+    """The curated free/transferred list — see portfolio/cost_annotations.py."""
+
+    def _row(self, **over):
+        r = dict(account="Moomoo", canonical_ticker="AAPL", trade_date=D(2022, 12, 28),
+                 action="open/transfer_in", qty_signed=1)
+        r.update(over)
+        return r
+
+    def test_every_curated_row_is_in_scope_and_asserts_a_real_condition(self):
+        """An annotation written against, say, a `buy` would never be consulted — it would sit
+        in the list looking authoritative and doing nothing."""
+        for a in ca.ANNOTATIONS:
+            self.assertIn(a[3], ca.ANNOTATABLE_ACTIONS, a)
+            self.assertIn(a[5], ca.ANNOTATION_CONDITIONS, a)
+
+    def test_the_list_is_the_three_rows_the_spec_names(self):
+        self.assertEqual([(a[1], a[4], a[5]) for a in ca.ANNOTATIONS],
+                         [("AAPL", 1, "free"), ("HMN", 153, "free"), ("D05", 280, "free")])
+
+    def test_an_annotated_row_resolves_to_its_condition(self):
+        self.assertEqual(ca.condition_for(self._row(), ca.annotation_map()), "free")
+
+    def test_an_unannotated_row_of_the_same_shape_resolves_to_nothing(self):
+        """The default is `unknown`, expressed as "no annotation covers this" — the fold, not
+        the list, decides what an uncovered row means."""
+        m = ca.annotation_map()
+        self.assertIsNone(ca.condition_for(self._row(qty_signed=2), m))
+        self.assertIsNone(ca.condition_for(self._row(trade_date=D(2022, 12, 29)), m))
+        self.assertIsNone(ca.condition_for(self._row(canonical_ticker="MSFT"), m))
+        self.assertIsNone(ca.condition_for(self._row(account="FSM"), m))
+
+    def test_unmatched_reports_a_stale_annotation_and_a_twin(self):
+        """Both failures are silent otherwise: a stale key quietly turns a measured free lot
+        back into an unknown one, and a twin annotates a lot nobody looked at."""
+        m = ca.annotation_map()
+        self.assertEqual(ca.unmatched([self._row()], m).get(
+            ("Moomoo", "HMN", D(2023, 5, 28), "open/transfer_in", 153.0)), 0)
+        twins = ca.unmatched([self._row(), self._row()], m)
+        self.assertEqual(twins[("Moomoo", "AAPL", D(2022, 12, 28), "open/transfer_in", 1.0)], 2)
+
+    def test_out_of_scope_actions_are_never_consulted(self):
+        """Scope is `open/transfer_in` and zero-priced `corp action`. A priced corp action is a
+        rights subscription and classifies as cash long before it reaches the list."""
+        ann = {("Moomoo", "AAPL", D(2022, 12, 28), "buy", 1.0): "free"}
+        self.assertIsNone(ca.condition_for(self._row(action="buy"), ann))
 
 
 class TestCdpCost(unittest.TestCase):

--- a/tests/test_performance_fold.py
+++ b/tests/test_performance_fold.py
@@ -11,6 +11,7 @@ Run: PYTHONPATH=. .venv/bin/python -m pytest tests/test_performance_fold.py -q
 import datetime as dt
 
 from portfolio import performance as perf
+from portfolio.cost_annotations import annotation_map
 
 D = dt.date
 TODAY = D(2024, 1, 1)
@@ -110,9 +111,14 @@ def test_switch_carries_cost_and_rebases_qty():
     assert new["cost_basis_native"] == 1000.0       # buy_qty rebased to 90 -> avg cost * 90
     assert new["realised_pl_sgd"] == 0.0            # a switch is not a sale
     assert new["unrealised_pl_sgd"] == 170.0        # 90*13 - 1000
-    # predecessor was zeroed out and no longer carries cost
+    # predecessor was zeroed out and no longer carries cost. NOT `cost_known is False`:
+    # cost_known now reads the partition, and OLD's 100 units entered on a priced buy — they
+    # are `costed` and always were. What the carry moved is the money, not the knowledge.
     old = next(r for r in rows if r["ticker"] == "OLD")
-    assert old["cost_known"] is False
+    assert old["invested_native"] == 0.0
+    assert old["cost_basis_native"] is None
+    assert old["simple_return"] is None             # no denominator left to divide by
+    assert old["cost_partition"]["costed"] == 100.0
 
 
 def test_foreign_currency_converts_at_fx():
@@ -130,9 +136,10 @@ def test_foreign_currency_converts_at_fx():
 # and reach no endpoint.
 # ---------------------------------------------------------------------------
 
-def _acc(txns, *, divs=None, cdp=None, corp=None):
+def _acc(txns, *, divs=None, cdp=None, corp=None, annotations=None):
     """The fold's accumulators, before _build_row flattens them into output rows."""
-    return perf._accumulate_positions(txns, divs or [], cdp or {}, corp or [], TODAY)[0]
+    return perf._accumulate_positions(txns, divs or [], cdp or {}, corp or [], TODAY,
+                                      annotations or annotation_map())[0]
 
 
 def _cdp(*legs):
@@ -191,12 +198,19 @@ def test_cost_events_carry_the_date_the_cost_and_the_quantity():
     _assert_terminal_equal(pos)                      # a sell moves neither cost nor bought qty
 
 
-def test_free_and_uncosted_units_book_no_cost_event():
-    """Bonus shares and a priceless trade move units without moving cost, on both series."""
+def test_free_and_uncosted_units_book_no_cost():
+    """Bonus shares and a priceless trade move units without moving cost, on both series.
+
+    They part company on the DENOMINATOR (#148). A bonus lot is free — a measured zero — so it
+    enters `buy_qty` and books a cost event whose cost really is 0.0, which is what dilutes the
+    average the way a bonus issue should. A priceless buy is `unknown`, not free, so it enters
+    neither: inventing a zero-cost lot there would hand the position units for nothing."""
     pos = _acc([_txn(action="bonus", qty_signed=280, price=None),
                 _txn(action="buy", qty_signed=100, price=None)])
     p = pos[("cash", 10)]
-    assert len(p["unit_events"]) == 2 and p["cost_events"] == []
+    assert len(p["unit_events"]) == 2
+    assert [tuple(e) for e in p["cost_events"]] == [(D(2020, 1, 1), 0.0, 280.0)]
+    assert p["buy_cost"] == 0.0 and p["buy_qty"] == 280.0
     _assert_terminal_equal(pos)
 
 
@@ -271,7 +285,7 @@ ROW_FIELDS = {
     "bucket", "accounts", "ticker", "name", "market", "asset_type", "currency", "units", "price",
     "mv_native", "avg_cost", "cost_basis_native", "cost_basis_sgd", "unrealised_pl_sgd",
     "realised_pl_sgd", "invested_native", "income_native", "fees_sgd", "cost_known",
-    "uncosted_units", "total_pl_native", "invested_sgd", "mv_sgd", "income_sgd", "pl_sgd",
+    "cost_partition", "total_pl_native", "invested_sgd", "mv_sgd", "income_sgd", "pl_sgd",
     "xirr", "simple_return", "options_pl_sgd",
 }
 
@@ -280,3 +294,233 @@ def test_the_dated_series_reach_no_output_row():
     """`No field on any endpoint moves` — the accumulators stay behind _build_row."""
     r = _only(_fold([_txn(qty_signed=100, price=10.0)], price={10: 12.0}))
     assert set(r) == ROW_FIELDS
+
+
+# --------------------------------------------------------------------------------------
+# cost_partition — every entering unit lands in exactly one of costed / free / unknown
+# --------------------------------------------------------------------------------------
+
+def _part(rows, ticker=None):
+    r = next(x for x in rows if ticker is None or x["ticker"] == ticker)
+    return r["cost_partition"]
+
+
+def _sums(p):
+    assert round(p["costed"] + p["free"] + p["unknown"], 4) == p["units_in"], p
+    return p
+
+
+def test_partition_sums_to_units_in_and_precomputes_the_pct():
+    """The self-check the nested object exists to make visible: Σ == units_in, and the
+    frontend does no arithmetic to learn how much of that is unknown."""
+    txns = [_txn(action="buy", qty_signed=100, price=10.0),
+            _txn(action="buy", qty_signed=300, price=None)]      # unpriced -> unknown
+    p = _sums(_part(_fold(txns, price={10: 12.0})))
+    assert p == {"units_in": 400.0, "costed": 100.0, "free": 0.0, "unknown": 300.0,
+                 "unknown_pct": 0.75}
+
+
+def test_priced_trade_units_are_costed():
+    p = _sums(_part(_fold([_txn(qty_signed=100, price=10.0)], price={10: 12.0})))
+    assert (p["costed"], p["free"], p["unknown"]) == (100.0, 0.0, 0.0)
+
+
+def test_units_leaving_are_not_entering_units():
+    """`units_in` is GROSS units in — a sale removes units but never subtracts from it."""
+    txns = [_txn(action="buy", qty_signed=100, price=10.0),
+            _txn(action="sell", qty_signed=-40, price=15.0)]
+    assert _sums(_part(_fold(txns, price={10: 12.0})))["units_in"] == 100.0
+
+
+def test_zero_unit_stock_dividend_echoes_belong_to_no_bucket():
+    """261 of these rows exist: qty 0, price 0, a positive gross_amount. They deliver no
+    units, are cash dividends already counted from the `dividend` table, and must not
+    appear anywhere in the partition."""
+    txns = [_txn(action="buy", qty_signed=100, price=10.0),
+            _txn(action="stock dividend", qty_signed=0, price=0.0, gross_amount=120.0)]
+    p = _sums(_part(_fold(txns, price={10: 12.0})))
+    assert p["units_in"] == 100.0 and p["unknown"] == 0.0
+
+
+def test_mechanically_free_actions_need_no_annotation():
+    """`gifted stock in` and `bonus issuance` are the broker's own word for a gift — the
+    string is not ambiguous, so AMZN, BABA and D05's cpf bonus need no annotation."""
+    for act in ("gifted stock in", "bonus issuance"):
+        txns = [_txn(action="buy", qty_signed=100, price=10.0),
+                _txn(action=act, qty_signed=5, price=None)]
+        p = _sums(_part(_fold(txns, price={10: 12.0})))
+        assert (p["costed"], p["free"], p["unknown"]) == (100.0, 5.0, 0.0), act
+
+
+def test_unannotated_transfer_in_is_unknown_not_free():
+    """C38U's 417: the same `open/transfer_in` string as AAPL's gift, but these were paid
+    for as part of C31's 10,071. Refuse rather than invent a free lot."""
+    txns = [_txn(canonical_ticker="C38U", action="buy", qty_signed=3200, price=2.0),
+            _txn(canonical_ticker="C38U", account="Moomoo", action="open/transfer_in",
+                 qty_signed=417, price=None)]
+    p = _sums(_part(_fold(txns, price={10: 2.0})))
+    assert (p["costed"], p["free"], p["unknown"]) == (3200.0, 0.0, 417.0)
+    assert p["unknown_pct"] == round(417 / 3617, 4)
+
+
+def test_annotated_transfer_in_is_free_and_carries_a_price_of_zero():
+    """AAPL's welcome gift. `free` units carry a price, not only a count: without
+    `cost_basis = 0.0` the component sum is `null + 0 + dividends` on a name whose basis is
+    a MEASURED zero."""
+    txns = [_txn(canonical_ticker="AAPL", account="Moomoo", action="open/transfer_in",
+                 qty_signed=1, price=None, trade_date=D(2022, 12, 28))]
+    r = _only(_fold(txns, price={10: 426.60}))
+    p = _sums(r["cost_partition"])
+    assert (p["costed"], p["free"], p["unknown"]) == (0.0, 1.0, 0.0)
+    assert r["avg_cost"] == 0.0                     # not None — a measured zero
+    assert r["cost_basis_native"] == 0.0
+    assert r["unrealised_pl_sgd"] == 426.60         # mv - 0
+    assert r["realised_pl_sgd"] == 0.0
+    assert r["cost_known"] is True
+
+
+def test_annotation_is_per_transaction_not_per_security():
+    """The day one ticker holds both a gift lot and a real transfer-in, per-security breaks.
+    Same ticker, same action, same account — only the annotated row is free."""
+    txns = [_txn(canonical_ticker="AAPL", account="Moomoo", action="open/transfer_in",
+                 qty_signed=1, price=None, trade_date=D(2022, 12, 28)),
+            _txn(canonical_ticker="AAPL", account="Moomoo", action="open/transfer_in",
+                 qty_signed=50, price=None, trade_date=D(2023, 6, 1))]
+    p = _sums(_part(_fold(txns, price={10: 200.0})))
+    assert (p["costed"], p["free"], p["unknown"]) == (0.0, 1.0, 50.0)
+
+
+def test_annotation_scope_stops_at_the_two_actions_it_was_drawn_for():
+    """A `buy` matching an annotation's other four fields takes no condition from it."""
+    ann = {("Moomoo", "AAPL", D(2022, 12, 28), "buy", 1.0): "free"}
+    txns = [_txn(canonical_ticker="AAPL", account="Moomoo", action="buy",
+                 qty_signed=1, price=None, trade_date=D(2022, 12, 28))]
+    p = _sums(_part(perf.fold_positions(txns, [], {}, [], {}, {}, {10: 200.0}, TODAY,
+                                        annotations=ann)))
+    assert p["unknown"] == 1.0 and p["free"] == 0.0
+
+
+def test_transfer_in_matched_by_a_transfer_out_is_costed():
+    """The CDP->FSM migration: both legs sit in the same (bucket, security) position, so the
+    cost never left. The re-entering units are costed, not a second uncosted lot."""
+    txns = [_txn(action="buy", qty_signed=2800, price=26.17),
+            _txn(action="sell/transfer_out", qty_signed=-2800, price=None),
+            _txn(account="FSM", action="transfer_in", qty_signed=2800, price=None)]
+    p = _sums(_part(_fold(txns, price={10: 30.0})))
+    assert p["units_in"] == 5600.0                  # gross: the units entered twice
+    assert (p["costed"], p["unknown"]) == (5600.0, 0.0)
+
+
+def test_transfer_in_beyond_the_transfer_out_is_unknown():
+    txns = [_txn(action="buy", qty_signed=1000, price=10.0),
+            _txn(action="sell/transfer_out", qty_signed=-1000, price=None),
+            _txn(account="FSM", action="transfer_in", qty_signed=1500, price=None)]
+    p = _sums(_part(_fold(txns, price={10: 12.0})))
+    assert (p["costed"], p["unknown"]) == (2000.0, 500.0)
+
+
+def test_a_carried_unit_is_costed():
+    """9CI's 2,700 arrived as `open/transfer_in` with no price, but C31's cost carried onto
+    them in the 2021 CapitaLand split. Its cost is known; it just came from a predecessor."""
+    txns = [_txn(security_id=1, canonical_ticker="C31", action="buy", qty_signed=2700,
+                 price=3.5, trade_date=D(2020, 1, 1)),
+            _txn(security_id=1, canonical_ticker="C31", action="sell/transfer",
+                 qty_signed=-2700, price=None, trade_date=D(2021, 9, 1)),
+            _txn(security_id=2, canonical_ticker="9CI", account="Moomoo",
+                 action="open/transfer_in", qty_signed=2700, price=None,
+                 trade_date=D(2021, 9, 1))]
+    rows = _fold(txns, corp=[("C31", "9CI", "split")], price={2: 4.0})
+    p = _sums(_part(rows, "9CI"))
+    assert (p["units_in"], p["costed"], p["unknown"]) == (2700.0, 2700.0, 0.0)
+
+
+def test_switched_units_are_costed_by_the_carry_not_by_their_action():
+    txns = [
+        _txn(security_id=1, canonical_ticker="OLD", asset_type="fund", action="buy",
+             qty_signed=100, price=10.0, trade_date=D(2020, 1, 1)),
+        _txn(security_id=1, canonical_ticker="OLD", asset_type="fund", action="sell",
+             qty_signed=-100, price=11.0, trade_date=D(2021, 1, 1)),
+        _txn(security_id=2, canonical_ticker="NEW", asset_type="fund", action="switch_in",
+             qty_signed=90, price=None, trade_date=D(2021, 1, 1)),
+    ]
+    rows = _fold(txns, corp=[("OLD", "NEW", "switch")], price={2: 13.0})
+    p = _sums(_part(rows, "NEW"))
+    assert (p["units_in"], p["costed"], p["unknown"]) == (90.0, 90.0, 0.0)
+
+
+def test_cdp_cost_is_matched_at_position_level_not_per_row():
+    """A CDP txn row is a month-end statement diff and routinely aggregates several
+    trade-dated cost lots. Q01: two CDP rows of 17,000 against one 17,000-unit cost pool —
+    17,000 costed and 17,000 unknown, not a shortfall on each row."""
+    txns = [_txn(canonical_ticker="Q01", account="CDP", action="open", qty_signed=17000,
+                 price=None),
+            _txn(canonical_ticker="Q01", account="CDP", action="buy", qty_signed=17000,
+                 price=None),
+            _txn(canonical_ticker="Q01", account="FSM", action="buy", qty_signed=34000,
+                 price=0.7)]
+    cdp = {"Q01": _cdp((D(2018, 1, 1), -20418.59, 17000.0))}
+    p = _sums(_part(_fold(txns, cdp=cdp, price={10: 0.8})))
+    assert p == {"units_in": 68000.0, "costed": 51000.0, "free": 0.0, "unknown": 17000.0,
+                 "unknown_pct": 0.25}
+
+
+def test_cost_known_is_false_only_when_every_entering_unit_is_unknown():
+    """The tempting simpler rule `unknown == 0` would flip C38U to false and delete its Net
+    from Holdings, Performance and Overview."""
+    refused = _only(_fold([_txn(canonical_ticker="ASTREA6B", account="CDP", action="open",
+                                qty_signed=15000, price=None)], price={10: 1.0}))
+    assert refused["cost_known"] is False
+    caveat = _fold([_txn(canonical_ticker="C38U", action="buy", qty_signed=3200, price=2.0),
+                    _txn(canonical_ticker="C38U", account="Moomoo",
+                         action="open/transfer_in", qty_signed=417, price=None)],
+                   price={10: 2.0})
+    assert _only(caveat)["cost_known"] is True
+
+
+def test_invested_sgd_is_null_when_cost_is_unknown_not_zero():
+    r = _only(_fold([_txn(account="CDP", action="open", qty_signed=15000, price=None)],
+                    price={10: 1.0}))
+    assert r["cost_known"] is False
+    assert r["invested_sgd"] is None
+
+
+def test_uncosted_units_has_left_the_wire():
+    r = _only(_fold([_txn(qty_signed=100, price=None)], price={10: 12.0}))
+    assert "uncosted_units" not in r
+    assert r["cost_partition"]["unknown"] == 100.0
+
+
+def test_xirr_is_suppressed_while_any_entering_unit_is_unknown():
+    txns = [_txn(action="buy", qty_signed=100, price=10.0, trade_date=D(2020, 1, 1)),
+            _txn(action="sell", qty_signed=-100, price=15.0, trade_date=D(2021, 1, 1)),
+            _txn(action="open", account="CDP", qty_signed=50, price=None,
+                 trade_date=D(2021, 1, 1))]
+    assert _only(_fold(txns, price={10: 12.0}))["xirr"] is None
+
+
+def test_a_priced_corp_action_cannot_be_annotated_free():
+    """Scope is zero-priced `corp action`. UD1U's ESR-LOGOS rights at 0.49 are cash the holder
+    paid; an annotation matching their other four fields must not turn them into a gift."""
+    ann = {("FSM", "UD1U", D(2021, 5, 1), "corp action", 9500.0): "free"}
+    txns = [_txn(canonical_ticker="UD1U", action="corp action", qty_signed=9500, price=0.49,
+                 trade_date=D(2021, 5, 1))]
+    p = _sums(_part(perf.fold_positions(txns, [], {}, [], {}, {}, {10: 0.6}, TODAY,
+                                        annotations=ann)))
+    assert (p["costed"], p["free"]) == (9500.0, 0.0)
+
+
+def test_the_carry_costs_the_units_it_arrived_on_not_every_doubtful_one():
+    """A carry is bounded by SHAPE: it promotes the transfer/switch arrivals it travels in, not
+    an unpriced buy that happens to sit on the same name. Without the bound, 9CI's split would
+    silently cost a 500-unit price-less purchase nobody has a receipt for."""
+    txns = [_txn(security_id=1, canonical_ticker="C31", action="buy", qty_signed=2700,
+                 price=3.5, trade_date=D(2020, 1, 1)),
+            _txn(security_id=1, canonical_ticker="C31", action="sell/transfer",
+                 qty_signed=-2700, price=None, trade_date=D(2021, 9, 1)),
+            _txn(security_id=2, canonical_ticker="9CI", account="Moomoo",
+                 action="open/transfer_in", qty_signed=2700, price=None,
+                 trade_date=D(2021, 9, 1)),
+            _txn(security_id=2, canonical_ticker="9CI", account="Moomoo", action="buy",
+                 qty_signed=500, price=None, trade_date=D(2023, 1, 1))]
+    p = _sums(_part(_fold(txns, corp=[("C31", "9CI", "split")], price={2: 4.0}), "9CI"))
+    assert (p["units_in"], p["costed"], p["unknown"]) == (3200.0, 2700.0, 500.0)

--- a/tests/test_performance_fold.py
+++ b/tests/test_performance_fold.py
@@ -11,7 +11,6 @@ Run: PYTHONPATH=. .venv/bin/python -m pytest tests/test_performance_fold.py -q
 import datetime as dt
 
 from portfolio import performance as perf
-from portfolio.cost_annotations import annotation_map
 
 D = dt.date
 TODAY = D(2024, 1, 1)
@@ -139,7 +138,7 @@ def test_foreign_currency_converts_at_fx():
 def _acc(txns, *, divs=None, cdp=None, corp=None, annotations=None):
     """The fold's accumulators, before _build_row flattens them into output rows."""
     return perf._accumulate_positions(txns, divs or [], cdp or {}, corp or [], TODAY,
-                                      annotations or annotation_map())[0]
+                                      {} if annotations is None else annotations)[0]
 
 
 def _cdp(*legs):
@@ -510,9 +509,7 @@ def test_a_priced_corp_action_cannot_be_annotated_free():
 
 
 def test_the_carry_costs_the_units_it_arrived_on_not_every_doubtful_one():
-    """A carry is bounded by SHAPE: it promotes the transfer/switch arrivals it travels in, not
-    an unpriced buy that happens to sit on the same name. Without the bound, 9CI's split would
-    silently cost a 500-unit price-less purchase nobody has a receipt for."""
+    """A carry is bounded by its event: a later transfer with the same shape stays unknown."""
     txns = [_txn(security_id=1, canonical_ticker="C31", action="buy", qty_signed=2700,
                  price=3.5, trade_date=D(2020, 1, 1)),
             _txn(security_id=1, canonical_ticker="C31", action="sell/transfer",
@@ -520,7 +517,33 @@ def test_the_carry_costs_the_units_it_arrived_on_not_every_doubtful_one():
             _txn(security_id=2, canonical_ticker="9CI", account="Moomoo",
                  action="open/transfer_in", qty_signed=2700, price=None,
                  trade_date=D(2021, 9, 1)),
-            _txn(security_id=2, canonical_ticker="9CI", account="Moomoo", action="buy",
+            _txn(security_id=2, canonical_ticker="9CI", account="Moomoo",
+                 action="open/transfer_in",
                  qty_signed=500, price=None, trade_date=D(2023, 1, 1))]
-    p = _sums(_part(_fold(txns, corp=[("C31", "9CI", "split")], price={2: 4.0}), "9CI"))
+    row = next(r for r in _fold(txns, corp=[("C31", "9CI", "split")], price={2: 4.0})
+               if r["ticker"] == "9CI")
+    p = _sums(row["cost_partition"])
     assert (p["units_in"], p["costed"], p["unknown"]) == (3200.0, 2700.0, 500.0)
+    assert p["unknown_pct"] == round(500 / 3200, 4)
+    assert row["cost_known"] is True
+    assert row["pl_sgd"] == 3350.0
+
+
+def test_a_carry_does_not_cost_only_later_unrelated_units():
+    """With no successor arrival at the conversion, later opens have no cost coverage or P/L."""
+    for action in ("open", "transfer_in"):
+        txns = [_txn(security_id=1, canonical_ticker="OLD", action="buy", qty_signed=100,
+                     price=10.0, trade_date=D(2020, 1, 1)),
+                _txn(security_id=1, canonical_ticker="OLD", action="sell/transfer",
+                     qty_signed=-100, price=None, trade_date=D(2021, 1, 1)),
+                _txn(security_id=2, canonical_ticker="NEW", action=action, qty_signed=50,
+                     price=None, trade_date=D(2023, 1, 1))]
+        row = next(r for r in _fold(txns, corp=[("OLD", "NEW", "split")], price={2: 12.0})
+                   if r["ticker"] == "NEW")
+        assert row["cost_partition"] == {
+            "units_in": 50.0, "costed": 0.0, "free": 0.0, "unknown": 50.0,
+            "unknown_pct": 1.0,
+        }
+        assert row["cost_known"] is False
+        assert row["unrealised_pl_sgd"] is None
+        assert row["pl_sgd"] is None

--- a/tests/test_performance_live.py
+++ b/tests/test_performance_live.py
@@ -1,0 +1,132 @@
+"""The cost partition against the LIVE book — the half of #148's acceptance the fabricated
+shapes in tests/test_performance_fold.py cannot reach.
+
+Two claims, deliberately gated differently:
+
+  - **The invariant** — `costed + free + unknown == units_in` on every position — is true of any
+    book, so it runs against whatever ledger is loaded. This is the one that must never drift:
+    `cost_partition`'s own self-check only logs, so without a test a mis-assignment ships.
+  - **The measured totals** — 1,574,652 in / 1,521,274 costed / 545 free / 52,833 unknown, the
+    caveat set, the refusal set — are a point-in-time reading of a 548-row ledger, so they are
+    asserted only while the book is still that book. A ledger that has grown skips them rather
+    than failing; re-measuring is a deliberate act, the way `capture_web_fixtures` is.
+
+Skips cleanly when no Postgres answers — the normal state of a checkout that has not run
+`make db-up`, and the same bargain tests/pgtest.py strikes. Run: `pytest -m pg`.
+
+    PYTHONPATH=. .venv/bin/python -m pytest tests/test_performance_live.py -q
+"""
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+import pytest
+from sqlalchemy import text
+from sqlalchemy.exc import SQLAlchemyError
+
+from portfolio.db import session_scope
+from portfolio.performance import compute
+
+# The ledger #148 was measured against: 548 txn rows / 73 positions. The totals below are
+# readings of THAT book and nothing else.
+MEASURED_TXN_ROWS = 548
+MEASURED = {"units_in": 1_574_652, "costed": 1_521_274, "free": 545, "unknown": 52_833}
+MEASURED_CAVEAT = [("S51", 0.4), ("SET", 0.2786), ("Q01", 0.25), ("C38U", 0.0746)]
+MEASURED_REFUSAL = ["ASTREA6B"]
+
+
+def _rows_or_skip():
+    """The loaded ledger, or a skip. Three ways there is nothing to measure, and all three are
+    the normal state of a machine that is not the one holding the book:
+
+      - no server answers (`OperationalError`) — a checkout that has not run `make db-up`;
+      - the server answers but the app database has no schema (`ProgrammingError`,
+        `relation "txn" does not exist`) — which is CI, where the Postgres service exists for
+        the `*_pg.py` tests and those build their own throwaway schema;
+      - the schema is there and empty.
+
+    Caught as `SQLAlchemyError` rather than the two exact classes because the question this
+    asks is "is there a book here", and every negative answer to it arrives as a database
+    error. A real book that then fails to fold is a genuine failure and propagates."""
+    try:
+        with session_scope() as s:
+            n = s.execute(text("SELECT count(*) FROM txn")).scalar()
+    except SQLAlchemyError as e:
+        raise unittest.SkipTest(f"no ledger to measure (start one with `make db-up` and "
+                                f"`make ingest`): {type(e).__name__}") from None
+    if not n:
+        raise unittest.SkipTest("database has no txn rows — nothing to measure")
+    return compute(), n
+
+
+@pytest.mark.pg
+class TestLiveBook(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.rows, cls.n_txn = _rows_or_skip()
+
+    def _measured_book_or_skip(self):
+        if self.n_txn != MEASURED_TXN_ROWS:
+            raise unittest.SkipTest(
+                f"ledger has {self.n_txn} txn rows, not the {MEASURED_TXN_ROWS} these figures "
+                f"were measured against — re-measure deliberately, don't loosen the assertion")
+
+    def test_the_partition_sums_to_units_in_on_every_position(self):
+        """True of any book. The one assertion that is not a point-in-time reading."""
+        for r in self.rows:
+            p = r["cost_partition"]
+            self.assertAlmostEqual(p["costed"] + p["free"] + p["unknown"], p["units_in"], 4,
+                                   f"{r['bucket']}/{r['ticker']}: {p}")
+
+    def test_unknown_pct_agrees_with_the_counts_it_summarises(self):
+        for r in self.rows:
+            p = r["cost_partition"]
+            want = round(p["unknown"] / p["units_in"], 4) if p["units_in"] else 0.0
+            self.assertEqual(p["unknown_pct"], want, f"{r['bucket']}/{r['ticker']}: {p}")
+
+    def test_cost_known_is_false_exactly_where_every_entering_unit_is_unknown(self):
+        for r in self.rows:
+            p = r["cost_partition"]
+            all_unknown = p["units_in"] > 0 and p["unknown"] == p["units_in"]
+            self.assertEqual(r["cost_known"], not all_unknown and p["units_in"] > 0,
+                             f"{r['bucket']}/{r['ticker']}: {p}")
+
+    def test_uncosted_units_is_gone_and_invested_sgd_is_null_where_cost_is_unknown(self):
+        for r in self.rows:
+            self.assertNotIn("uncosted_units", r)
+            if not r["cost_known"]:
+                self.assertIsNone(r["invested_sgd"], r["ticker"])
+
+    def test_the_book_totals(self):
+        self._measured_book_or_skip()
+        self.assertEqual(len(self.rows), 73)
+        for k, want in MEASURED.items():
+            got = sum(r["cost_partition"][k] for r in self.rows)
+            self.assertEqual(round(got), want, k)
+
+    def test_the_caveat_set_and_the_refusal_set(self):
+        self._measured_book_or_skip()
+        caveat = sorted(((r["ticker"], r["cost_partition"]["unknown_pct"]) for r in self.rows
+                         if r["cost_known"] and r["cost_partition"]["unknown"] > 0),
+                        key=lambda t: -t[1])
+        self.assertEqual(caveat, MEASURED_CAVEAT)
+        self.assertEqual([r["ticker"] for r in self.rows if not r["cost_known"]],
+                         MEASURED_REFUSAL)
+
+    def test_the_two_free_lots_reproduce_their_component_sums(self):
+        """`free -> cost_basis 0.0` is what makes these sums a number at all — without it
+        AAPL's is `null + 0 + 1.22` on a name whose basis is a MEASURED zero."""
+        self._measured_book_or_skip()
+        for ticker, want in (("AAPL", 427.82), ("HMN", 144.57)):
+            r = next(r for r in self.rows if r["ticker"] == ticker)
+            self.assertEqual(r["cost_partition"]["free"], r["cost_partition"]["units_in"])
+            self.assertEqual(r["avg_cost"], 0.0)
+            self.assertEqual(r["cost_basis_sgd"], 0.0)
+            total = (r["unrealised_pl_sgd"] + r["realised_pl_sgd"] + r["income_sgd"]
+                     + r["options_pl_sgd"])
+            self.assertAlmostEqual(total, want, 2, ticker)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/web/src/modules/portfolio/Holdings.jsx
+++ b/web/src/modules/portfolio/Holdings.jsx
@@ -81,7 +81,7 @@ const netOf = (r) => {
  *
  * Avg cost is the interesting one: it folds **exactly**, not approximately. `cost_basis` is
  * `avg_cost × units`, so pooled cost basis over pooled units *is* the true weighted average
- * (D05 → 24.7283 from 26.1747 and 21.0464). It wants no caveat in the UI.
+ * (D05 → 22.4802 from 23.7952 and 19.1331). It wants no caveat in the UI.
  */
 const sumOf = (rs, f) => rs.reduce((a, r) => a + (f(r) || 0), 0);
 
@@ -89,6 +89,13 @@ const sumOf = (rs, f) => rs.reduce((a, r) => a + (f(r) || 0), 0);
 // holds nothing — contributes 0 rather than erasing the open side's real figure.
 const sumOrNull = (rs, f) =>
   rs.every((r) => f(r) == null) ? null : sumOf(rs, f);
+
+// Sum the legs' cost partitions into the merged row's own — see the note at its call site.
+const foldPartition = (rs) => {
+  const p = { units_in: 0, costed: 0, free: 0, unknown: 0 };
+  for (const r of rs) for (const k of Object.keys(p)) p[k] += r.cost_partition?.[k] || 0;
+  return { ...p, unknown_pct: p.units_in > 0 ? p.unknown / p.units_in : 0 };
+};
 
 function mergeTicker(rows) {
   if (rows.length === 1) return rows[0];
@@ -130,7 +137,11 @@ function mergeTicker(rows) {
     cost_known: costKnown,
     net_folded: netFolded,                                   // folded Net for netOf to consume
     net_partial: netPartial,                                 // whether any leg is partial
-    uncosted_units: sumOf(rs, (r) => r.uncosted_units),
+    // The partition folds by addition — every leg's entering units are that leg's own, so no
+    // unit is counted twice and the three conditions stay a partition of the merged total.
+    // `unknown_pct` is recomputed rather than averaged: a mean of two percentages is not the
+    // percentage of the merged counts.
+    cost_partition: foldPartition(rs),
     mv_native: sumOf(rs, (r) => r.mv_native),
     mv_sgd: sumOf(rs, (r) => r.mv_sgd),
     income_native: sumOf(rs, (r) => r.income_native),


### PR DESCRIPTION
Closes #148. Implements spec #143 §7 (part of map #126).

A boolean cannot say the thing that is actually true of Q01: **17,000 of its 68,000 units
entered with no recorded cost**. So `cost_known` stops being the whole answer and becomes a
reading of one. Every entering unit now lands in exactly one of `costed`, `free` or `unknown`,
computed after the corporate-action carry and the switch rebasing run, and the three sum to
gross units in on all 73 live positions.

```json
"cost_partition": { "units_in": 68000, "costed": 51000, "free": 0,
                    "unknown": 17000, "unknown_pct": 0.25 }
```

Nested so the counts cannot drift apart among ~25 flat siblings and the self-check is visible
in one place; `unknown_pct` is pre-computed so the frontend does no arithmetic.

## Acceptance, measured against the live book

| criterion | result |
|---|---|
| `cost_partition` on every position row, nested, `unknown_pct` pre-computed | ✅ |
| `costed + free + unknown == units_in` — fabricated shapes **and** all 73 live positions | ✅ 73/73 exact |
| totals **1,574,652 in / 1,521,274 costed / 545 free / 52,833 unknown** | ✅ exact |
| caveat set S51 40.0%, SET 27.9%, Q01 25.0%, C38U 7.5%; refusal set ASTREA6B alone | ✅ exact |
| `free → cost_basis 0.0` and `unknown → cost_basis null` separately gated; AAPL 427.82, HMN 144.57 | ✅ exact |
| `cost_known` false exactly where every entering unit is unknown; `uncosted_units` gone; `invested_sgd` null | ✅ |
| `/api/performance` and `/api/overview` do not move | ❌ — **they move; see below** |

## The four rules

- **The action string cannot decide free from transferred.** Every unpriced carry-in is
  `open/transfer_in` on one account, covering a landed corporate-action carry, a real in-specie
  distribution and two windfalls. The distinction lives in a per-transaction annotation
  (`portfolio/cost_annotations.py`) defaulting to `unknown` — three rows, keyed on
  `(account, canonical ticker, date, action, qty)` so a re-ingest cannot orphan them. Scope is
  `open/transfer_in` and zero-priced `corp action`, enforced **structurally**: a priced row
  classifies as cash before the list is ever consulted, so a rights subscription cannot be
  annotated free. `gifted stock in` and `bonus issuance` are mechanical and need none.
- **A carried unit is `costed`** — its cost came from a predecessor. Bounded by *shape*: only
  the transfer/switch arrivals a carry travels in are promoted, so an unpriced buy on a carried
  name stays `unknown`.
- **Free units carry a price, not only a count.** They enter `buy_qty` at zero cost, so
  `cost_basis` is a measured `0.0` rather than null.
- **CDP cost is matched at position level, not per row.** A CDP row is a month-end statement
  diff aggregating several trade-dated lots; per-row matching invents shortfalls on LIW, S7OU,
  D05, J2T and Z74 that do not exist. The same reasoning covers the CDP→FSM migration: a
  transfer in whose paired transfer out sits in the same position is costed, because the cost
  never left. Without it, **205,090 units** read as entering twice with nothing behind them.

`cost_known` is redefined **in place** — false only when *every* entering unit is unknown — so
all five call sites are correct with no change. Not the simpler `unknown == 0`, which would flip
C38U to false and delete its 7,756.75 Net from Holdings, Performance and Overview.

## What moves, and why

The ticket asked that `/api/performance` and `/api/overview` not move. **They do**, and only
where this change is the correction:

- **Overview P/L 478,989.73 → 479,665.76 (+676.03)** — AAPL, HMN and AMZN previously had
  `cost_known: false` and were excluded from every rollup. Valuing a measured zero is the point
  of §7.
- **Capital falls, unrealised rises on D05 and BABA**, realised falling to match (net per
  position invariant). D05 cash's cost basis was **80,618.12 against 73,289.20 ever invested** —
  the 280 bonus units inflated it and booked a phantom **7,328.92 realised gain on a position
  that sold nothing**. Now exactly 73,289.20 and 0.00.
- **XIRR suppressed on Q01, S51, SET** — the three held positions with unknown entering units.
  S51 was reporting 242% p.a. over flows missing 40% of their cost.

Everything else in both endpoints is byte-identical.

## Rebased onto #147

#147 landed on main while this was in review and touches the same fold. Three seams needed
deciding rather than merging:

- **A free lot books a dated cost event.** Free units enter `buy_qty`, and #147's dated cost
  series mirrors that scalar — so a free lot is booked through `_book_buy` at a cost of
  exactly `0.0`. #147's criterion is terminal equality on *every* shape, and a series that
  agrees with its scalars on one path and not the other is worse than no series at all. This
  changes one of #147's own tests: a bonus lot's `cost_events` is now
  `[(date, 0.0, 280.0)]`, not `[]`. A priceless *buy* is `unknown`, not free, so it
  still books neither.
- **Transfer cover is keyed on #147's `STOCK_MOVING_LEG`**, not a second list of the same
  spellings — "moved stock rather than traded it" is this rule's premise too. It is also the
  sharper set: it catches `transfer out` (a standing gap in `ZERO_CASH`) and declines a
  negative `corp action`, which removes units in a consolidation and backs nothing.
- **The annotation audit moved from the fold to `compute()`.** The fold is a pure function
  over whatever rows it is handed; a fabricated two-row test book is not missing AAPL's gift,
  it simply never had one.

Every live figure above is identical before and after the rebase.

## Known limit

The carry is bounded by shape, not by date, so a carried name taking a *second* unpriced
transfer in would be promoted on cost that never covered it. Bounding by date needs the
accumulators to carry one — the prefactor in #147. The docstring says so at the site.

## Two hygiene facts, recorded so nobody writes them

- **There is no scrip correction.** Zero `scrip` / `scrip dividend` / `script dividend` rows
  exist in `txn`; the four live in `cdp_cost_lot` with a negative amount and are already
  invested. No scrip spelling is in `FREE_ACTION`, with a comment saying why.
- **No unclassified action fires**, and `ZERO_CASH` keeps doing both its jobs — splitting it
  would leave `stock dividend` homeless and resurrect a double count of every dividend.

## Tests

- `tests/test_performance_fold.py` — 27 fabricated shapes: the partition's self-check, the
  annotation's per-transaction scope, transfer cover, the carry bound, CDP position-level
  matching, the `cost_known` rule, the free lot's zero price.
- `tests/test_performance.py` — the annotation list's own guards, including `unmatched()`,
  which warns when a key matches zero txn rows (a stale annotation silently un-frees a lot) or
  two (the key cannot tell twins apart — `ingestion.load`'s occurrence counter does).
- `tests/test_performance_live.py` (new, `pg`-marked) — against the real ledger: the Σ
  invariant on **any** book, and the measured figures only while the book is still the 548-row
  one they were read from. Skips rather than fails after the next ingest.

**500 python tests pass**, ruff clean, and the full local Playwright suite is green —
**1500 passed, 477 skipped, 0 failed** (14.7m).

## Docs

`CONTEXT.md` retires **Uncosted units** and gains **Cost partition** and **Cost annotation**;
`BACKEND.md` replaces a stale "31/37 positions" paragraph with the partition rules.

https://claude.ai/code/session_01A4mnHgCc2bqJwzv5gjFpva


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer cost classification for holdings, distinguishing costed, free, and unknown units.
  * Added cost details to position records, including unit counts and unknown-cost percentages.
  * Added transaction-level annotations for free and transferred holdings.
* **Improvements**
  * Cost information now carries through transfers, corporate actions, and consolidated ticker rows.
  * Updated cost-known, invested-value, and return calculations to account for zero-cost holdings.
* **Documentation**
  * Updated backend and portfolio terminology to explain cost partitions and annotations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->