### PR TITLE
The four cell states in the fold (#149)

### DIFF
--- a/BACKEND.md
+++ b/BACKEND.md
@@ -99,17 +99,20 @@ drift apart among ~25 flat siblings and the self-check is visible in one place.
 
 ## The four cell states
 
-A missing number on a position row means one of four things, and the fold says which so the page
-can render each differently. The rule is *has this stream ever existed*, not *is the number zero*.
+A missing number on a position row means one of four things. The **fold names which** so a page
+can render each differently; the rendering itself is not here — the detail page still says `n/a`
+where it now means *not known*, and #158 / #159 land the words. The rule is *has this stream ever
+existed*, not *is the number zero*.
 
-| state | meaning | renders |
+| state | meaning | intended rendering |
 |---|---|---|
 | omitted | the stream has never existed for this ticker | row absent |
 | `0` | the stream exists and measured zero | `0` |
 | `—` | structurally impossible | `—` |
 | not known | the stream exists but is unmeasurable | words |
 
-So `null` means **exactly one thing per field**:
+So `null` means **exactly one thing per field**. `income_sgd` is named on the first line by
+#143 §6 and is **not** done: it still ships `0.0` on a name that never paid a dividend.
 
 - **`options_pl_sgd` null means the stream never existed** — a never-optioned ticker omits the
   row rather than carrying a permanent `Options 0` line (61 of 73 legs live). An optioned name
@@ -126,7 +129,12 @@ So `null` means **exactly one thing per field**:
   always entered.
 - **`stock_pl_sgd` joins every row.** `realised + unrealised` is identically
   `proceeds − buy_cost + mv`, so the **pair's sum is sound while neither member is** — which is
-  what lets a doubted name show an arithmetically exact Net. `rollup()` accumulates it and
-  `/api/performance` builds `net_pl_sgd` from it, so the four caveat legs' stock P/L stays in the
-  group total instead of vanishing with the split. On every leg that knows both members it is
-  identically their sum, so no group figure moves.
+  what lets a doubted name show an arithmetically exact Net. Where both members exist it is
+  rounded *from* them, so §14's measured cent stays where it already is rather than opening a
+  second gap between a sum and its parts.
+- **The group says what its two columns do not reach.** `rollup()` accumulates `stock_pl_sgd` and
+  `/api/performance` builds `net_pl_sgd` from it, so the four doubted legs' stock P/L stays in the
+  group total instead of vanishing with the split — every group net is unchanged to the cent.
+  Beside it, `unsplit_pl_sgd` is the part of that total no leg could attribute to either member,
+  so `realised + unrealised + unsplit == stock_pl` on every group and the Performance table marks
+  those two cells `~` instead of printing a short column beside a whole Net.

--- a/BACKEND.md
+++ b/BACKEND.md
@@ -96,3 +96,37 @@ drift apart among ~25 flat siblings and the self-check is visible in one place.
   unknown. Not `unknown == 0`, which would flip C38U to false and delete its 7,756.75 Net.
   Live, the refusal set is ASTREA6B alone; the caveat set is S51 40.0%, SET 27.9%, Q01 25.0%,
   C38U 7.5%.
+
+## The four cell states
+
+A missing number on a position row means one of four things, and the fold says which so the page
+can render each differently. The rule is *has this stream ever existed*, not *is the number zero*.
+
+| state | meaning | renders |
+|---|---|---|
+| omitted | the stream has never existed for this ticker | row absent |
+| `0` | the stream exists and measured zero | `0` |
+| `—` | structurally impossible | `—` |
+| not known | the stream exists but is unmeasurable | words |
+
+So `null` means **exactly one thing per field**:
+
+- **`options_pl_sgd` null means the stream never existed** — a never-optioned ticker omits the
+  row rather than carrying a permanent `Options 0` line (61 of 73 legs live). An optioned name
+  still ships a number when that number is zero. Dividends and options can be *absent* but never
+  *unmeasurable*: cash received is always known. The `—` state is leg-level — a non-cash leg of
+  an optioned name — and is reconstructed where the ticker's own option book is in view, not here.
+- **`avg_cost`, both cost-basis fields and the realised/unrealised pair null mean *not known***,
+  and it is the **partition** that decides it, never the unit count. A leg holding `unknown`
+  units cannot price the shares it still has, so all five go null together. A leg whose every
+  unit entered priced *can* price them — even when it holds none left — and ships the measured
+  zero: nulling on `units ≈ 0` would say *not known* of TSLA and of F34's closed cpf leg, whose
+  Net (940.00) is exact and whose unrealised is a genuine zero, and F34's second bucket column
+  would stop adding up. Realised and unrealised can be *unmeasurable* but never *absent*: units
+  always entered.
+- **`stock_pl_sgd` joins every row.** `realised + unrealised` is identically
+  `proceeds − buy_cost + mv`, so the **pair's sum is sound while neither member is** — which is
+  what lets a doubted name show an arithmetically exact Net. `rollup()` accumulates it and
+  `/api/performance` builds `net_pl_sgd` from it, so the four caveat legs' stock P/L stays in the
+  group total instead of vanishing with the split. On every leg that knows both members it is
+  identically their sum, so no group figure moves.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -102,6 +102,33 @@ in the ledger, which has nowhere to put it. Scope is `open/transfer_in` and zero
 _Avoid_: per-security override (rejected — it breaks the day one ticker holds both a gift lot
 and a real transfer-in)
 
+**Cell state**:
+Which of **four** things a missing number means. The rule is *has this stream ever existed*, not
+*is the number zero* — a closed position keeps its `Realised 0` while a name that never paid a
+dividend loses the row outright.
+
+- **Omitted** — the stream has never existed for this ticker; the row is absent.
+- **Zero** — the stream exists and measured zero.
+- **Impossible** — structurally cannot exist for this leg; renders `—`.
+- **Not known** — the stream exists but is unmeasurable; renders in words.
+
+`null` therefore means **exactly one** of these per field, and the contract says which:
+`options_pl_sgd` null means *omitted* (cash received is always known, so an options stream can
+be absent but never unmeasurable); `realised_pl_sgd`, `unrealised_pl_sgd`, `stock_pl_sgd`,
+`avg_cost` and both cost-basis fields null mean *not known* (units always entered, so those can
+be unmeasurable but never absent).
+_Avoid_: "n/a" (it reads as *not applicable*, i.e. impossible, on cells that mean *not known*),
+empty (says which pixels are blank, not which of the four facts is being stated)
+
+**Stock P/L**:
+`realised + unrealised` — the whole result on the shares themselves, dividends and option
+premiums excluded. Identically `proceeds − buy_cost + mv`, which needs no split of the cost
+between the units sold and the units held: the **pair's sum is sound while neither member is**,
+which is what lets a name the partition doubts still show a Net that is arithmetically exact.
+Ships on every row (`stock_pl_sgd`), not only the doubtful ones — a field that appears only
+where the split fails is a field nobody can add up.
+_Avoid_: total P/L (that is stock P/L *plus* dividends and premiums — the Net)
+
 ### Returns
 
 **Money-weighted return (XIRR)**:

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -104,8 +104,8 @@ and a real transfer-in)
 
 **Cell state**:
 Which of **four** things a missing number means. The rule is *has this stream ever existed*, not
-*is the number zero* — a closed position keeps its `Realised 0` while a name that never paid a
-dividend loses the row outright.
+*is the number zero* — a closed position keeps its `Realised 0` while a name that never traded an
+option loses the row outright.
 
 - **Omitted** — the stream has never existed for this ticker; the row is absent.
 - **Zero** — the stream exists and measured zero.
@@ -116,9 +116,12 @@ dividend loses the row outright.
 `options_pl_sgd` null means *omitted* (cash received is always known, so an options stream can
 be absent but never unmeasurable); `realised_pl_sgd`, `unrealised_pl_sgd`, `stock_pl_sgd`,
 `avg_cost` and both cost-basis fields null mean *not known* (units always entered, so those can
-be unmeasurable but never absent).
-_Avoid_: "n/a" (it reads as *not applicable*, i.e. impossible, on cells that mean *not known*),
-empty (says which pixels are blank, not which of the four facts is being stated)
+be unmeasurable but never absent). `income_sgd` belongs on the first line by #143 §6 and does
+**not** ship that way yet — it is still `0.0` on a name that never paid, so nothing can tell
+*never paid* from *paid zero*.
+_Avoid_: "n/a" (it reads as *not applicable*, i.e. impossible, on cells that mean *not known* —
+the wording the detail page still uses, which #158 replaces with words), empty (says which pixels
+are blank, not which of the four facts is being stated)
 
 **Stock P/L**:
 `realised + unrealised` — the whole result on the shares themselves, dividends and option

--- a/portfolio/performance.py
+++ b/portfolio/performance.py
@@ -441,15 +441,30 @@ def _build_row(k, p, m, fx, price, today):
     # a free lot has a cost of zero, so it has no denominator — a percentage return on nothing
     # is not a smaller number, it is not a number.
     simple = (total_pl / p["invested"]) if (cost_known and p["invested"] > 1e-6) else None
-    # cost basis of CURRENT holding (avg cost × held units) + unrealised P/L. `is not None`,
-    # not truthiness: a free lot's avg cost is 0.0, which is a measured price and must not be
-    # read as "no answer" (AAPL's basis is zero because the unit was a gift).
-    avg_cost = (p["buy_cost"] / p["buy_qty"]) if p["buy_qty"] > 1e-6 else None
-    cost_basis = (avg_cost * p["units"]) if (avg_cost is not None and p["units"] > 1e-6) else None
+    # §6: `null` on the cost-basis family means one thing — *not known*. So it is the PARTITION
+    # that decides it, never the unit count. A leg holding unknown units cannot price the shares
+    # it still has, and everything derived from that price goes null; a leg whose every unit
+    # entered priced CAN price them, even when it holds none left, and ships the measured zero.
+    # Nulling on `units ≈ 0` instead would say `not known` of TSLA and of F34's closed cpf leg —
+    # whose Net is exact and whose unrealised is a genuine zero — and stop the bucket column
+    # adding up.
+    priceable = cost_known and part["unknown"] < 1e-6
+    # cost basis of CURRENT holding (avg cost × held units). `is not None`, not truthiness: a
+    # free lot's avg cost is 0.0, which is a measured price and must not be read as "no answer"
+    # (AAPL's basis is zero because the unit was a gift).
+    avg_cost = (p["buy_cost"] / p["buy_qty"]) if (priceable and p["buy_qty"] > 1e-6) else None
+    # avg_cost is None on a priceable leg only when nothing ever entered `buy_qty` — the emptied
+    # predecessor of a carry, whose scalars the carry zeroed. Its basis is zero, not unknown.
+    cost_basis = (avg_cost * p["units"]) if avg_cost is not None else (0.0 if priceable else None)
     unreal = (mv - cost_basis) if cost_basis is not None else None
     # realised stock P/L = sell proceeds − cost of the shares sold (buy_cost minus the
-    # cost still tied up in the current holding). Closed positions: cost_basis None -> all sold.
-    realised = (p["proceeds"] - p["buy_cost"] + (cost_basis or 0.0)) if cost_known else None
+    # cost still tied up in the current holding).
+    realised = (p["proceeds"] - p["buy_cost"] + cost_basis) if cost_basis is not None else None
+    # the pair's SUM is sound while neither member is: realised + unrealised is identically
+    # proceeds − buy_cost + mv, and that needs no split of the cost between sold and held units.
+    # It joins EVERY row, not only the caveats — it is what lets a caveat show a Net that is
+    # arithmetically exact, and a row that carries it only sometimes is a row nobody can add up.
+    stock_pl = (p["proceeds"] - p["buy_cost"] + mv) if cost_known else None
     return {
         "bucket": k[0], "accounts": sorted(p["accounts"]), "ticker": m["canonical_ticker"],
         "name": m["name"], "market": m["market"], "asset_type": m["asset_type"], "currency": ccy,
@@ -459,6 +474,7 @@ def _build_row(k, p, m, fx, price, today):
         "cost_basis_sgd": _rn(cost_basis, 2, rate),
         "unrealised_pl_sgd": _rn(unreal, 2, rate),
         "realised_pl_sgd": _rn(realised, 2, rate),
+        "stock_pl_sgd": _rn(stock_pl, 2, rate),
         "invested_native": round(p["invested"], 2), "income_native": round(p["income"], 2),
         "fees_sgd": round(p["fees"] * rate, 2), "cost_known": cost_known,
         "cost_partition": part,
@@ -586,7 +602,11 @@ def fold_positions(txns, divs, cdp, corp_actions, options, fx, price, today=None
     # (no stock position) are still counted in the Performance rollup via options.realized_by().
     for r in out:
         o = options.get(r["ticker"]) if r["bucket"] == "cash" else None
-        r["options_pl_sgd"] = o["pl_sgd"] if o else 0.0
+        # §6: null means the stream NEVER EXISTED, so the row is omitted — 51 of 63 names stop
+        # carrying a permanent `Options 0` line. An optioned name still ships a number when that
+        # number is zero: "the stream measured zero" and "there is no stream" are different facts
+        # and the page renders them differently.
+        r["options_pl_sgd"] = o["pl_sgd"] if o else None
     return out
 
 
@@ -641,7 +661,7 @@ def empty_group():
     synthesises for orphan option underlyings match rollup()'s schema exactly."""
     return {"mv_sgd": 0.0, "income_sgd": 0.0, "pl_sgd": 0.0, "cost_sgd": 0.0,
             "capital_sgd": 0.0, "invested_sgd": 0.0,
-            "realised_pl_sgd": 0.0, "unrealised_pl_sgd": 0.0}
+            "realised_pl_sgd": 0.0, "unrealised_pl_sgd": 0.0, "stock_pl_sgd": 0.0}
 
 
 def rollup(rows, by):
@@ -663,6 +683,10 @@ def rollup(rows, by):
             g["invested_sgd"] += r["invested_sgd"] or 0
             g["realised_pl_sgd"] += r["realised_pl_sgd"] or 0
             g["unrealised_pl_sgd"] += r["unrealised_pl_sgd"] or 0
+            # a caveat leg knows the pair's sum and neither member (#149 §6), so summing the
+            # members alone would silently drop its stock P/L out of the group. `stock_pl_sgd`
+            # is the accumulator /api/performance builds its Net from, for that reason.
+            g["stock_pl_sgd"] += r["stock_pl_sgd"] or 0
     return {k: {kk: round(vv, 2) for kk, vv in v.items()} for k, v in agg.items()}
 
 

--- a/portfolio/performance.py
+++ b/portfolio/performance.py
@@ -441,29 +441,33 @@ def _build_row(k, p, m, fx, price, today):
     # a free lot has a cost of zero, so it has no denominator — a percentage return on nothing
     # is not a smaller number, it is not a number.
     simple = (total_pl / p["invested"]) if (cost_known and p["invested"] > 1e-6) else None
-    # §6: `null` on the cost-basis family means one thing — *not known*. So it is the PARTITION
-    # that decides it, never the unit count. A leg holding unknown units cannot price the shares
-    # it still has, and everything derived from that price goes null; a leg whose every unit
-    # entered priced CAN price them, even when it holds none left, and ships the measured zero.
-    # Nulling on `units ≈ 0` instead would say `not known` of TSLA and of F34's closed cpf leg —
-    # whose Net is exact and whose unrealised is a genuine zero — and stop the bucket column
-    # adding up.
+    # #143 §6: `null` on the cost-basis family means one thing — *not known*. So it is the
+    # PARTITION that decides it, never the unit count. A leg holding unknown units cannot price
+    # the shares it still has, and everything derived from that price goes null; a leg whose
+    # every unit entered priced CAN price them, even holding none left, and ships the measured
+    # zero. Nulling on `units ≈ 0` instead would say `not known` of TSLA and of F34's closed cpf
+    # leg — whose Net is exact and whose unrealised is a genuine zero — and stop the bucket
+    # column adding up.
     priceable = cost_known and part["unknown"] < 1e-6
-    # cost basis of CURRENT holding (avg cost × held units). `is not None`, not truthiness: a
-    # free lot's avg cost is 0.0, which is a measured price and must not be read as "no answer"
-    # (AAPL's basis is zero because the unit was a gift).
-    avg_cost = (p["buy_cost"] / p["buy_qty"]) if (priceable and p["buy_qty"] > 1e-6) else None
-    # avg_cost is None on a priceable leg only when nothing ever entered `buy_qty` — the emptied
-    # predecessor of a carry, whose scalars the carry zeroed. Its basis is zero, not unknown.
-    cost_basis = (avg_cost * p["units"]) if avg_cost is not None else (0.0 if priceable else None)
+    # cost basis of CURRENT holding (avg cost × held units). A priceable leg with nothing in
+    # `buy_qty` is the emptied predecessor of a carry (C31, 0P00006FYT), whose scalars the carry
+    # zeroed: it prices at zero, because what the carry moved is the money, not the knowledge.
+    # The whole family answers together or not at all — `avg_cost: null` beside `cost_basis: 0.0`
+    # would be one leg saying both "not known" and "measured zero" of the same fact.
+    avg_cost = ((p["buy_cost"] / p["buy_qty"]) if p["buy_qty"] > 1e-6 else 0.0) \
+        if priceable else None
+    # `is not None`, not truthiness: a free lot's avg cost is 0.0, which is a measured price and
+    # must not be read as "no answer" (AAPL's basis is zero because the unit was a gift).
+    cost_basis = (avg_cost * p["units"]) if avg_cost is not None else None
     unreal = (mv - cost_basis) if cost_basis is not None else None
     # realised stock P/L = sell proceeds − cost of the shares sold (buy_cost minus the
     # cost still tied up in the current holding).
     realised = (p["proceeds"] - p["buy_cost"] + cost_basis) if cost_basis is not None else None
     # the pair's SUM is sound while neither member is: realised + unrealised is identically
     # proceeds − buy_cost + mv, and that needs no split of the cost between sold and held units.
-    # It joins EVERY row, not only the caveats — it is what lets a caveat show a Net that is
-    # arithmetically exact, and a row that carries it only sometimes is a row nobody can add up.
+    # It joins EVERY row, not only the doubted ones — it is what lets a doubted name show a Net
+    # that is arithmetically exact, and a row that carries it only sometimes is a row nobody can
+    # add up.
     stock_pl = (p["proceeds"] - p["buy_cost"] + mv) if cost_known else None
     return {
         "bucket": k[0], "accounts": sorted(p["accounts"]), "ticker": m["canonical_ticker"],
@@ -474,7 +478,14 @@ def _build_row(k, p, m, fx, price, today):
         "cost_basis_sgd": _rn(cost_basis, 2, rate),
         "unrealised_pl_sgd": _rn(unreal, 2, rate),
         "realised_pl_sgd": _rn(realised, 2, rate),
-        "stock_pl_sgd": _rn(stock_pl, 2, rate),
+        # rounded FROM the members where the members exist, not independently beside them: the
+        # cent §14 measures on five tickers is `_build_row` rounding each component at 2dp, and
+        # a third rounding of the same quantity would put that cent between this field and the
+        # two it is the sum of. Where the pair collapses there is nothing to sum, so it rounds
+        # the identity instead.
+        "stock_pl_sgd": (round(_rn(realised, 2, rate) + _rn(unreal, 2, rate), 2)
+                         if realised is not None and unreal is not None
+                         else _rn(stock_pl, 2, rate)),
         "invested_native": round(p["invested"], 2), "income_native": round(p["income"], 2),
         "fees_sgd": round(p["fees"] * rate, 2), "cost_known": cost_known,
         "cost_partition": part,
@@ -602,10 +613,10 @@ def fold_positions(txns, divs, cdp, corp_actions, options, fx, price, today=None
     # (no stock position) are still counted in the Performance rollup via options.realized_by().
     for r in out:
         o = options.get(r["ticker"]) if r["bucket"] == "cash" else None
-        # §6: null means the stream NEVER EXISTED, so the row is omitted — 51 of 63 names stop
-        # carrying a permanent `Options 0` line. An optioned name still ships a number when that
-        # number is zero: "the stream measured zero" and "there is no stream" are different facts
-        # and the page renders them differently.
+        # #143 §6: null means the stream NEVER EXISTED, so the row is omitted — 61 of the live
+        # book's 73 legs stop carrying a permanent `Options 0` line. An optioned name still ships
+        # a number when that number is zero: "the stream measured zero" and "there is no stream"
+        # are different facts, and the states they belong to render differently.
         r["options_pl_sgd"] = o["pl_sgd"] if o else None
     return out
 
@@ -660,8 +671,8 @@ def empty_group():
     """Zeroed rollup-group accumulator. Shared with server.main so the groups it
     synthesises for orphan option underlyings match rollup()'s schema exactly."""
     return {"mv_sgd": 0.0, "income_sgd": 0.0, "pl_sgd": 0.0, "cost_sgd": 0.0,
-            "capital_sgd": 0.0, "invested_sgd": 0.0,
-            "realised_pl_sgd": 0.0, "unrealised_pl_sgd": 0.0, "stock_pl_sgd": 0.0}
+            "capital_sgd": 0.0, "invested_sgd": 0.0, "realised_pl_sgd": 0.0,
+            "unrealised_pl_sgd": 0.0, "stock_pl_sgd": 0.0, "unsplit_pl_sgd": 0.0}
 
 
 def rollup(rows, by):
@@ -683,10 +694,16 @@ def rollup(rows, by):
             g["invested_sgd"] += r["invested_sgd"] or 0
             g["realised_pl_sgd"] += r["realised_pl_sgd"] or 0
             g["unrealised_pl_sgd"] += r["unrealised_pl_sgd"] or 0
-            # a caveat leg knows the pair's sum and neither member (#149 §6), so summing the
-            # members alone would silently drop its stock P/L out of the group. `stock_pl_sgd`
-            # is the accumulator /api/performance builds its Net from, for that reason.
+            # a leg the partition doubts knows the pair's SUM and neither member (#143 §6), so
+            # summing the members alone would silently drop its stock P/L out of the group.
+            # `stock_pl_sgd` is the accumulator /api/performance builds its Net from, for that
+            # reason, and `unsplit_pl_sgd` is the part of it no leg could attribute to either
+            # member — so `realised + unrealised + unsplit == stock_pl` on every group, and a
+            # page showing the two members can say how much they do not reach rather than
+            # printing a short column beside a whole Net.
             g["stock_pl_sgd"] += r["stock_pl_sgd"] or 0
+            if r["realised_pl_sgd"] is None or r["unrealised_pl_sgd"] is None:
+                g["unsplit_pl_sgd"] += r["stock_pl_sgd"] or 0
     return {k: {kk: round(vv, 2) for kk, vv in v.items()} for k, v in agg.items()}
 
 

--- a/server/main.py
+++ b/server/main.py
@@ -277,9 +277,11 @@ def performance(by: str = Query("market", enum=["market", "bucket", "account"]))
         r[k]["options_pl_sgd"] = v
     for g in r.values():
         g.setdefault("options_pl_sgd", 0.0)
-        # net = unrealised + realised stock P/L + dividends + option premiums
-        g["net_pl_sgd"] = round(g["unrealised_pl_sgd"] + g["realised_pl_sgd"]
-                                + g["income_sgd"] + g["options_pl_sgd"], 2)
+        # net = stock P/L + dividends + option premiums. `stock_pl_sgd`, not the pair, because
+        # a leg whose partition holds unknown units knows the SUM and neither member (#149 §6):
+        # adding the members would drop C38U's and S51's stock P/L out of the group total. On
+        # every leg that knows both, stock_pl_sgd is identically their sum, so nothing moves.
+        g["net_pl_sgd"] = round(g["stock_pl_sgd"] + g["income_sgd"] + g["options_pl_sgd"], 2)
         # ROI on total money ever deployed (incl. since-sold positions)
         g["return_pct"] = round(g["net_pl_sgd"] / g["invested_sgd"], 4) if g.get("invested_sgd") else None
     return r

--- a/tests/test_performance_fold.py
+++ b/tests/test_performance_fold.py
@@ -62,9 +62,13 @@ def test_partial_sell_books_realised_pl():
 def test_transfer_legs_do_not_book_proceeds_or_pl():
     """CDP->FSM style move: transfer_out at market value + its paired transfer_in net to a still
     fully-held position. The transfer must not read as a sale (no proceeds, no realised P/L)."""
+    # the ledger's own spellings, which matter now that the partition reads them (#148): the
+    # out leg is the cover the in leg draws on, so the re-entering units are costed rather than
+    # a second unpriced lot — and the components stay knowable (#149). `transfer out`, with a
+    # space, is a standing gap in ZERO_CASH and lives only in `cdp_cost_lot`.
     txns = [_txn(action="buy", qty_signed=100, price=10.0),
-            _txn(action="transfer out", qty_signed=-100, price=15.0),   # positive-value move
-            _txn(action="transfer in", qty_signed=100, price=15.0)]
+            _txn(action="sell/transfer_out", qty_signed=-100, price=15.0),  # positive-value move
+            _txn(action="transfer_in", qty_signed=100, price=15.0)]
     r = _only(_fold(txns, price={10: 12.0}))
     assert r["units"] == 100.0
     assert r["realised_pl_sgd"] == 0.0              # nothing was actually sold
@@ -86,7 +90,10 @@ def test_options_income_attaches_to_cash_bucket_only():
     # a non-cash bucket position for the same ticker must NOT pick up the cash-account options P/L
     cpf = _fold([_txn(funding_bucket="cpf", account="CPF", qty_signed=100, price=10.0)],
                 options={"D05": {"pl_sgd": 123.45}}, price={10: 10.0})
-    assert _only(cpf)["options_pl_sgd"] == 0.0
+    # null, not 0.0: at leg level "no options stream here" is all this row knows. The `—`
+    # state §6 draws for a non-cash leg of an OPTIONED name is reconstructed one level up,
+    # where the ticker's own option book is in view; a leg cannot tell the two apart alone.
+    assert _only(cpf)["options_pl_sgd"] is None
 
 
 def test_switch_carries_cost_and_rebases_qty():
@@ -115,7 +122,10 @@ def test_switch_carries_cost_and_rebases_qty():
     # are `costed` and always were. What the carry moved is the money, not the knowledge.
     old = next(r for r in rows if r["ticker"] == "OLD")
     assert old["invested_native"] == 0.0
-    assert old["cost_basis_native"] is None
+    # 0.0, not None: the carry took OLD's money, not the knowledge that its 100 units were
+    # bought at a price. It holds nothing, so its basis is a measured zero (#149 §6) — `null`
+    # here would say `not known` of a leg whose every unit entered priced.
+    assert old["cost_basis_native"] == 0.0
     assert old["simple_return"] is None             # no denominator left to divide by
     assert old["cost_partition"]["costed"] == 100.0
 
@@ -283,7 +293,8 @@ def test_non_cash_carry_replays_cost_and_quantity_at_the_original_dates():
 ROW_FIELDS = {
     "bucket", "accounts", "ticker", "name", "market", "asset_type", "currency", "units", "price",
     "mv_native", "avg_cost", "cost_basis_native", "cost_basis_sgd", "unrealised_pl_sgd",
-    "realised_pl_sgd", "invested_native", "income_native", "fees_sgd", "cost_known",
+    "realised_pl_sgd", "stock_pl_sgd", "invested_native", "income_native", "fees_sgd",
+    "cost_known",
     "cost_partition", "total_pl_native", "invested_sgd", "mv_sgd", "income_sgd", "pl_sgd",
     "xirr", "simple_return", "options_pl_sgd",
 }
@@ -547,3 +558,126 @@ def test_a_carry_does_not_cost_only_later_unrelated_units():
         assert row["cost_known"] is False
         assert row["unrealised_pl_sgd"] is None
         assert row["pl_sgd"] is None
+
+
+# --------------------------------------------------------------------------------------
+# The four cell states (#149). `null` means exactly one thing per field: on `options_pl_sgd`
+# it means the stream never existed (the row is omitted), on the cost-basis family and the
+# realised/unrealised pair it means *not known*. Which is why the rule is "has this stream
+# ever existed", not "is the number zero" — a closed leg's Unrealised is a measured 0.0.
+# --------------------------------------------------------------------------------------
+
+def test_a_never_optioned_ticker_omits_the_options_stream():
+    """51 of 63 names carry a permanent `Options 0` line today. `null` is the row's absence."""
+    assert _only(_fold([_txn(qty_signed=100, price=10.0)], price={10: 12.0}))[
+        "options_pl_sgd"] is None
+
+
+def test_an_optioned_ticker_ships_a_number_even_when_it_is_zero():
+    """The stream exists and measured zero — which is a different fact from never existing."""
+    rows = _fold([_txn(qty_signed=100, price=10.0)], price={10: 12.0},
+                 options={"D05": {"pl_sgd": 0.0}})
+    assert _only(rows)["options_pl_sgd"] == 0.0
+
+
+def test_a_closed_leg_ships_a_measured_zero_basis_not_null():
+    """TSLA's shape: bought, sold out, holds nothing. Its cost basis is not *unknown* — it is
+    zero, and every unit that entered was priced. Nulling it would say `not known` under §6 and
+    stop the bucket column adding up."""
+    r = _only(_fold([_txn(qty_signed=100, price=10.0, trade_date=D(2020, 1, 1)),
+                     _txn(qty_signed=-100, price=15.0, trade_date=D(2021, 1, 1))]))
+    assert r["units"] == 0.0
+    assert (r["cost_basis_native"], r["cost_basis_sgd"]) == (0.0, 0.0)
+    assert r["unrealised_pl_sgd"] == 0.0             # measured zero, not "not known"
+    assert r["realised_pl_sgd"] == 500.0             # 1500 proceeds − 1000 cost
+    assert r["avg_cost"] == 10.0
+
+
+def test_an_f34_shaped_name_keeps_both_bucket_columns_adding_up():
+    """F34's shape: one open leg, one closed, in different buckets. Each leg's components must
+    sum to its own Net, which is what makes the second bucket column reconcile."""
+    rows = _fold([_txn(funding_bucket="cash", qty_signed=100, price=10.0,
+                       trade_date=D(2020, 1, 1)),
+                  _txn(funding_bucket="cpf", account="CPF", qty_signed=40, price=10.0,
+                       trade_date=D(2020, 1, 1)),
+                  _txn(funding_bucket="cpf", account="CPF", qty_signed=-40, price=13.5,
+                       trade_date=D(2021, 1, 1))], price={10: 12.0})
+    closed = next(r for r in rows if r["bucket"] == "cpf")
+    assert (closed["cost_basis_sgd"], closed["unrealised_pl_sgd"]) == (0.0, 0.0)
+    assert closed["realised_pl_sgd"] == 140.0        # 540 − 400
+    for r in rows:
+        assert r["realised_pl_sgd"] + r["unrealised_pl_sgd"] == r["stock_pl_sgd"]
+
+
+def test_a_partition_holding_unknown_units_cannot_price_what_it_holds():
+    """C38U's shape — some units priced, some not. The average of a partly-priced lot is not a
+    price, so avg cost, both cost-basis fields and BOTH members of the pair go null. `Net` is
+    unaffected: `cost_known` stays true, because a name with some cost still answers the
+    question the page asks."""
+    r = _only(_fold([_txn(canonical_ticker="C38U", qty_signed=6283, price=2.0),
+                     _txn(canonical_ticker="C38U", account="Moomoo",
+                          action="open/transfer_in", qty_signed=417, price=None)],
+                    price={10: 2.5}))
+    assert r["cost_partition"]["unknown"] == 417.0
+    assert r["cost_known"] is True
+    assert r["avg_cost"] is None
+    assert r["cost_basis_native"] is None and r["cost_basis_sgd"] is None
+    assert r["realised_pl_sgd"] is None and r["unrealised_pl_sgd"] is None
+    assert r["pl_sgd"] is not None                   # the Net is still exact
+
+
+def test_the_pair_sums_even_where_neither_member_is_known():
+    """realised + unrealised is identically proceeds − buy_cost + mv, so the PAIR is sound
+    while each member is not — which is what lets a caveat show an arithmetically exact Net."""
+    r = _only(_fold([_txn(canonical_ticker="C38U", qty_signed=6283, price=2.0),
+                     _txn(canonical_ticker="C38U", account="Moomoo",
+                          action="open/transfer_in", qty_signed=417, price=None)],
+                    price={10: 2.5}))
+    # 6700 * 2.5 − 6283 * 2.0 = 16750 − 12566
+    assert r["stock_pl_sgd"] == 4184.0
+    assert r["realised_pl_sgd"] is None and r["unrealised_pl_sgd"] is None
+
+
+def test_stock_pl_joins_every_row_and_equals_the_pair_where_both_are_known():
+    for txns, price in (([_txn(qty_signed=100, price=10.0)], {10: 12.0}),
+                        ([_txn(qty_signed=100, price=10.0, trade_date=D(2020, 1, 1)),
+                          _txn(qty_signed=-100, price=15.0, trade_date=D(2021, 1, 1))], {}),
+                        ([_txn(action="open/transfer_in", qty_signed=100, price=None)],
+                         {10: 12.0})):
+        r = _only(_fold(txns, price=price))
+        assert "stock_pl_sgd" in r
+        if r["realised_pl_sgd"] is not None and r["unrealised_pl_sgd"] is not None:
+            assert r["realised_pl_sgd"] + r["unrealised_pl_sgd"] == r["stock_pl_sgd"]
+
+
+def test_a_name_with_no_cost_at_all_knows_none_of_it():
+    """Every entering unit unknown: the pair, the basis and the sum are all `not known`."""
+    r = _only(_fold([_txn(account="CDP", action="open", qty_signed=15000, price=None)],
+                    price={10: 1.0}))
+    assert r["cost_known"] is False
+    assert (r["avg_cost"], r["cost_basis_native"], r["cost_basis_sgd"]) == (None, None, None)
+    assert (r["realised_pl_sgd"], r["unrealised_pl_sgd"], r["stock_pl_sgd"]) == (None, None, None)
+
+
+def test_free_units_ship_a_measured_zero_basis_not_null():
+    """AAPL's welcome gift. `free → 0.0` and `unknown → null` are the two halves the partition
+    was drawn to separate, and this is the half that must not read as `not known`."""
+    txns = [_txn(canonical_ticker="AAPL", account="Moomoo", action="open/transfer_in",
+                 qty_signed=1, price=None, trade_date=D(2022, 12, 28))]
+    r = _only(_fold(txns, price={10: 426.60}))
+    assert (r["avg_cost"], r["cost_basis_native"], r["cost_basis_sgd"]) == (0.0, 0.0, 0.0)
+    assert r["unrealised_pl_sgd"] == 426.60
+    assert r["realised_pl_sgd"] == 0.0
+    assert r["stock_pl_sgd"] == 426.60
+
+
+def test_the_rollup_keeps_a_caveat_legs_stock_pl():
+    """The pair going null must not delete money from /api/performance: the group carries the
+    sum the caveat leg still knows, so `Σ group net` is what it was."""
+    rows = _fold([_txn(canonical_ticker="C38U", qty_signed=6283, price=2.0),
+                  _txn(canonical_ticker="C38U", account="Moomoo",
+                       action="open/transfer_in", qty_signed=417, price=None)],
+                 price={10: 2.5})
+    g = perf.rollup(rows, "bucket")["cash"]
+    assert g["realised_pl_sgd"] == 0.0 and g["unrealised_pl_sgd"] == 0.0
+    assert g["stock_pl_sgd"] == 4184.0

--- a/tests/test_performance_fold.py
+++ b/tests/test_performance_fold.py
@@ -609,15 +609,20 @@ def test_an_f34_shaped_name_keeps_both_bucket_columns_adding_up():
         assert r["realised_pl_sgd"] + r["unrealised_pl_sgd"] == r["stock_pl_sgd"]
 
 
+# C38U's shape, which three of the tests below need: 6,283 units bought at a price and 417 that
+# arrived unpriced and unannotated. Its stock P/L is 6700*2.5 − 6283*2.0 = 16,750 − 12,566.
+CAVEAT_TXNS = [_txn(canonical_ticker="C38U", qty_signed=6283, price=2.0),
+               _txn(canonical_ticker="C38U", account="Moomoo", action="open/transfer_in",
+                    qty_signed=417, price=None)]
+CAVEAT_PRICE = {10: 2.5}
+CAVEAT_STOCK_PL = 4184.0
+
+
 def test_a_partition_holding_unknown_units_cannot_price_what_it_holds():
-    """C38U's shape — some units priced, some not. The average of a partly-priced lot is not a
-    price, so avg cost, both cost-basis fields and BOTH members of the pair go null. `Net` is
-    unaffected: `cost_known` stays true, because a name with some cost still answers the
-    question the page asks."""
-    r = _only(_fold([_txn(canonical_ticker="C38U", qty_signed=6283, price=2.0),
-                     _txn(canonical_ticker="C38U", account="Moomoo",
-                          action="open/transfer_in", qty_signed=417, price=None)],
-                    price={10: 2.5}))
+    """The average of a partly-priced lot is not a price, so avg cost, both cost-basis fields
+    and BOTH members of the pair go null. `Net` is unaffected: `cost_known` stays true, because
+    a name with some cost still answers the question the page asks."""
+    r = _only(_fold(CAVEAT_TXNS, price=CAVEAT_PRICE))
     assert r["cost_partition"]["unknown"] == 417.0
     assert r["cost_known"] is True
     assert r["avg_cost"] is None
@@ -629,12 +634,8 @@ def test_a_partition_holding_unknown_units_cannot_price_what_it_holds():
 def test_the_pair_sums_even_where_neither_member_is_known():
     """realised + unrealised is identically proceeds − buy_cost + mv, so the PAIR is sound
     while each member is not — which is what lets a caveat show an arithmetically exact Net."""
-    r = _only(_fold([_txn(canonical_ticker="C38U", qty_signed=6283, price=2.0),
-                     _txn(canonical_ticker="C38U", account="Moomoo",
-                          action="open/transfer_in", qty_signed=417, price=None)],
-                    price={10: 2.5}))
-    # 6700 * 2.5 − 6283 * 2.0 = 16750 − 12566
-    assert r["stock_pl_sgd"] == 4184.0
+    r = _only(_fold(CAVEAT_TXNS, price=CAVEAT_PRICE))
+    assert r["stock_pl_sgd"] == CAVEAT_STOCK_PL
     assert r["realised_pl_sgd"] is None and r["unrealised_pl_sgd"] is None
 
 
@@ -671,13 +672,28 @@ def test_free_units_ship_a_measured_zero_basis_not_null():
     assert r["stock_pl_sgd"] == 426.60
 
 
-def test_the_rollup_keeps_a_caveat_legs_stock_pl():
+def test_the_rollup_keeps_a_caveat_legs_stock_pl_and_says_it_could_not_split_it():
     """The pair going null must not delete money from /api/performance: the group carries the
-    sum the caveat leg still knows, so `Σ group net` is what it was."""
-    rows = _fold([_txn(canonical_ticker="C38U", qty_signed=6283, price=2.0),
-                  _txn(canonical_ticker="C38U", account="Moomoo",
-                       action="open/transfer_in", qty_signed=417, price=None)],
-                 price={10: 2.5})
-    g = perf.rollup(rows, "bucket")["cash"]
+    sum the caveat leg still knows, and names the part of it neither member reached, so the
+    columns a page prints beside Net can say they are short rather than read as whole."""
+    g = perf.rollup(_fold(CAVEAT_TXNS, price=CAVEAT_PRICE), "bucket")["cash"]
     assert g["realised_pl_sgd"] == 0.0 and g["unrealised_pl_sgd"] == 0.0
-    assert g["stock_pl_sgd"] == 4184.0
+    assert g["stock_pl_sgd"] == CAVEAT_STOCK_PL
+    assert g["unsplit_pl_sgd"] == CAVEAT_STOCK_PL
+
+
+def test_the_rollup_ties_realised_plus_unrealised_plus_unsplit_to_stock_pl():
+    """The identity that makes `unsplit_pl_sgd` checkable rather than a second opinion."""
+    rows = _fold([_txn(qty_signed=100, price=10.0, trade_date=D(2020, 1, 1)),
+                  _txn(qty_signed=-40, price=15.0, trade_date=D(2021, 1, 1))],
+                 price={10: 12.0}) + _fold(CAVEAT_TXNS, price=CAVEAT_PRICE)
+    for g in perf.rollup(rows, "bucket").values():
+        assert round(g["realised_pl_sgd"] + g["unrealised_pl_sgd"]
+                     + g["unsplit_pl_sgd"], 2) == round(g["stock_pl_sgd"], 2)
+
+
+def test_a_group_with_nothing_unsplit_says_so_with_a_zero():
+    """`unsplit` is an amount, not a flag: a group whose every leg split its pair reaches its
+    stock P/L exactly, and a page keys its marker off that zero."""
+    g = perf.rollup(_fold([_txn(qty_signed=100, price=10.0)], price={10: 12.0}), "bucket")["cash"]
+    assert g["unsplit_pl_sgd"] == 0.0

--- a/tests/test_performance_live.py
+++ b/tests/test_performance_live.py
@@ -133,14 +133,20 @@ class TestLiveBook(unittest.TestCase):
 
     # -- the four cell states (#149) ------------------------------------------------------
 
-    def test_the_options_stream_is_absent_or_a_number_never_a_standing_zero(self):
-        """True of any book: `0.0` on a never-optioned name is a permanent `Options 0` line
-        on 61 of 73 legs. Absent and zero are different facts and render differently."""
+    def test_the_options_stream_is_absent_exactly_where_no_options_were_traded(self):
+        """True of any book. An optioned name may legitimately ship `0.0` — the stream exists
+        and measured zero — so the rule is about ABSENCE, not about the value."""
+        from portfolio.options import realized_by_ticker
+        traded = realized_by_ticker()
         for r in self.rows:
-            o = r["options_pl_sgd"]
-            self.assertTrue(o is None or isinstance(o, float), f"{r['ticker']}: {o!r}")
-            if o is not None:
-                self.assertNotEqual(o, 0.0, f"{r['ticker']} ships a zero-valued stream")
+            want = r["bucket"] == "cash" and r["ticker"] in traded
+            self.assertEqual(r["options_pl_sgd"] is not None, want,
+                             f"{r['bucket']}/{r['ticker']}: {r['options_pl_sgd']!r}")
+
+    def test_how_many_legs_the_options_row_leaves(self):
+        """The measured size of the change: 61 of 73 legs stop carrying `Options 0`."""
+        self._measured_book_or_skip()
+        self.assertEqual(sum(1 for r in self.rows if r["options_pl_sgd"] is None), 61)
 
     def test_a_closed_leg_ships_measured_zeros_not_nulls(self):
         """True of any book. This is the one that decides whether a bucket column adds up:
@@ -150,6 +156,15 @@ class TestLiveBook(unittest.TestCase):
                 continue
             for f in ("cost_basis_native", "cost_basis_sgd", "unrealised_pl_sgd"):
                 self.assertEqual(r[f], 0.0, f"{r['bucket']}/{r['ticker']}.{f}")
+
+    def test_the_cost_basis_family_answers_together_or_not_at_all(self):
+        """True of any book. `avg_cost: null` beside `cost_basis: 0.0` would be one leg saying
+        both "not known" and "measured zero" of the same fact — which is what an emptied
+        predecessor (C31, 0P00006FYT) used to do."""
+        for r in self.rows:
+            answered = {f: r[f] is not None for f in
+                        ("avg_cost", "cost_basis_native", "cost_basis_sgd")}
+            self.assertEqual(len(set(answered.values())), 1, f"{r['ticker']}: {answered}")
 
     def test_a_leg_holding_unknown_units_nulls_the_whole_cost_basis_family(self):
         """True of any book: an average over a partly-priced lot is not a price, so every
@@ -169,21 +184,21 @@ class TestLiveBook(unittest.TestCase):
             self.assertIn("stock_pl_sgd", r)
             self.assertEqual(r["stock_pl_sgd"] is None, not r["cost_known"], r["ticker"])
             if r["realised_pl_sgd"] is not None and r["unrealised_pl_sgd"] is not None:
-                # to the cent, not exactly: `_build_row` rounds each component independently at
-                # 2dp, which is a measured 1¢ on five tickers (§14 names them — UD1U, 00468,
-                # 01310, 01523, 00101). §14's zero tolerance is on the summary, which rounds
-                # once; tightening it here would only push the rounding somewhere less honest.
-                self.assertAlmostEqual(r["realised_pl_sgd"] + r["unrealised_pl_sgd"],
-                                       r["stock_pl_sgd"], delta=0.01,
-                                       msg=f"{r['bucket']}/{r['ticker']}")
+                # exactly, with no tolerance: the field is rounded FROM the members, so §14's
+                # measured cent (UD1U, 00468, 01310, 01523, 00101 — `_build_row` rounding each
+                # component at 2dp) stays where it already is and does not open a second gap
+                # between this field and the two it is the sum of.
+                self.assertEqual(round(r["realised_pl_sgd"] + r["unrealised_pl_sgd"], 2),
+                                 r["stock_pl_sgd"], f"{r['bucket']}/{r['ticker']}")
 
     def test_the_caveat_legs_keep_their_stock_pl_out_of_the_pair(self):
-        """The four names the partition doubts. Their components are `not known` and their
-        Net is exact — the whole reason the pair ships as a sum as well as as two members."""
-        self._measured_book_or_skip()
+        """The names the partition doubts: their components are `not known` and their Net is
+        exact — the whole reason the pair ships as a sum as well as as two members. Derived
+        from the partition rather than checked against `MEASURED_CAVEAT`, because the claim is
+        about every doubted leg, not about which legs this ledger happens to doubt."""
         caveat = {r["ticker"]: r for r in self.rows
                   if r["cost_known"] and r["cost_partition"]["unknown"] > 0}
-        self.assertEqual(sorted(caveat), sorted(t for t, _ in MEASURED_CAVEAT))
+        self.assertTrue(caveat, "no doubted leg in this book — nothing to assert")
         for t, r in caveat.items():
             self.assertIsNone(r["realised_pl_sgd"], t)
             self.assertIsNone(r["unrealised_pl_sgd"], t)
@@ -206,15 +221,23 @@ class TestLiveBook(unittest.TestCase):
                           tsla["realised_pl_sgd"], tsla["pl_sgd"]), (0.0, 0.0, 0.0, 0.0, 0.0))
         self.assertNotEqual(tsla["options_pl_sgd"], 0.0)   # the stream exists and is real
 
-    def test_the_group_net_survives_the_pair_going_null(self):
-        """`Σ group net` must not move because four legs stopped splitting their stock P/L:
-        the group reads `stock_pl_sgd`, which is what those legs still know."""
+    def test_every_group_ties_its_two_members_and_its_unsplit_to_its_stock_pl(self):
+        """`Σ group net` must not move because four legs stopped splitting their stock P/L. The
+        group carries the whole sum and names the part neither member reached, so what a page
+        prints beside Net adds up to it — which is the claim a reader can check."""
         for by in ("market", "bucket", "account"):
-            g = rollup(self.rows, by)
-            want = sum(r["stock_pl_sgd"] or 0 for r in self.rows
-                       if r["cost_known"] and not (r["units"] <= 1e-6 and not r["cost_known"]
-                                                   and abs(r["income_sgd"]) < 1e-6))
-            self.assertAlmostEqual(sum(v["stock_pl_sgd"] for v in g.values()), want, 2, by)
+            for k, v in rollup(self.rows, by).items():
+                self.assertAlmostEqual(v["realised_pl_sgd"] + v["unrealised_pl_sgd"]
+                                       + v["unsplit_pl_sgd"], v["stock_pl_sgd"],
+                                       delta=0.01, msg=f"{by}/{k}")
+
+    def test_the_unsplit_amount_is_exactly_the_doubted_legs_stock_pl(self):
+        """It is not a plug: every cent of it comes from a leg the partition doubts."""
+        self._measured_book_or_skip()
+        want = sum(r["stock_pl_sgd"] for r in self.rows
+                   if r["cost_known"] and r["cost_partition"]["unknown"] > 0)
+        got = sum(v["unsplit_pl_sgd"] for v in rollup(self.rows, "bucket").values())
+        self.assertAlmostEqual(got, want, delta=0.01)
 
 
 if __name__ == "__main__":

--- a/tests/test_performance_live.py
+++ b/tests/test_performance_live.py
@@ -26,7 +26,7 @@ from sqlalchemy import text
 from sqlalchemy.exc import SQLAlchemyError
 
 from portfolio.db import session_scope
-from portfolio.performance import compute
+from portfolio.performance import compute, rollup
 
 # The ledger #148 was measured against: 548 txn rows / 73 positions. The totals below are
 # readings of THAT book and nothing else.
@@ -123,9 +123,98 @@ class TestLiveBook(unittest.TestCase):
             self.assertEqual(r["cost_partition"]["free"], r["cost_partition"]["units_in"])
             self.assertEqual(r["avg_cost"], 0.0)
             self.assertEqual(r["cost_basis_sgd"], 0.0)
-            total = (r["unrealised_pl_sgd"] + r["realised_pl_sgd"] + r["income_sgd"]
-                     + r["options_pl_sgd"])
+            # the sum is over the components AS SHIPPED (#143 §14): neither name was ever
+            # optioned, so `options_pl_sgd` is null — the stream is absent, and an absent
+            # stream contributes nothing rather than a zero somebody has to explain.
+            self.assertIsNone(r["options_pl_sgd"], ticker)
+            total = (r["unrealised_pl_sgd"] + r["realised_pl_sgd"] + r["income_sgd"])
             self.assertAlmostEqual(total, want, 2, ticker)
+
+
+    # -- the four cell states (#149) ------------------------------------------------------
+
+    def test_the_options_stream_is_absent_or_a_number_never_a_standing_zero(self):
+        """True of any book: `0.0` on a never-optioned name is a permanent `Options 0` line
+        on 61 of 73 legs. Absent and zero are different facts and render differently."""
+        for r in self.rows:
+            o = r["options_pl_sgd"]
+            self.assertTrue(o is None or isinstance(o, float), f"{r['ticker']}: {o!r}")
+            if o is not None:
+                self.assertNotEqual(o, 0.0, f"{r['ticker']} ships a zero-valued stream")
+
+    def test_a_closed_leg_ships_measured_zeros_not_nulls(self):
+        """True of any book. This is the one that decides whether a bucket column adds up:
+        every leg that sold out but priced every unit it ever held knows its basis is zero."""
+        for r in self.rows:
+            if r["units"] > 1e-6 or not r["cost_known"] or r["cost_partition"]["unknown"]:
+                continue
+            for f in ("cost_basis_native", "cost_basis_sgd", "unrealised_pl_sgd"):
+                self.assertEqual(r[f], 0.0, f"{r['bucket']}/{r['ticker']}.{f}")
+
+    def test_a_leg_holding_unknown_units_nulls_the_whole_cost_basis_family(self):
+        """True of any book: an average over a partly-priced lot is not a price, so every
+        field derived from one goes null together — never some of them."""
+        for r in self.rows:
+            family = ("avg_cost", "cost_basis_native", "cost_basis_sgd",
+                      "realised_pl_sgd", "unrealised_pl_sgd")
+            if r["cost_known"] and not r["cost_partition"]["unknown"]:
+                continue
+            self.assertEqual([r[f] for f in family], [None] * len(family),
+                             f"{r['bucket']}/{r['ticker']}")
+
+    def test_stock_pl_is_on_every_row_and_is_the_pair_wherever_the_pair_is_known(self):
+        """True of any book. `realised + unrealised ≡ proceeds − buy_cost + mv`, so the pair's
+        sum survives a split nobody can make — which is what lets a caveat show an exact Net."""
+        for r in self.rows:
+            self.assertIn("stock_pl_sgd", r)
+            self.assertEqual(r["stock_pl_sgd"] is None, not r["cost_known"], r["ticker"])
+            if r["realised_pl_sgd"] is not None and r["unrealised_pl_sgd"] is not None:
+                # to the cent, not exactly: `_build_row` rounds each component independently at
+                # 2dp, which is a measured 1¢ on five tickers (§14 names them — UD1U, 00468,
+                # 01310, 01523, 00101). §14's zero tolerance is on the summary, which rounds
+                # once; tightening it here would only push the rounding somewhere less honest.
+                self.assertAlmostEqual(r["realised_pl_sgd"] + r["unrealised_pl_sgd"],
+                                       r["stock_pl_sgd"], delta=0.01,
+                                       msg=f"{r['bucket']}/{r['ticker']}")
+
+    def test_the_caveat_legs_keep_their_stock_pl_out_of_the_pair(self):
+        """The four names the partition doubts. Their components are `not known` and their
+        Net is exact — the whole reason the pair ships as a sum as well as as two members."""
+        self._measured_book_or_skip()
+        caveat = {r["ticker"]: r for r in self.rows
+                  if r["cost_known"] and r["cost_partition"]["unknown"] > 0}
+        self.assertEqual(sorted(caveat), sorted(t for t, _ in MEASURED_CAVEAT))
+        for t, r in caveat.items():
+            self.assertIsNone(r["realised_pl_sgd"], t)
+            self.assertIsNone(r["unrealised_pl_sgd"], t)
+            self.assertIsNotNone(r["stock_pl_sgd"], t)
+            self.assertIsNotNone(r["pl_sgd"], t)          # the Net is still exact
+
+    def test_the_shapes_the_ticket_was_gated_on(self):
+        """F34 (one open leg, one closed) and TSLA (closed, no units, real options P/L against
+        a `pl_sgd` of 0) — the two live shapes #149's acceptance names."""
+        self._measured_book_or_skip()
+        legs = {r["bucket"]: r for r in self.rows if r["ticker"] == "F34"}
+        self.assertEqual(sorted(legs), ["cash", "cpf"])
+        self.assertEqual((legs["cpf"]["cost_basis_sgd"], legs["cpf"]["unrealised_pl_sgd"],
+                          legs["cpf"]["realised_pl_sgd"]), (0.0, 0.0, 520.0))
+        for r in legs.values():                            # each column adds up on its own
+            self.assertAlmostEqual(r["realised_pl_sgd"] + r["unrealised_pl_sgd"]
+                                   + r["income_sgd"], r["pl_sgd"], 2, r["bucket"])
+        tsla = next(r for r in self.rows if r["ticker"] == "TSLA")
+        self.assertEqual((tsla["units"], tsla["cost_basis_sgd"], tsla["unrealised_pl_sgd"],
+                          tsla["realised_pl_sgd"], tsla["pl_sgd"]), (0.0, 0.0, 0.0, 0.0, 0.0))
+        self.assertNotEqual(tsla["options_pl_sgd"], 0.0)   # the stream exists and is real
+
+    def test_the_group_net_survives_the_pair_going_null(self):
+        """`Σ group net` must not move because four legs stopped splitting their stock P/L:
+        the group reads `stock_pl_sgd`, which is what those legs still know."""
+        for by in ("market", "bucket", "account"):
+            g = rollup(self.rows, by)
+            want = sum(r["stock_pl_sgd"] or 0 for r in self.rows
+                       if r["cost_known"] and not (r["units"] <= 1e-6 and not r["cost_known"]
+                                                   and abs(r["income_sgd"]) < 1e-6))
+            self.assertAlmostEqual(sum(v["stock_pl_sgd"] for v in g.values()), want, 2, by)
 
 
 if __name__ == "__main__":

--- a/web/src/modules/portfolio/Performance.jsx
+++ b/web/src/modules/portfolio/Performance.jsx
@@ -1,6 +1,17 @@
 import React, { useEffect, useState } from "react";
 import { get, sgd, pct, cls } from "../../api.js";
 
+// The `~` Holdings already uses for a Net it could only part-answer, on the two columns that
+// split stock P/L. `unsplit_pl_sgd` is the amount they cannot reach; a group without one renders
+// nothing, so the marker appears exactly where a reader would otherwise mis-add the row.
+function Unsplit({ v }) {
+  if (!v.unsplit_pl_sgd) return null;
+  return <span className="mut" style={{ fontWeight: 400 }}
+               title={`${sgd(v.unsplit_pl_sgd)} of stock P/L is in Net but cannot be split `
+                      + "between realised and unrealised — the book cannot price every unit "
+                      + "that entered"}> ~</span>;
+}
+
 export default function Performance() {
   const [by, setBy] = useState("market");
   const [d, setD] = useState(null);
@@ -35,8 +46,15 @@ export default function Performance() {
                   <td className="l" style={{ fontWeight: 600 }}>{k}</td>
                   <td className="mut">{v.capital_sgd ? sgd(v.capital_sgd) : "—"}</td>
                   <td>{sgd(v.mv_sgd)}</td>
-                  <td className={cls(v.unrealised_pl_sgd)}>{v.capital_sgd ? sgd(v.unrealised_pl_sgd) : "—"}</td>
-                  <td className={cls(v.realised_pl_sgd)}>{v.realised_pl_sgd ? sgd(v.realised_pl_sgd) : "—"}</td>
+                  {/* Marked `~` when the group holds a leg whose entering units the book cannot
+                      price: that leg knows its stock P/L and neither half of it, so these two
+                      cells are short of Net by `unsplit_pl_sgd` and say so rather than reading
+                      as a whole figure. The server ships the shortfall — re-deriving it here
+                      from three columns is how the options P/L went wrong. */}
+                  <td className={cls(v.unrealised_pl_sgd)}>
+                    {v.capital_sgd ? sgd(v.unrealised_pl_sgd) : "—"}<Unsplit v={v} /></td>
+                  <td className={cls(v.realised_pl_sgd)}>
+                    {v.realised_pl_sgd ? sgd(v.realised_pl_sgd) : "—"}<Unsplit v={v} /></td>
                   <td className="pos">{sgd(v.income_sgd)}</td>
                   <td className={cls(v.options_pl_sgd)}>{v.options_pl_sgd ? sgd(v.options_pl_sgd) : "—"}</td>
                   <td className={cls(v.net_pl_sgd)} style={{ fontWeight: 600 }}>{sgd(v.net_pl_sgd)}</td>
@@ -49,9 +67,11 @@ export default function Performance() {
       )}
       <p className="mut" style={{ fontSize: 12 }}>
         <b>Capital</b> = cost basis of current holdings (Capital + Unrealised = Current Value).
-        <b> Net P/L</b> = Unrealised + Realised + Dividends + Options premiums.
+        <b> Net P/L</b> = stock P/L (Unrealised + Realised) + Dividends + Options premiums.
         <b> Return</b> = Net P/L ÷ total ever invested (incl. positions since sold).
         Includes closed positions; cost-known rows only. All SGD at latest FX.
+        A <b>~</b> means the group holds a name whose entering units the book cannot price: its
+        stock P/L is in Net, but nothing can say which of the two columns beside it to put it in.
       </p>
     </div>
   );


### PR DESCRIPTION
Closes #149. Spec #143 §6 (part of map #126). Stacks on #148, now merged.

A missing number on a position row meant one of four things and the fold said none of
them. `null` now means **exactly one thing per field**, and the rule is *has this stream
ever existed*, not *is the number zero*.

| state | meaning | field |
|---|---|---|
| omitted | the stream has never existed for this ticker | `options_pl_sgd` |
| `0` | the stream exists and measured zero | a closed leg's Realised / Unrealised |
| not known | the stream exists but is unmeasurable | `avg_cost`, both cost-basis fields, the realised/unrealised pair |

## What changed

- **`options_pl_sgd` goes `0.0 → None` on a never-optioned ticker.** 61 of the live book's
  73 legs stop carrying a permanent `Options 0` line. An optioned name still ships a number
  when that number is zero — "the stream measured zero" and "there is no stream" are
  different facts.
- **The cost-basis family goes null on the PARTITION, never on the unit count.** A leg
  holding `unknown` units cannot price the shares it still has, so `avg_cost`, both
  cost-basis fields and both members of the pair go null together. A leg whose every unit
  entered priced *can* price them — even holding none left — and ships the measured zero.
  Nulling on `units ≈ 0` said *not known* of TSLA and of F34's closed cpf leg, whose Net
  (940.00) is exact and whose unrealised is a genuine zero, and F34's second bucket column
  stopped adding up.
- **`stock_pl_sgd` joins every row.** `realised + unrealised` is identically
  `proceeds − buy_cost + mv`, so the **pair's sum is sound while neither member is** — which
  is what lets a doubted name show an arithmetically exact Net. Rounded *from* its members
  where they exist, so §14's measured cent stays where it already is instead of opening a
  second gap between a sum and its two parts.
- **The group says what its two columns do not reach.** Nulling the pair on five doubted
  legs would have left `/api/performance`'s Realised and Unrealised columns short of a Net
  that still carried them — the same "column stops adding up" this ticket exists to prevent,
  one level up. `rollup()` gains `unsplit_pl_sgd`, so
  `realised + unrealised + unsplit == stock_pl` on every group; `net_pl_sgd` is built from
  `stock_pl_sgd`; and the Performance table marks those two cells with the `~` Holdings
  already uses for a part-answered Net. **Measured: every group net across all three `by`
  dimensions is byte-identical to `main`.**

## Acceptance, against the live 548-row book

| # | criterion | evidence |
|---|---|---|
| 1 | `options_pl_sgd` null on a never-optioned ticker, a number (incl. `0`) on an optioned one | 61 of 73 legs omit it; TSLA ships 3,460.11 |
| 2 | a closed leg ships `unrealised 0.0` and `cost_basis 0.0` | F34 cpf `0.0 / 0.0 / 520.00` against an exact Net of 940.00; TSLA `0/0/0` |
| 3 | a leg whose partition holds unknown units nulls the family | Q01, C38U, S51, SET, 0P0001OOJG |
| 4 | `stock_pl_sgd` on every row, `= realised + unrealised` where both known | exact, no tolerance |
| 5 | free-unit names ship `avg_cost 0.0` / `cost_basis 0.0` | AAPL 427.82, HMN 144.57 |

## Reviewed

Ran through a two-axis review (standards + spec). The group-columns problem above, the
third rounding of `stock_pl_sgd`, and `avg_cost: null` beside `cost_basis: 0.0` on an
emptied predecessor were all found there and fixed in the second commit.

## Not in this PR

- **`income_sgd` is still `0.0` on a name that never paid a dividend.** #143 §6 puts it on
  the *omitted* line beside `options_pl_sgd`, but #149's own null table and its five
  acceptance criteria name only options. Nothing can currently tell *never paid* from *paid
  zero*; called out in `BACKEND.md` and `CONTEXT.md` rather than widened into here.
- **The detail page still renders `n/a`** where the fold now means *not known* — #158's job.
  `BACKEND.md` says the fold names the state and the words land later, rather than
  describing a render that does not exist.

## Note for the reviewer

`tests/test_performance_live.py::test_the_book_totals` and `::test_the_caveat_set_and_the_refusal_set`
fail against the app database **on `main` as well as here** — #148's merged carry bound is
date-bounded rather than shape-bounded, which moves `costed` by 394 units and puts
0P0001OOJG in the caveat set at 95.9%, and `MEASURED` / `MEASURED_CAVEAT` were not
re-measured with it. Not touched here: that file's own header says re-measuring is a
deliberate act. They skip in CI, which runs an empty Postgres.

https://claude.ai/code/session_01J8av1LdXL7hgLLyi75Ypds


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added stock P/L values to performance data and group totals.
  * Added `~` markers and tooltips for P/L amounts that cannot be fully split between realised and unrealised values.
  * Updated Net P/L calculations to include stock P/L, dividends, and options premiums.

* **Bug Fixes**
  * Improved handling of zero-valued cost basis and closed positions.
  * Corrected options P/L display when no options activity exists.
  * Improved consistency when position data is incomplete or unknown.

* **Documentation**
  * Documented cell states, P/L definitions, and rendering behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->