### PR TITLE
Peak capital-at-risk, and the one percentage on the page (#152)

### DIFF
--- a/BACKEND.md
+++ b/BACKEND.md
@@ -138,3 +138,62 @@ So `null` means **exactly one thing per field**. `income_sgd` is named on the fi
   Beside it, `unsplit_pl_sgd` is the part of that total no leg could attribute to either member,
   so `realised + unrealised + unsplit == stock_pl` on every group and the Performance table marks
   those two cells `~` instead of printing a short column beside a whole Net.
+
+## Peak capital-at-risk, and the one percentage
+
+One return figure per name, and the denominator that earns it. Shipped server-computed on every
+position row as `peak_car_sgd`, `return_span_days`, `return_pct` and `return_verdict`.
+
+```
+CAR(t)       = costed stock basis at t
+             + Σ strike × contracts × multiplier over short PUTS open at t,   at latest FX
+peak_car_sgd = max CAR(t) over the span
+span         = first event → today if still held, else → last resolution
+return_pct   = Net ÷ peak_car_sgd          — a LIFETIME total, never annualised
+```
+
+Six rules, each with its own gate in `tests/test_peak_car.py`:
+
+1. **Collateral is released when the contract resolves — `close_date or expiry_date`.** A put
+   that expired worthless carries `close_date: null`; reading it naively leaves the collateral
+   locked forever and puts one name at +348.9%. The release lands *on* the resolution date, so
+   an assigned put's shares (which arrive the day after) meet a one-day trough, never a
+   one-day double count.
+2. **Covered calls contribute nothing; open contracts do.** A call's collateral *is* the
+   shares, already in the stock term. An unresolved contract runs `[open_date, today]`.
+3. **The stock term is the transaction fold + the `cdp_cost_lot` attach + the corporate-action
+   carry, replayed in date order.** CDP qty counts toward `buy_qty` — omitting it inflates one
+   peak 3.5×. A sell fee never touches `buy_cost`.
+4. **An equal-and-opposite pair of stock-moving legs is one internal move** and contributes no
+   net units on any date, so *both* legs drop — from the unit count *and* from the costed
+   share's entering units, since the same units were held once and paid for once. Matching is
+   **leg-level, not ticker-level**: one name holds an internal round-trip *and* an external
+   leg, and netting swallows the exit. Legs pair by size, and every unpaired leg is untouched.
+   `cost_partition` deliberately still counts them: it answers "every unit that ever came
+   through a door", which is what makes it sum to gross units in.
+5. **The span ends today only if the position is still held** — units remaining or a contract
+   open, the same test `options._is_open()` makes.
+6. **Units nobody paid for contribute nothing** — the term carries the costed share,
+   `costed(t) / units_in(t)`. Dated like every other term: an undated ratio lets a lot arriving
+   uncosted in 2021 shrink capital that was at risk in 2020, which reads 25,096 on one name
+   against a measured 33,461.
+
+`return_verdict` is a second axis, independent of the Net's: `no_capital` where peak CAR is
+zero (the return does not *exist* — undefined, not unmeasured), `caveat` where some entering
+units are unknown (the numerator is an upper bound and the denominator a lower one, so the
+error compounds) **or where there is no Net to divide at all**, else `ok`. Never `ok` beside a
+null percentage — that is the one pairing a renderer branching on the verdict cannot survive. **`peak_car_sgd` is always a number**, a measured zero where
+nothing was at risk; the verdict, not a null, is what a renderer branches on.
+
+`peak_car_date` is deliberately **not** on the wire — nothing renders it, and a field with no
+consumer is how a rule gets re-derived wrongly. `performance.ticker_car()` returns it for the
+ledger audit.
+
+**Not annualised, and no XIRR on the ticker detail page.** Across the 58 non-optioned legs
+carrying an XIRR, lifetime and annualised return differ by a median 20 points and up to 367,
+and two names read a negative rate beside a five-figure positive Net. Holdings keeps its XIRR
+column (it pairs XIRR with a Net column, not a lifetime hero percentage) and `/api/return`'s
+portfolio-wide `xirr_annualised` is untouched.
+
+`tests/test_performance_live.py` holds the settled peaks to the ledger they were measured
+against, and records the one name where this build and the spec's settled table disagree.

--- a/BACKEND.md
+++ b/BACKEND.md
@@ -144,7 +144,7 @@ So `null` means **exactly one thing per field**. `income_sgd` is named on the fi
 One return figure per name, and the denominator that earns it. Shipped server-computed on every
 position row as `peak_car_sgd`, `return_span_days`, `return_pct` and `return_verdict`.
 
-```
+```text
 CAR(t)       = costed stock basis at t
              + Σ strike × contracts × multiplier over short PUTS open at t,   at latest FX
 peak_car_sgd = max CAR(t) over the span

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -161,8 +161,8 @@ activity" undercharges open ones.
 
 **Return verdict**:
 What the percentage can claim, on its own axis rather than the Net's: `ok`, `caveat` (some
-entering units are unknown, so the numerator is an upper bound and the denominator a lower one
-— the error compounds), or `no_capital` (peak CAR is zero, so the return does not exist —
+entering units are unknown, or no Net exists for the division, so the numerator is an upper bound
+and the denominator a lower one — the error compounds), or `no_capital` (peak CAR is zero, so the return does not exist —
 undefined, not unmeasured). The **verdict**, not a null, is what decides how the figure renders.
 _Avoid_: net verdict (a different axis — one name can be hero-on-Net and no-capital-on-return
 at once)

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -134,9 +134,47 @@ _Avoid_: total P/L (that is stock P/L *plus* dividends and premiums — the Net)
 
 ### Returns
 
+**Peak capital-at-risk (CAR)**:
+The most a name ever had exposed at once: the **costed stock basis** at a moment plus the
+collateral locked behind short **puts** open at that moment, converted at latest FX, maximised
+over the position's span. Covered calls contribute nothing — their collateral *is* the shares,
+already in the stock term. Every term is read at the date it applies, including the costed
+share, so a lot that arrives uncosted years later cannot shrink capital that was genuinely at
+risk before it. Where nothing was ever paid for and no collateral was ever locked it is a
+**measured zero**, not a null.
+_Avoid_: cost basis (a peak is a maximum over a span, not a current holding), invested (total
+money ever deployed, which double-counts capital that was recycled)
+
+**Peak-CAR return**:
+`Net ÷ peak capital-at-risk`, a **lifetime total** and never annualised. Annualising a ratio
+whose denominator is a *peak* asserts the capital sat at peak for the whole span, when it may
+have touched that on a single day — so the figure is a lifetime total return on worst-case
+exposure and is always rendered with its span beside it. Whole-ticker only. There is no minimum
+span and no materiality floor.
+_Avoid_: return (unqualified), annualised return (it is deliberately neither)
+
+**Span**:
+The window a peak-CAR return is measured over: the first event, to **today if the position is
+still held** — units remaining or a contract still open — and otherwise to the date the last
+unit left or the last contract resolved. "Always today" overcharges closed names; "always last
+activity" undercharges open ones.
+
+**Return verdict**:
+What the percentage can claim, on its own axis rather than the Net's: `ok`, `caveat` (some
+entering units are unknown, so the numerator is an upper bound and the denominator a lower one
+— the error compounds), or `no_capital` (peak CAR is zero, so the return does not exist —
+undefined, not unmeasured). The **verdict**, not a null, is what decides how the figure renders.
+_Avoid_: net verdict (a different axis — one name can be hero-on-Net and no-capital-on-return
+at once)
+
 **Money-weighted return (XIRR)**:
 The internal rate of return over a position's dated cashflows plus its current market value as a
 terminal inflow. Sensitive to contribution timing. Computed per position and portfolio-wide.
+**Not on the ticker detail page** — an annualised rate and a lifetime return are different
+claims and no label reconciles them: across the 58 non-optioned legs carrying one, the two
+differ by a median 20 points and up to 367, and two names read a negative rate beside a
+five-figure positive Net. Holdings keeps its column, because it pairs XIRR with a Net column
+rather than with a lifetime hero percentage.
 _Avoid_: IRR, return (unqualified)
 
 **Time-weighted return (TWR)**:

--- a/portfolio/options.py
+++ b/portfolio/options.py
@@ -151,6 +151,34 @@ def realized_by_ticker():
             for k, v in out.items()}
 
 
+def contracts_by_ticker():
+    """Every option contract keyed by underlying, in the shape peak capital-at-risk folds.
+
+    Distinct from `realized_by_ticker()` and deliberately not derived from it: that one is a
+    realized-P/L rollup over CLOSED trades, and a denominator needs the strike, the size, the
+    multiplier and both dates of every contract — the open ones most of all, since their
+    collateral is locked right now.
+
+    `open` is `_is_open()`'s answer, carried as data. The fold decides release from
+    `close_date or expiry_date` itself (that rule is its own gate), but it must not re-derive
+    resolved-vs-open: `SecurityDetail.jsx` re-deriving exactly that from `close_date` is the
+    defect this whole page is being rebuilt around.
+    """
+    s = SessionLocal()
+    try:
+        out = {}
+        for t in s.scalars(select(OptionTrade)).all():
+            out.setdefault(t.underlying, []).append({
+                "type": t.option_type, "contracts": float(t.contracts or 0),
+                "strike": _f(t.strike), "multiplier": int(t.multiplier or 100),
+                "currency": t.currency, "open_date": t.open_date,
+                "expiry_date": t.expiry_date, "close_date": t.close_date,
+                "open": _is_open(t)})
+        return out
+    finally:
+        s.close()
+
+
 def realized_by(dim):
     """Closed-trade realized P/L (SGD) grouped by dimension: 'market' | 'bucket' | 'account'.
     Options trade on the Tiger Prime cash account, so bucket='cash', account='Tiger Prime'."""

--- a/portfolio/performance.py
+++ b/portfolio/performance.py
@@ -46,6 +46,16 @@ class CostEvent(NamedTuple):
     qty: float
 
 
+class EntryLot(NamedTuple):
+    """One dated arrival of units, with the cost condition they entered under. The dated mirror
+    of the partition's counters — `condition` is the provisional answer `_condition` gave the
+    row; `pending` and `cdp` are resolved against the position's budgets by `_resolved_entries`.
+    """
+    date: dt.date
+    qty: float
+    condition: str
+
+
 def _book_buy(acc, day, cost, qty):
     """Book one purchase into an accumulator: the three running totals and the dated cost event
     that mirrors them. The same buy arrives from two ledgers (`_apply_txn` for the broker CSVs,
@@ -327,15 +337,18 @@ def _apply_units(p, r, kind, today, annotations):
     transfer in is an FSM one. Reading only the FSM side saw 205,090 units enter a second time
     with nothing behind them and called eight positions cost-doubtful that are not."""
     qty = float(r["qty_signed"])
+    day = r["trade_date"] or today
     if qty > 0:
         p["units_in"] += qty                       # GROSS units in; a sale subtracts nothing
         if r["account"] == "CDP":
             p["cdp_units_in"] += qty               # matched against the cost pool, not per row
+            p["entries"].append(EntryLot(day, qty, "cdp"))
             return
         cond = _condition(r, kind, annotations)
         p[f"{cond}_units"] += qty
         if cond == "pending":
-            p["pending_events"].append((r["trade_date"] or today, qty))
+            p["pending_events"].append((day, qty))
+        p["entries"].append(EntryLot(day, qty, cond))
         if cond == "free":
             # free units carry a PRICE, not only a count. avg_cost = buy_cost / buy_qty, so
             # entering them at zero cost is what makes cost_basis a measured 0.0 rather than
@@ -343,7 +356,7 @@ def _apply_units(p, r, kind, today, annotations):
             # Through _book_buy, not a bare `buy_qty +=`: #147's dated cost series mirrors that
             # scalar, and a series that agrees with its scalars on one path and not the other is
             # worse than no series at all. The event is real and its cost is really zero.
-            _book_buy(p, r["trade_date"] or today, 0.0, qty)
+            _book_buy(p, day, 0.0, qty)
     elif r["action"] in STOCK_MOVING_LEG:
         # units left without being sold. The cost stayed in the position, so this is the cover a
         # later transfer in draws on — see cost_partition. Keyed on #147's STOCK_MOVING_LEG
@@ -374,12 +387,8 @@ def _apply_txn(p, r, kind, today):
     return None
 
 
-def cost_partition(p):
-    """The three conditions every entering unit lands in, as the nested wire object.
-
-    Nested rather than three more flat siblings among ~25: the counts cannot drift apart when
-    they travel together, and the self-check — costed + free + unknown == units_in — is visible
-    in one place. `unknown_pct` is pre-computed so the frontend does no arithmetic.
+def _resolved_entries(p, exclude=frozenset()):
+    """Every entering lot, dated, with its cost condition finally resolved.
 
     Three resolutions happen here rather than row by row, because none is knowable row by row:
 
@@ -394,21 +403,370 @@ def cost_partition(p):
       - **A corporate-action carry costs the units it arrived on** — pending arrivals through
         the predecessor's closing event, not every doubtful unit later added to the name. An
         unpriced buy or later transfer into a carried holding is still `unknown`.
+
+    Each of the three is a **budget over the whole position**, not a fact about a row, so
+    spending them is what gives a resolved unit a DATE as well as a condition. They are spent
+    **earliest-first**, because a budget is evidence and evidence attaches to the oldest claim
+    on it: the CDP cost pool's lots *are* the early rows, and a transfer out covers the arrival
+    it paired with, which is the one nearest it in time. The order changes nothing about the
+    totals — it only matters where a budget runs out mid-position, and every ordering sums the
+    same — so `cost_partition` reads this list rather than keeping its own arithmetic, and the
+    dated share peak capital-at-risk needs (#143 §9 rule 6) reads the same one.
+
+    `exclude` — indices into `p["entries"]` that rule 4 has ruled an internal move's ARRIVAL,
+    which peak capital-at-risk passes and `cost_partition` does not. The two are asking
+    different questions and the difference is deliberate: the partition counts every unit that
+    ever came through a door, which is what makes it sum to gross units in; the peak's costed
+    SHARE asks what fraction of the units a position actually held were paid for, and units
+    that re-entered by an internal move were held once and paid for once. Counting them twice
+    pulls the share toward 1 on exactly the mixed shape rule 4 was written for. An excluded
+    arrival also gives back the budget it would otherwise have spent covering itself — its own
+    paired departure — so nothing else in the position resolves differently.
     """
-    covered = min(p["pending_units"], p["transfer_out_units"])
-    cdp_costed = min(p["cdp_buy_qty"], p["cdp_units_in"])
-    carried = min(p["pending_units"] - covered, p["carried_units"])
-    costed = p["costed_units"] + covered + cdp_costed + carried
-    free = p["free_units"]
-    unknown = (p["unknown_units"] + (p["pending_units"] - covered - carried)
-               + (p["cdp_units_in"] - cdp_costed))
+    pending, transfer_out, cdp_in = (p["pending_units"], p["transfer_out_units"],
+                                     p["cdp_units_in"])
+    entries = []
+    for i, e in enumerate(p["entries"]):
+        if i in exclude:
+            transfer_out -= e.qty                      # the departure leaves with the arrival
+            if e.condition == "pending":
+                pending -= e.qty
+            elif e.condition == "cdp":
+                cdp_in -= e.qty
+        else:
+            entries.append(e)
+    cover = min(pending, transfer_out)
+    carried = min(pending - cover, p["carried_units"])
+    budget = {"pending": cover + carried, "cdp": min(p["cdp_buy_qty"], cdp_in)}
+    out = []
+    for e in entries:
+        if e.condition not in budget:
+            out.append(e)
+            continue
+        take = min(e.qty, budget[e.condition])
+        budget[e.condition] -= take
+        if take > 1e-9:
+            out.append(EntryLot(e.date, take, "costed"))
+        if e.qty - take > 1e-9:
+            out.append(EntryLot(e.date, e.qty - take, "unknown"))
+    return out
+
+
+def cost_partition(p):
+    """The three conditions every entering unit lands in, as the nested wire object.
+
+    Nested rather than three more flat siblings among ~25: the counts cannot drift apart when
+    they travel together, and the self-check — costed + free + unknown == units_in — is visible
+    in one place. `unknown_pct` is pre-computed so the frontend does no arithmetic.
+
+    A sum over `_resolved_entries`, which is where the three position-level resolutions live."""
+    lots = _resolved_entries(p)
     units_in = round(p["units_in"], 4)
-    costed, free, unknown = round(costed, 4), round(free, 4), round(unknown, 4)
+    costed, free, unknown = (round(sum(e.qty for e in lots if e.condition == c), 4)
+                             for c in ("costed", "free", "unknown"))
     if round(costed + free + unknown, 4) != units_in:
         log.warning("cost partition does not sum to units in: %s vs %s+%s+%s",
                     units_in, costed, free, unknown)
     return {"units_in": units_in, "costed": costed, "free": free, "unknown": unknown,
             "unknown_pct": round(unknown / units_in, 4) if units_in > 1e-9 else 0.0}
+
+
+# ---------------------------------------------------------------- peak capital-at-risk (§9)
+# CAR(t) = costed stock basis at t + the collateral locked behind short puts open at t, at
+# latest FX; peak_car_sgd is its maximum over the span. Six rules, each one written here
+# because prose is how two candidate peaks came apart (#143 §9, pinned by #139).
+
+
+def _matched_transfer_pairs(unit_events):
+    """Indices of the stock-moving legs that pair off equal-and-opposite (rule 4).
+
+    One ledger holds the same 2,800 shares twice for nine days: an FSM `transfer in` lands
+    2020-03-19 and the matching CDP `sell/transfer_out` does not fire until 2020-03-28. The
+    pair is ONE internal move and contributes no net units at any date, so BOTH legs drop —
+    dropping only the arrival would leave the departure taking units the position never had.
+
+    Matching is **leg-level, not ticker-level**: one name holds an internal 10,000 round-trip
+    *and* an external -7,100, and netting the three would swallow the exit. Legs pair by SIZE
+    because the ledger carries nothing linking them, so a leg only pairs with one of exactly
+    its own magnitude and every unpaired leg is untouched — all 21 of them, which is what
+    keeps a gift, a distribution and a carry landing.
+    """
+    by_size = defaultdict(lambda: ([], []))
+    for i, e in enumerate(unit_events):
+        if not e.moves_stock or abs(e.qty) < 1e-9:
+            continue
+        arrivals, departures = by_size[round(abs(e.qty), 6)]
+        (arrivals if e.qty > 0 else departures).append(i)
+    drop, arrived = set(), []
+    for arrivals, departures in by_size.values():
+        n = min(len(arrivals), len(departures))         # the surplus side keeps its extras
+        drop.update(arrivals[:n])
+        drop.update(departures[:n])
+        arrived += [unit_events[i] for i in arrivals[:n]]
+    return drop, arrived
+
+
+def _internal_arrival_entries(entries, arrived):
+    """The `entries` indices that are the matched arrivals in `arrived` — the same rows, seen
+    from the partition's list instead of the unit series.
+
+    Matched on `(date, qty)` and claimed once each, because the two lists cannot carry an index
+    for one another: both are appended row by row but then sorted by date, and `entries` skips
+    every row that removed units. Same-date arrivals of the same size are interchangeable for
+    every purpose downstream, so which of them is claimed cannot matter."""
+    want = defaultdict(int)
+    for e in arrived:
+        want[(e.date, round(e.qty, 6))] += 1
+    out = set()
+    for i, e in enumerate(entries):
+        k = (e.date, round(e.qty, 6))
+        if want.get(k):
+            want[k] -= 1
+            out.add(i)
+    return out
+
+
+class _CarDelta:
+    """The five running totals `_leg_car_series` replays, as one thing that moves together.
+
+    Named rather than a five-slot list because they are read as a formula — `cost/qty x units
+    x costed_in/units_in` — and a positional `moves[d][3]` gives the reader nothing to check
+    that against. Mutable, so it can be both a per-date delta and the running total the walk
+    accumulates into."""
+    __slots__ = ("units", "cost", "qty", "units_in", "costed_in")
+
+    def __init__(self):
+        self.units = self.cost = self.qty = self.units_in = self.costed_in = 0.0
+
+    def add(self, other):
+        for f in self.__slots__:
+            setattr(self, f, getattr(self, f) + getattr(other, f))
+
+
+def _leg_car_series(p):
+    """One leg's costed stock basis as dated breakpoints, native currency (rules 3, 4, 6).
+
+    `buy_cost(t)/buy_qty(t) x units(t) x (costed units in at t / gross units in at t)` — every
+    term, the multiplier included, read from the accumulators' own dated series (#147) and
+    replayed in date order. Three rules live in that one line:
+
+      - **rule 3** — the series IS `_apply_txn` + the `cdp_cost_lot` attach + the
+        corporate-action carry, so CDP qty counts toward `buy_qty` (omitting it inflates one
+        peak 3.5x) and a sell fee does not touch `buy_cost` (and could not move a peak anyway,
+        which is set by a buy).
+      - **rule 4** — the matched transfer pairs above are already gone from `units(t)`.
+      - **rule 6** — units nobody paid for contribute nothing, so the term carries the costed
+        share. A free lot moves both factors: it enters `buy_qty` at zero cost, diluting the
+        average, and sits outside `costed`, shrinking the multiplier.
+
+    **The share is dated like everything else**, and that is load-bearing rather than tidy: an
+    undated ratio lets a lot that arrives uncosted in 2021 retroactively shrink capital that
+    was genuinely at risk in 2020. One name's 17,000-unit unpriced re-entry in 2021 is the live
+    case — it reads 25,096 against a measured 33,461 if the share is taken whole-history, and
+    the peak it shrinks was set fourteen months before those units existed.
+
+    Where nothing has been sold and the costed lots are the ones that booked the cost, the
+    three factors cancel to `buy_cost` — the term is simply the money actually paid and still
+    in the position, which is what makes it a capital-at-risk rather than a valuation.
+
+    Breakpoints only. The function is piecewise constant between events, so sampling at every
+    date something happened is exact — and it is also what neutralises the six same-day
+    transfer pairs, which never separate at date granularity.
+    """
+    drop, arrived = _matched_transfer_pairs(p["unit_events"])
+    moves = defaultdict(_CarDelta)
+    for i, e in enumerate(p["unit_events"]):
+        if i not in drop:
+            moves[e.date].units += e.qty
+    for e in p["cost_events"]:
+        moves[e.date].cost += e.cost
+        moves[e.date].qty += e.qty
+    for e in _resolved_entries(p, _internal_arrival_entries(p["entries"], arrived)):
+        moves[e.date].units_in += e.qty
+        if e.condition == "costed":
+            moves[e.date].costed_in += e.qty
+    run, out = _CarDelta(), []
+    for d in sorted(moves):
+        run.add(moves[d])
+        avg = (run.cost / run.qty) if run.qty > 1e-9 else 0.0
+        share = (run.costed_in / run.units_in) if run.units_in > 1e-9 else 0.0
+        out.append((d, avg * max(run.units, 0.0) * share))
+    return out
+
+
+def _put_collateral_steps(contracts, fx, today):
+    """Short-put collateral as dated (date, delta SGD) steps (rules 1, 2).
+
+    **Rule 1 — collateral is released when the contract RESOLVES: `close_date or
+    expiry_date`.** A put bought back early releases on the close date; one that expired
+    worthless releases at expiry and carries `close_date: null`. Reading the naive
+    `close_date` leaves that one locked forever, which is this map's founding defect in a new
+    place and catastrophic on a denominator (+348.9% on one name). The release step lands ON
+    the resolution date, so an assigned put's shares — which arrive the day after — meet a
+    one-day trough rather than a one-day double count, and a max is insensitive to a trough.
+
+    **Rule 2 — covered calls contribute nothing; open contracts do.** A covered call's
+    collateral IS the shares, already in the stock term, and there are 116 calls in this book,
+    so this is not a rounding error. A contract still open has no release date, so it runs
+    `[open_date, today]`.
+
+    `open` is `options._is_open()`'s answer, carried in rather than re-derived: re-deriving
+    the resolved/open rule from `close_date` is exactly the defect rule 1 exists to undo.
+    """
+    steps = []
+    for c in contracts:
+        if (c.get("type") or "").lower() != "put":
+            continue
+        start = c.get("open_date")
+        if start is None:
+            continue
+        end = (today + dt.timedelta(days=1)) if c.get("open") else \
+            (c.get("close_date") or c.get("expiry_date"))
+        if end is None or end <= start:
+            continue
+        amt = (float(c.get("strike") or 0) * float(c.get("contracts") or 0)
+               * float(c.get("multiplier") or 100)
+               * rate_to_sgd(c.get("currency"), fx))
+        if abs(amt) < 1e-9:
+            continue
+        steps.append((start, amt))
+        steps.append((end, -amt))
+    steps.sort()
+    return steps
+
+
+def legs_by_ticker(pos, meta):
+    """`_accumulate_positions`' output regrouped as `{ticker: [(accumulator, meta), ...]}`,
+    which is the unit peak capital-at-risk works in — a name's exposure is the sum of its
+    funding-pool legs. Exported because the ledger audit regroups exactly the same way, and
+    two spellings of one grouping is how two readings of one figure start."""
+    out = {}
+    for k, p in pos.items():
+        if k in meta:
+            out.setdefault(meta[k]["canonical_ticker"], []).append((p, meta[k]))
+    return out
+
+
+def ticker_car(legs, contracts, fx, today):
+    """Peak capital-at-risk and its span for ONE ticker, across every funding bucket.
+
+    `legs` are `(accumulator, meta)` pairs from `_accumulate_positions`; `contracts` are the
+    underlying's option contracts in `options.contracts_by_ticker()`'s shape.
+
+    **Whole-ticker, and the max is taken after the sum.** A max over summed legs is not the
+    sum of the legs' maxima, so the merged series is what gets sampled. No per-bucket figure
+    exists: no optioned ticker is multi-bucket, so a per-bucket peak would render only where
+    it collapses to peak stock cost basis — a differently-defined number wearing the same
+    label as the hero, appearing exclusively where the difference is invisible.
+
+    **Rule 5 — the span ends today only if the position is still held**: `units > 0` or a
+    contract is open, the same open/closed test `_is_open()` already makes. Otherwise it ends
+    the day the last unit left or the last contract resolved. "Always today" overcharges 27 of
+    31 closed names; "always last activity" undercharges 17 open ones.
+
+    Returns `peak_car_sgd` (a measured **zero**, never null, when nothing was ever at risk),
+    `peak_car_date` and `return_span_days`. Only the first and last reach the wire —
+    `peak_car_date` has no consumer on the page (the hero prints the amount, not the date) and
+    #143 §2's discipline is absent, not null. It is returned here because the ledger audit
+    reads it, and for nothing else.
+    """
+    series = [[(d, v * rate_to_sgd(m["currency"] or "SGD", fx)) for d, v in _leg_car_series(p)]
+              for p, m in legs]
+    steps = _put_collateral_steps(contracts, fx, today)
+    dates = sorted({d for s in series for d, _ in s} | {d for d, _ in steps})
+    held = (any(p["units"] > 1e-6 for p, _ in legs)
+            or any(c.get("open") for c in contracts))
+    opened = [c["open_date"] for c in contracts if c.get("open_date")]
+    starts = [s[0][0] for s in series if s] + opened
+    start = min(starts) if starts else today
+    if held:
+        end = today
+    else:
+        resolved = [c.get("close_date") or c.get("expiry_date") for c in contracts
+                    if (c.get("close_date") or c.get("expiry_date"))]
+        ends = [s[-1][0] for s in series if s] + resolved
+        end = max(ends) if ends else start
+    # one forward walk over the merged breakpoints: each leg holds its latest value and the
+    # collateral its running total, so CAR(t) is read rather than recomputed at every date.
+    peak, peak_date, collateral = 0.0, None, 0.0
+    leg_car, leg_next, step_next = [0.0] * len(series), [0] * len(series), 0
+    for d in dates:
+        for i, leg in enumerate(series):
+            while leg_next[i] < len(leg) and leg[leg_next[i]][0] <= d:
+                leg_car[i] = leg[leg_next[i]][1]
+                leg_next[i] += 1
+        while step_next < len(steps) and steps[step_next][0] <= d:
+            collateral += steps[step_next][1]
+            step_next += 1
+        car = sum(leg_car) + collateral
+        if car > peak + 1e-9:
+            peak, peak_date = car, d
+    return {"peak_car_sgd": round(peak, 2), "peak_car_date": peak_date,
+            "return_span_days": max((end - start).days, 0)}
+
+
+def _return_figures(car, rows):
+    """The four fields the page's one percentage needs, from a ticker's peak CAR and its rows.
+
+    **`Net / peak CAR`, a lifetime total and never annualised.** Annualising a ratio whose
+    denominator is a *peak* asserts the capital sat at peak for the whole span, when it
+    touched that on a single day; the figure is honestly a lifetime total return on worst-case
+    exposure and the page says so by printing the span beside it. There is no minimum span and
+    no materiality floor: nothing here annualises, so nothing explodes at a short span, and
+    `+104.5% on peak capital of 1.54` is reported rather than suppressed by an unargued
+    threshold. A negative Net gives a negative percentage and needs no rule either.
+
+    **`no_capital`** where no unit was ever paid for and no collateral was ever locked: peak
+    CAR is zero and the return does not exist — undefined, not unmeasured. The percentage, the
+    span and the peak all die together on the page; here the peak still ships as a measured
+    `0`, because that is the true answer to "how much was at risk", and **the verdict, not a
+    null, is what gates the render**.
+
+    **`caveat`** where some entering units are unknown: the error compounds, because the
+    numerator is an upper bound (unknown units assumed free) while the denominator is a lower
+    bound (costed lots only). It carries its own verdict rather than reusing the Net's, which
+    would leave it reading as merely optimistic instead of not comparable to any other name.
+    """
+    peak = car["peak_car_sgd"]
+    unknown = sum(r["cost_partition"]["unknown"] for r in rows)
+    # Net summed over the ticker's legs. `pl_sgd` is already `stock P/L + income`
+    # (`mv + proceeds + income - invested`), so Net is it plus the options stream — the same
+    # four components the reconciliation block totals. Null on every leg means there is no
+    # numerator at all, which is a refusal rather than a zero.
+    #
+    # The two nulls here mean opposite things and are treated as such. `options_pl_sgd` is null
+    # on a never-optioned name (#143 §6, 61 of 73 legs) — a stream that does not exist
+    # contributes nothing, so it reads as 0 and the name still gets a percentage. `pl_sgd` null
+    # is the stock stream REFUSING on a leg that has one; only when every leg refuses is there
+    # no numerator. Net is still assembled from `pl_sgd` rather than #149's `stock_pl_sgd +
+    # income_sgd`, which is the same sum wherever both exist but keeps its value on a refusing
+    # leg — adopting it would move the four caveat names' percentages, and that unification
+    # belongs to #150, which puts one `net_pl_sgd` on the wire for everyone.
+    pl = [r["pl_sgd"] for r in rows]
+    net = (round(sum(x or 0.0 for x in pl) + sum(r["options_pl_sgd"] or 0.0 for r in rows), 2)
+           if any(x is not None for x in pl) else None)
+    if peak <= 1e-9:
+        verdict = "no_capital"
+    elif unknown > 1e-6 or net is None:
+        # `net is None` is the numerator refusing, not the denominator: capital WAS at risk and
+        # the book cannot say what it earned. The ordinary route there is a Net refusal, whose
+        # hero replaces the number with prose and takes the percentage with it — so this is the
+        # verdict for a name that refuses on Net while still having written puts. `caveat` and
+        # not `ok`, because the one thing that must never happen is a renderer branching on the
+        # verdict, reading `ok`, and printing a null as a percentage.
+        verdict = "caveat"
+    else:
+        verdict = "ok"
+    return {"peak_car_sgd": peak, "return_span_days": car["return_span_days"],
+            "return_pct": None if verdict == "no_capital" else _rn(net, 4, 1.0 / peak),
+            "return_verdict": verdict}
+
+
+# `return_pct` is the third field of that name in this codebase — `/api/positions` divides P/L
+# by cost and `/api/performance` divides Net by ever-invested — and it is the name #143 §2 pins
+# for this page, so the collision is inherited rather than introduced. The three denominators
+# are genuinely different questions and the one P/L definition across the whole app is the map's
+# named out-of-scope; recorded here so the next reader does not assume they agree.
 
 
 def _rn(x, n, mult=1.0):
@@ -517,6 +875,7 @@ def _accumulate_positions(txns, divs, cdp, corp_actions, today, annotations):
     pos = defaultdict(lambda: {"units": 0.0, "flows": [], "invested": 0.0, "proceeds": 0.0,
                                 "income": 0.0, "buy_cost": 0.0, "buy_qty": 0.0, "fees": 0.0,
                                 "accounts": set(), "unit_events": [], "cost_events": [],
+                                "entries": [],
                                 "units_in": 0.0, "costed_units": 0.0, "free_units": 0.0,
                                 "unknown_units": 0.0, "pending_units": 0.0,
                                 "pending_events": [], "carried_units": 0.0,
@@ -578,11 +937,12 @@ def _accumulate_positions(txns, divs, cdp, corp_actions, today, annotations):
     for p in pos.values():
         p["unit_events"].sort(key=lambda e: e.date)
         p["cost_events"].sort(key=lambda e: e.date)
+        p["entries"].sort(key=lambda e: e.date)
     return pos, meta
 
 
 def fold_positions(txns, divs, cdp, corp_actions, options, fx, price, today=None,
-                   annotations=None):
+                   annotations=None, contracts=None):
     """Pure fold: accumulate per-(funding_bucket, security) positions from already-fetched
     inputs and emit one output row each. No DB or session — every input is plain data, so the
     cost-basis rules (transfer double-count, CDP cost attach, dividend income, corporate-action
@@ -598,9 +958,13 @@ def fold_positions(txns, divs, cdp, corp_actions, options, fx, price, today=None
       annotations — {natural key: condition} from portfolio.cost_annotations; the curated list
               when omitted. The free/transferred distinction is not in the ledger and cannot be
               put there, so it arrives as data like the corporate actions do.
+      contracts — {ticker: [contract dicts]} from options.contracts_by_ticker(). The realized
+              rollup in `options` cannot serve peak capital-at-risk: a denominator needs the
+              strike, the size and the two dates of every contract, resolved or not.
     """
     today = today or dt.date.today()
     annotations = annotation_map() if annotations is None else annotations
+    contracts = contracts or {}
     pos, meta = _accumulate_positions(txns, divs, cdp, corp_actions, today, annotations)
     out = []
     for k, p in pos.items():
@@ -618,6 +982,23 @@ def fold_positions(txns, divs, cdp, corp_actions, options, fx, price, today=None
         # a number when that number is zero: "the stream measured zero" and "there is no stream"
         # are different facts, and the states they belong to render differently.
         r["options_pl_sgd"] = o["pl_sgd"] if o else None
+    # peak capital-at-risk and the one percentage (#143 §9). Whole-ticker: the peak is a max
+    # over the SUM of a name's legs, which is not the sum of their maxima, and the percentage
+    # answers "did I make money on this name" rather than on one funding pool of it. The four
+    # fields therefore repeat identically on every leg of a ticker — the same way `ticker`,
+    # `name` and `currency` already do — so a consumer holding any one leg has the whole-ticker
+    # answer without re-deriving it. They are read off a leg and lifted into the summary; the
+    # per-bucket columns never carry them.
+    legs = legs_by_ticker(pos, meta)
+    rows = defaultdict(list)
+    for r in out:
+        rows[r["ticker"]].append(r)
+    for tk, rs in rows.items():
+        # `legs[tk]`, not `.get` — every output row came from an accumulator, so a miss is a
+        # broken fold and should raise rather than quietly answer `no_capital`.
+        figures = _return_figures(ticker_car(legs[tk], contracts.get(tk, ()), fx, today), rs)
+        for r in rs:
+            r.update(figures)
     return out
 
 
@@ -648,9 +1029,10 @@ def compute(session=None):
         log.warning("cost annotation %s matched %d txn rows, expected 1 — a stale annotation "
                     "silently un-frees a lot; a duplicate annotates one nobody looked at", k, n)
     # options open their own session (see realized_by_ticker); fetched outside the DB block above.
-    from .options import realized_by_ticker
+    from .options import contracts_by_ticker, realized_by_ticker
     options = realized_by_ticker()
-    return fold_positions(txns, divs, cdp, corp_actions, options, fx, price, today)
+    return fold_positions(txns, divs, cdp, corp_actions, options, fx, price, today,
+                          contracts=contracts_by_ticker())
 
 
 def alloc_by_account(session=None):

--- a/tests/test_peak_car.py
+++ b/tests/test_peak_car.py
@@ -1,0 +1,521 @@
+"""Peak capital-at-risk and the one percentage — #143 §9's six rules, one gate each.
+
+Tier-1 rule gates (#143 Testing Decisions): fabricated rows, no database, no fixture. Each
+rule is gated **independently**, because prose is how two candidate peaks came apart — a
+suite that only checks a composite figure cannot say which rule moved it.
+
+Every gate asserts what `fold_positions` RETURNS, never how it accumulates: the six rules are
+observable in `peak_car_sgd` / `return_span_days` / `return_pct` / `return_verdict` alone.
+Where a rule's whole point is that the wrong reading is *larger*, the shape is built so the
+wrong reading has a different number — a gate that both readings pass is not a gate.
+
+Run: PYTHONPATH=. .venv/bin/python -m pytest tests/test_peak_car.py -q
+"""
+import datetime as dt
+
+from portfolio import performance as perf
+
+D = dt.date
+TODAY = D(2026, 1, 1)
+
+
+def _txn(**over):
+    """One txn mapping-row with sensible defaults (SG stock, cash bucket, security_id 10)."""
+    r = dict(account_id=1, account="FSM", funding_bucket="cash", security_id=10,
+             canonical_ticker="D05", name="DBS", market="SG", asset_type="stock",
+             currency="SGD", trade_date=D(2020, 1, 1), action="buy", qty_signed=100,
+             price=10.0, gross_amount=None, fees=None)
+    r.update(over)
+    return r
+
+
+def _put(**over):
+    """One fold-shaped option contract, in exactly the shape `options.contracts_by_ticker()`
+    emits — no `outcome`, because the fold never sees one: resolved-vs-open arrives already
+    decided, as `open`. Defaults to a short put, resolved, 100 x 100 = 10,000 of collateral."""
+    r = dict(type="put", contracts=1.0, strike=100.0, multiplier=100, currency="SGD",
+             open_date=D(2021, 1, 1), expiry_date=D(2021, 6, 1), close_date=None, open=False)
+    r.update(over)
+    return r
+
+
+def _call(**over):
+    """The same, sold as a covered call — whose collateral is the shares, not cash."""
+    return _put(**{"type": "call", **over})
+
+
+def _fold(txns, *, cdp=None, contracts=None, fx=None, price=None, divs=None, corp=None,
+          options=None, annotations=None):
+    return perf.fold_positions(txns, divs or [], cdp or {}, corp or [], options or {},
+                               fx or {}, price or {}, TODAY, annotations=annotations,
+                               contracts=contracts or {})
+
+
+def _row(rows, ticker="D05"):
+    r = [x for x in rows if x["ticker"] == ticker]
+    assert len(r) == 1, [x["bucket"] for x in r]
+    return r[0]
+
+
+def _cdp(*legs):
+    """A cdp_cost()-shaped group: legs are (date, cash, qty), cash negative on a buy."""
+    g = {"flows": [], "invested": 0.0, "buy_cost": 0.0, "buy_qty": 0.0, "cost_events": []}
+    for d, cash, qty in legs:
+        g["flows"].append((d, cash))
+        if cash < 0:
+            g["invested"] += -cash; g["buy_cost"] += -cash; g["buy_qty"] += qty
+            g["cost_events"].append(perf.CostEvent(d, -cash, qty))
+    return g
+
+
+# ---------------------------------------------------------------- rule 1: resolve, not close
+
+def test_collateral_is_released_at_expiry_when_the_put_expired_worthless():
+    """A put that expired worthless carries `close_date: null`. Reading collateral as locked
+    until `close_date` leaves it locked forever — this map's founding defect in a new place,
+    and catastrophic on a denominator (PLTR +348.9%).
+
+    The two puts here never overlap, so the naive read stacks 10,000 + 3,000 and the rule
+    reads 10,000."""
+    rows = _fold([_txn(qty_signed=0, price=None, action="stock dividend")],
+                 contracts={"D05": [
+                     _put(open_date=D(2021, 1, 1), expiry_date=D(2021, 6, 1), close_date=None),
+                     _put(open_date=D(2022, 1, 1), expiry_date=D(2022, 6, 1), close_date=None,
+                          strike=30.0)]})
+    assert _row(rows)["peak_car_sgd"] == 10000.0
+
+
+def test_collateral_is_released_on_close_date_when_the_put_was_bought_back_early():
+    """The other half of `close_date or expiry_date`: a put bought back early releases on the
+    close date, so a later put opened before the ORIGINAL expiry does not stack onto it."""
+    rows = _fold([_txn(qty_signed=0, price=None, action="stock dividend")],
+                 contracts={"D05": [
+                     _put(open_date=D(2021, 1, 1), expiry_date=D(2021, 12, 1),
+                          close_date=D(2021, 2, 1)),
+                     _put(open_date=D(2021, 3, 1), expiry_date=D(2021, 9, 1),
+                          close_date=D(2021, 4, 1), strike=30.0)]})
+    assert _row(rows)["peak_car_sgd"] == 10000.0
+
+
+def test_two_puts_open_at_once_do_stack():
+    """The counterexample that keeps the rule above from being satisfied by never adding:
+    concurrent collateral is genuinely concurrent."""
+    rows = _fold([_txn(qty_signed=0, price=None, action="stock dividend")],
+                 contracts={"D05": [
+                     _put(open_date=D(2021, 1, 1), expiry_date=D(2021, 6, 1)),
+                     _put(open_date=D(2021, 2, 1), expiry_date=D(2021, 5, 1), strike=30.0)]})
+    assert _row(rows)["peak_car_sgd"] == 13000.0
+
+
+def test_assigned_collateral_and_the_shares_it_bought_do_not_double_count():
+    """Collateral ends AT the resolution date and the assigned shares land the day after, so
+    the handoff leaves a one-day trough rather than a one-day double count. 10,000 of
+    collateral becomes 10,000 of stock, and the peak is 10,000 either side."""
+    rows = _fold([_txn(action="buy", qty_signed=100, price=100.0, trade_date=D(2021, 6, 2))],
+                 price={10: 100.0},
+                 contracts={"D05": [_put(open_date=D(2021, 1, 1), expiry_date=D(2021, 6, 1),
+                                         close_date=None)]})
+    assert _row(rows)["peak_car_sgd"] == 10000.0
+
+
+# ---------------------------------------------------------------- rule 2: calls, and opens
+
+def test_covered_calls_contribute_no_collateral():
+    """A covered call's collateral IS the shares, already in the stock term. 116 calls sit in
+    this book, so counting them would not be a rounding error."""
+    rows = _fold([_txn(action="buy", qty_signed=100, price=10.0, trade_date=D(2021, 1, 1))],
+                 price={10: 10.0},
+                 contracts={"D05": [_call(strike=500.0, open_date=D(2021, 2, 1),
+                                          expiry_date=D(2021, 3, 1))]})
+    assert _row(rows)["peak_car_sgd"] == 1000.0        # the shares alone
+
+
+def test_an_open_contract_locks_collateral_through_today():
+    """An unresolved put has no release date, so its collateral runs [open_date, today]."""
+    rows = _fold([_txn(qty_signed=0, price=None, action="stock dividend",
+                       trade_date=D(2025, 12, 1))],
+                 contracts={"D05": [_put(open_date=D(2025, 12, 1), expiry_date=D(2026, 3, 1),
+                                         close_date=None, open=True)]})
+    r = _row(rows)
+    assert r["peak_car_sgd"] == 10000.0
+    assert r["return_span_days"] == (TODAY - D(2025, 12, 1)).days
+
+
+# ---------------------------------------------------------------- rule 3: the stock term
+
+def test_cdp_qty_counts_toward_the_stock_term():
+    """CDP units arrive from the txn ledger and their cost from `cdp_cost_lot`; both feed the
+    same accumulators. Dropping the qty leaves an average cost over the broker lot alone and
+    inflates the peak (D05: 587,408, 3.5x)."""
+    txns = [_txn(account="CDP", action="open", qty_signed=1000, price=None,
+                 trade_date=D(2020, 1, 1)),
+            _txn(action="buy", qty_signed=100, price=10.0, trade_date=D(2021, 1, 1))]
+    rows = _fold(txns, cdp={"D05": _cdp((D(2020, 1, 1), -10000.0, 1000))}, price={10: 10.0})
+    assert _row(rows)["peak_car_sgd"] == 11000.0       # 1,100 units at an average of 10
+
+
+def test_a_cdp_only_position_reads_the_cost_its_lots_recorded():
+    """The isolated half of the rule above: units from the CDP txn ledger, cost from
+    `cdp_cost_lot`, and no broker lot anywhere to average against. Drop the CDP qty and there
+    is no denominator at all — the average goes to zero and the peak with it."""
+    txns = [_txn(account="CDP", action="open", qty_signed=1000, price=None,
+                 trade_date=D(2020, 1, 1))]
+    rows = _fold(txns, cdp={"D05": _cdp((D(2020, 1, 1), -10000.0, 1000))}, price={10: 10.0})
+    assert _row(rows)["peak_car_sgd"] == 10000.0
+
+
+def test_a_sell_fee_does_not_move_the_peak():
+    """`_apply_txn` books a sell fee against proceeds, never `buy_cost`. On this book that is
+    inconsequential — 21 fee-bearing sell rows move 0 of 66 names, because a peak is set by a
+    buy — so the shape here deliberately puts the peak AFTER the fee-bearing sell, which is
+    the only arrangement where the wrong reading is visible at all."""
+    txns = [_txn(action="buy", qty_signed=100, price=10.0, trade_date=D(2020, 1, 1)),
+            _txn(action="sell", qty_signed=-40, price=15.0, trade_date=D(2021, 1, 1),
+                 fees=25.0),
+            _txn(action="buy", qty_signed=100, price=10.0, trade_date=D(2022, 1, 1))]
+    r = _row(_fold(txns, price={10: 12.0}))
+    assert r["peak_car_sgd"] == 1600.0                 # 160 units at 10.00, not at 10.125
+
+
+def test_the_peak_is_a_maximum_over_the_span_not_the_terminal_basis():
+    """The whole reason the series is replayed in date order: a position sold down reads its
+    peak, not what it happens to hold today."""
+    txns = [_txn(action="buy", qty_signed=1000, price=10.0, trade_date=D(2020, 1, 1)),
+            _txn(action="sell", qty_signed=-900, price=12.0, trade_date=D(2021, 1, 1))]
+    assert _row(_fold(txns, price={10: 12.0}))["peak_car_sgd"] == 10000.0
+
+
+# ---------------------------------------------------------------- rule 4: transfer matching
+
+def test_an_equal_and_opposite_transfer_pair_contributes_no_net_units():
+    """One ledger holds the same 2,800 shares twice for nine days: the FSM `transfer in` lands
+    before the matching CDP `sell/transfer_out` fires. Both legs drop, so the phantom plateau
+    never appears and the peak lands on a real one."""
+    txns = [_txn(account="CDP", action="open", qty_signed=2800, price=None,
+                 trade_date=D(2019, 1, 1)),
+            _txn(action="transfer in", qty_signed=2800, price=None, trade_date=D(2020, 3, 19)),
+            _txn(account="CDP", action="sell/transfer_out", qty_signed=-2800, price=None,
+                 trade_date=D(2020, 3, 28)),
+            _txn(action="buy", qty_signed=100, price=10.0, trade_date=D(2021, 1, 1))]
+    rows = _fold(txns, cdp={"D05": _cdp((D(2019, 1, 1), -28000.0, 2800))}, price={10: 10.0})
+    r = _row(rows)
+    assert r["units"] == 2900.0
+    assert r["peak_car_sgd"] == 29000.0                # not 56,000 + the phantom nine days
+
+
+def test_transfer_matching_is_leg_level_not_ticker_level():
+    """Z74's shape: an internal 20,000 round-trip AND an external -3,000 on one name. Netting
+    the three legs at ticker level swallows the external exit, so the position reads 3,000
+    units it no longer holds for the rest of its life — and the peak lands on them."""
+    txns = [_txn(action="buy", qty_signed=10000, price=1.0, trade_date=D(2019, 1, 1)),
+            _txn(action="transfer in", qty_signed=20000, price=None, trade_date=D(2020, 1, 1)),
+            _txn(action="sell/transfer_out", qty_signed=-20000, price=None,
+                 trade_date=D(2020, 1, 10)),
+            _txn(action="sell/transfer_out", qty_signed=-3000, price=None,
+                 trade_date=D(2020, 6, 1)),
+            _txn(action="buy", qty_signed=8000, price=1.0, trade_date=D(2021, 1, 1))]
+    r = _row(_fold(txns, price={10: 1.0}))
+    assert r["units"] == 15000.0
+    # 15,000 in 2021, not the 30,000 the unmatched round-trip fabricates in 2020, and not the
+    # 18,000 a ticker-level net leaves behind by swallowing the -3,000.
+    assert r["peak_car_sgd"] == 15000.0
+
+
+def test_an_internal_move_is_not_a_unit_entering_twice():
+    """Rule 4 reaches the costed share as well as the unit count. This position held 100 units
+    it paid for and 100 it did not, with a 2,800 internal round-trip passing through in
+    between — the same 2,800, held once. Counted as entering, they read 2,900 of 3,000 costed
+    and the share drifts to 0.97, which prices 200 units at 1,933.33 on a position whose
+    costed money is 1,000.
+
+    Excluding the arrival hands back the cover budget it would have spent on its own departure,
+    so the uncovered 100 stays `unknown` either way — only the ratio moves."""
+    txns = [_txn(action="buy", qty_signed=100, price=10.0, trade_date=D(2019, 1, 1)),
+            _txn(action="transfer in", qty_signed=2800, price=None, trade_date=D(2020, 1, 1)),
+            _txn(account="CDP", action="sell/transfer_out", qty_signed=-2800, price=None,
+                 trade_date=D(2020, 1, 10)),
+            _txn(action="transfer in", qty_signed=100, price=None, trade_date=D(2021, 1, 1))]
+    r = _row(_fold(txns, price={10: 10.0}))
+    assert r["units"] == 200.0
+    assert r["peak_car_sgd"] == 1000.0                 # not 1,933.33
+
+
+def test_an_unpaired_transfer_leg_is_untouched():
+    """All 21 unpaired transfer legs still land — AAPL's gift, C38U's 417, C31's 2,700 carry.
+    A transfer in with no matching out is units arriving, and the peak has to see them."""
+    txns = [_txn(action="buy", qty_signed=100, price=10.0, trade_date=D(2020, 1, 1)),
+            _txn(action="transfer in", qty_signed=100, price=None, trade_date=D(2021, 1, 1))]
+    r = _row(_fold(txns, price={10: 10.0}))
+    assert r["units"] == 200.0
+    # 200 units at the one average cost the book has (10.00), all of them covered by nothing —
+    # the cover rule leaves them `unknown`, so the costed share halves the term back to 1,000.
+    assert r["peak_car_sgd"] == 1000.0
+
+
+# ---------------------------------------------------------------- rule 5: where the span ends
+
+def test_the_span_ends_today_while_the_position_is_still_held():
+    """"Always last activity" undercharges 17 open names (Q01 3.4y against 8.8)."""
+    txns = [_txn(action="buy", qty_signed=100, price=10.0, trade_date=D(2020, 1, 1))]
+    assert _row(_fold(txns, price={10: 10.0}))["return_span_days"] == (TODAY - D(2020, 1, 1)).days
+
+
+def test_a_closed_position_span_ends_when_the_last_unit_left():
+    """"Always today" overcharges 27 of 31 closed names (BVA prints 9.2 years for a position
+    that ended after 0.3)."""
+    txns = [_txn(action="buy", qty_signed=100, price=10.0, trade_date=D(2020, 1, 1)),
+            _txn(action="sell", qty_signed=-100, price=12.0, trade_date=D(2021, 1, 1))]
+    r = _row(_fold(txns, price={10: 12.0}))
+    assert r["return_span_days"] == (D(2021, 1, 1) - D(2020, 1, 1)).days
+
+
+def test_a_closed_stock_with_an_open_contract_still_runs_to_today():
+    """`units > 0 OR a contract is open` — the same open/closed test `_is_open` already makes."""
+    txns = [_txn(action="buy", qty_signed=100, price=10.0, trade_date=D(2020, 1, 1)),
+            _txn(action="sell", qty_signed=-100, price=12.0, trade_date=D(2021, 1, 1))]
+    rows = _fold(txns, price={10: 12.0},
+                 contracts={"D05": [_put(open_date=D(2025, 1, 1), expiry_date=D(2026, 6, 1),
+                                         close_date=None, open=True)]})
+    assert _row(rows)["return_span_days"] == (TODAY - D(2020, 1, 1)).days
+
+
+def test_a_closed_position_span_ends_at_the_last_contract_resolution():
+    """Closed on both axes: the span ends at whichever resolved last, not at the stock exit."""
+    txns = [_txn(action="buy", qty_signed=100, price=10.0, trade_date=D(2020, 1, 1)),
+            _txn(action="sell", qty_signed=-100, price=12.0, trade_date=D(2021, 1, 1))]
+    rows = _fold(txns, price={10: 12.0},
+                 contracts={"D05": [_put(open_date=D(2021, 6, 1), expiry_date=D(2022, 6, 1),
+                                         close_date=None)]})
+    assert _row(rows)["return_span_days"] == (D(2022, 6, 1) - D(2020, 1, 1)).days
+
+
+# ---------------------------------------------------------------- rule 6: the costed share
+
+def test_the_stock_term_carries_only_the_costed_share():
+    """Half the units entered priced and half unpriced: the term is the money actually paid,
+    not the pooled average smeared back over units nobody paid for. Valuing the unknown half
+    at the pooled average would read 2,000."""
+    txns = [_txn(action="buy", qty_signed=100, price=10.0, trade_date=D(2020, 1, 1)),
+            _txn(action="buy", qty_signed=100, price=None, trade_date=D(2021, 1, 1))]
+    r = _row(_fold(txns, price={10: 10.0}))
+    assert r["cost_partition"] == {"units_in": 200.0, "costed": 100.0, "free": 0.0,
+                                   "unknown": 100.0, "unknown_pct": 0.5}
+    # 200 units at a pooled average of 10.00 (the unpriced lot books no cost), halved by the
+    # costed share the moment those units land — which is the money actually paid, 1,000.
+    assert r["peak_car_sgd"] == 1000.0
+
+
+def test_free_units_are_units_nobody_paid_for():
+    """A free lot moves both factors: it enters `buy_qty` at zero cost, diluting the pooled
+    average, and sits outside `costed`, shrinking the multiplier. Because both are read AT t,
+    a gift arriving in 2021 cannot reach back and shrink the 1,000 that was genuinely at risk
+    in 2020 — the peak stands where the money was paid."""
+    txns = [_txn(action="buy", qty_signed=100, price=10.0, trade_date=D(2020, 1, 1)),
+            _txn(action="gifted stock in", qty_signed=100, price=None,
+                 trade_date=D(2021, 1, 1))]
+    r = _row(_fold(txns, price={10: 10.0}))
+    assert r["cost_partition"]["free"] == 100.0
+    assert r["peak_car_sgd"] == 1000.0
+
+
+def test_the_costed_share_is_read_at_t_not_over_the_whole_history():
+    """The live case this rule exists for: 17,000 unpriced units re-enter one name in 2021 and
+    the peak was set fourteen months earlier. An undated share reads 25,096 against a measured
+    33,461 — it charges 2020's capital for a doubt that did not exist until 2021.
+
+    Here the peak is 1,000 either way; what an undated share would do is shave it to 500."""
+    txns = [_txn(action="buy", qty_signed=100, price=10.0, trade_date=D(2020, 1, 1)),
+            _txn(action="sell", qty_signed=-100, price=10.0, trade_date=D(2020, 6, 1)),
+            _txn(action="buy", qty_signed=100, price=None, trade_date=D(2021, 1, 1))]
+    r = _row(_fold(txns, price={10: 10.0}))
+    assert r["cost_partition"]["unknown"] == 100.0     # half the entering units, whole-history
+    assert r["peak_car_sgd"] == 1000.0
+
+
+# ---------------------------------------------------------------- the FX conversion
+
+def test_the_stock_term_and_the_collateral_both_convert_at_latest_fx():
+    """"at latest FX" is the same rate the rest of the app values on. Both terms cross it."""
+    txns = [_txn(currency="USD", action="buy", qty_signed=100, price=10.0,
+                 trade_date=D(2020, 1, 1))]
+    rows = _fold(txns, price={10: 10.0}, fx={"USD": 1.3},
+                 contracts={"D05": [_put(currency="USD", strike=20.0,
+                                         open_date=D(2020, 1, 1), expiry_date=D(2020, 6, 1))]})
+    assert _row(rows)["peak_car_sgd"] == round((1000.0 + 2000.0) * 1.3, 2)
+
+
+# ---------------------------------------------------------------- the percentage itself
+
+def test_the_percentage_is_net_over_peak_car():
+    txns = [_txn(action="buy", qty_signed=100, price=10.0, trade_date=D(2020, 1, 1))]
+    r = _row(_fold(txns, price={10: 13.0}, options={"D05": {"pl_sgd": 200.0}}))
+    assert r["peak_car_sgd"] == 1000.0
+    net = r["pl_sgd"] + r["options_pl_sgd"]            # 300 unrealised + 200 options
+    assert net == 500.0
+    assert r["return_pct"] == 0.5
+    assert r["return_verdict"] == "ok"
+
+
+def test_the_percentage_is_never_annualised():
+    """Two books identical but for their span read the same percentage. Annualising a ratio
+    whose denominator is a PEAK asserts the capital sat at peak for the whole span."""
+    def pct(bought):
+        txns = [_txn(action="buy", qty_signed=100, price=10.0, trade_date=bought)]
+        return _row(_fold(txns, price={10: 13.0}))["return_pct"]
+    assert pct(D(2016, 1, 1)) == pct(D(2025, 12, 1)) == 0.3
+
+
+def test_no_annualised_rate_is_on_the_wire_beside_the_return():
+    """§10: no XIRR anywhere on this page. The return fields are four, and none of them
+    annualises."""
+    r = _row(_fold([_txn(action="buy", qty_signed=100, price=10.0)], price={10: 13.0}))
+    assert {k for k in r if k.startswith("return_")} == {"return_pct", "return_span_days",
+                                                          "return_verdict"}
+
+
+def test_peak_car_date_is_absent_from_the_wire():
+    """Nothing renders it — the hero prints the amount, not the date. It lives in the ledger
+    audit's readings, which is where a figure pinned to a moving book belongs."""
+    r = _row(_fold([_txn(action="buy", qty_signed=100, price=10.0)], price={10: 13.0}))
+    assert "peak_car_date" not in r
+
+
+def test_a_negative_net_gives_a_negative_percentage_with_no_rule():
+    txns = [_txn(action="buy", qty_signed=100, price=10.0, trade_date=D(2020, 1, 1))]
+    r = _row(_fold(txns, price={10: 4.0}))
+    assert r["return_pct"] == -0.6
+    assert r["return_verdict"] == "ok"
+
+
+def test_there_is_no_materiality_floor():
+    """5E2 reads +104.5% over 2.3 years on peak capital of 1.54 — matched, and simply true.
+    No unargued threshold suppresses it."""
+    txns = [_txn(action="buy", qty_signed=1, price=1.54, trade_date=D(2023, 1, 1)),
+            _txn(action="sell", qty_signed=-1, price=3.15, trade_date=D(2025, 5, 1))]
+    r = _row(_fold(txns, price={10: 3.15}))
+    assert r["peak_car_sgd"] == 1.54
+    assert r["return_pct"] == round(1.61 / 1.54, 4)
+
+
+def test_there_is_no_minimum_span():
+    """No `MIN_XIRR_DAYS` equivalent is needed: nothing here annualises, so a one-day span
+    reads the same ratio a ten-year one does rather than exploding."""
+    txns = [_txn(action="buy", qty_signed=1, price=1.54, trade_date=D(2025, 12, 31)),
+            _txn(action="sell", qty_signed=-1, price=3.15, trade_date=TODAY)]
+    r = _row(_fold(txns, price={10: 3.15}))
+    assert r["return_span_days"] == 1
+    assert r["return_pct"] == round(1.61 / 1.54, 4)
+
+
+def test_a_tiny_stock_with_a_large_options_book_does_not_report_hundreds_of_percent():
+    """PLTR is that case — 5 units against 161k of gross buys — and reads +32.0%. The
+    collateral is the denominator, so a large options Net divides by the exposure that earned
+    it rather than by the sliver of stock left on the books."""
+    txns = [_txn(action="buy", qty_signed=5, price=100.0, trade_date=D(2020, 1, 1))]
+    r = _row(_fold(txns, price={10: 100.0}, options={"D05": {"pl_sgd": 30000.0}},
+                   contracts={"D05": [_put(strike=1000.0, contracts=1.0,
+                                           open_date=D(2021, 1, 1),
+                                           expiry_date=D(2022, 1, 1))]}))
+    assert r["peak_car_sgd"] == 100500.0               # 500 of stock under 100,000 of collateral
+    assert r["return_pct"] == round(30000.0 / 100500.0, 4)
+
+
+# ---------------------------------------------------------------- no capital at risk
+
+def test_no_capital_where_nothing_was_paid_for_and_no_collateral_was_locked():
+    """AAPL's shape: one unit of welcome gift, no options. Peak CAR is zero and the return does
+    not exist — undefined, not unmeasured."""
+    txns = [_txn(canonical_ticker="AAPL", account="Moomoo", action="gifted stock in",
+                 qty_signed=1, price=None, trade_date=D(2022, 12, 28))]
+    r = _row(_fold(txns, price={10: 300.0}), "AAPL")
+    assert r["peak_car_sgd"] == 0.0
+    assert r["return_verdict"] == "no_capital"
+    assert r["return_pct"] is None
+
+
+def test_peak_car_ships_as_a_measured_zero_never_null():
+    """The verdict, not the null, is what gates the render — so the field must carry the true
+    answer to "how much was at risk", which is zero."""
+    txns = [_txn(canonical_ticker="AAPL", account="Moomoo", action="gifted stock in",
+                 qty_signed=1, price=None, trade_date=D(2022, 12, 28))]
+    r = _row(_fold(txns, price={10: 300.0}), "AAPL")
+    assert r["peak_car_sgd"] is not None and r["peak_car_sgd"] == 0.0
+
+
+def test_a_free_lot_that_also_wrote_puts_reads_a_real_percentage():
+    """AMZN: `cost_known` is false and it still reads +1.7%. The live counterexample proving
+    the rule is peak CAR, not `cost_known` — the collateral was genuinely at risk, and the
+    gift added zero risk and some gain."""
+    txns = [_txn(canonical_ticker="AMZN", account="Moomoo", action="gifted stock in",
+                 qty_signed=3, price=None, trade_date=D(2022, 1, 1))]
+    rows = _fold(txns, price={10: 200.0}, fx={"USD": 1.0},
+                 contracts={"AMZN": [_put(strike=100.0, contracts=10.0,
+                                          open_date=D(2022, 6, 1),
+                                          expiry_date=D(2022, 12, 1))]})
+    r = _row(rows, "AMZN")
+    assert r["cost_partition"] == {"units_in": 3.0, "costed": 0.0, "free": 3.0,
+                                   "unknown": 0.0, "unknown_pct": 0.0}
+    assert r["peak_car_sgd"] == 100000.0
+    assert r["return_verdict"] == "ok"
+    assert r["return_pct"] == round(600.0 / 100000.0, 4)
+
+
+def test_a_refusal_reads_no_capital_too():
+    """ASTREA6B fires both verdicts: every entering unit is unknown, so the stock term is zero
+    and there is no collateral to stand in for it."""
+    txns = [_txn(canonical_ticker="ASTREA6B", account="CDP", action="open", qty_signed=15000,
+                 price=None, trade_date=D(2021, 1, 1))]
+    r = _row(_fold(txns), "ASTREA6B")
+    assert r["cost_partition"]["unknown"] == 15000.0
+    assert r["peak_car_sgd"] == 0.0
+    assert r["return_verdict"] == "no_capital"
+
+
+def test_the_percentage_caveats_when_some_entering_units_are_unknown():
+    """The error compounds — the numerator is an upper bound (unknown units assumed free) and
+    the denominator a lower bound (costed lots only) — so the percentage carries its own
+    verdict rather than reusing the Net's."""
+    txns = [_txn(action="buy", qty_signed=100, price=10.0, trade_date=D(2020, 1, 1)),
+            _txn(action="buy", qty_signed=100, price=None, trade_date=D(2021, 1, 1))]
+    r = _row(_fold(txns, price={10: 10.0}))
+    assert r["return_verdict"] == "caveat"
+    assert r["return_pct"] is not None                 # it still reads; it is not suppressed
+
+
+def test_a_missing_numerator_never_reads_ok():
+    """Capital at risk behind a name whose Net the book refuses: the denominator exists and the
+    numerator does not. `ok` beside a null percentage is the one combination a renderer
+    branching on the verdict cannot survive."""
+    txns = [_txn(canonical_ticker="ASTREA6B", account="CDP", action="open", qty_signed=15000,
+                 price=None, trade_date=D(2021, 1, 1))]
+    rows = _fold(txns, contracts={"ASTREA6B": [_put(open_date=D(2021, 6, 1),
+                                                    expiry_date=D(2021, 12, 1))]})
+    r = _row(rows, "ASTREA6B")
+    assert r["pl_sgd"] is None                         # no Net to divide
+    assert r["peak_car_sgd"] == 10000.0                # but real collateral was locked
+    assert r["return_pct"] is None
+    assert r["return_verdict"] == "caveat"
+
+
+# ---------------------------------------------------------------- whole-ticker, not per-leg
+
+def test_the_peak_is_whole_ticker_and_maxes_over_the_merged_series():
+    """No per-bucket percentage: the peak is a max over the SUM of the legs, which is not the
+    sum of their maxima. Here cash peaks in 2020 and cpf in 2022, and the merged series peaks
+    at neither leg's own maximum."""
+    txns = [_txn(action="buy", qty_signed=100, price=10.0, trade_date=D(2020, 1, 1)),
+            _txn(action="sell", qty_signed=-100, price=10.0, trade_date=D(2021, 1, 1)),
+            _txn(funding_bucket="cpf", account="CPF", account_id=2, security_id=11,
+                 action="buy", qty_signed=50, price=10.0, trade_date=D(2022, 1, 1))]
+    rows = _fold(txns, price={10: 10.0, 11: 10.0})
+    assert {r["peak_car_sgd"] for r in rows} == {1000.0}
+    assert {r["return_span_days"] for r in rows} == {(TODAY - D(2020, 1, 1)).days}
+
+
+def test_overlapping_legs_sum_before_the_max_is_taken():
+    """The other direction of the same rule: two legs held at once are one exposure."""
+    txns = [_txn(action="buy", qty_signed=100, price=10.0, trade_date=D(2020, 1, 1)),
+            _txn(funding_bucket="cpf", account="CPF", account_id=2, security_id=11,
+                 action="buy", qty_signed=50, price=10.0, trade_date=D(2022, 1, 1))]
+    rows = _fold(txns, price={10: 10.0, 11: 10.0})
+    assert {r["peak_car_sgd"] for r in rows} == {1500.0}

--- a/tests/test_performance_fold.py
+++ b/tests/test_performance_fold.py
@@ -289,7 +289,10 @@ def test_non_cash_carry_replays_cost_and_quantity_at_the_original_dates():
 
 
 # /api/positions splats the fold's row wholesale (`{**r, "status": ...}`), so a field added to
-# the row is a field added to the endpoint. This is the whole key set as it shipped before #147.
+# the row is a field added to the endpoint. This is the whole key set: #147's dated series is
+# deliberately NOT in it, #148 traded `uncosted_units` for `cost_partition`, and #152 added the
+# four return fields — and `peak_car_date` is deliberately not among them (#143 Further Notes:
+# nothing on the page renders it, and absent beats null for a field with no consumer).
 ROW_FIELDS = {
     "bucket", "accounts", "ticker", "name", "market", "asset_type", "currency", "units", "price",
     "mv_native", "avg_cost", "cost_basis_native", "cost_basis_sgd", "unrealised_pl_sgd",
@@ -297,6 +300,7 @@ ROW_FIELDS = {
     "cost_known",
     "cost_partition", "total_pl_native", "invested_sgd", "mv_sgd", "income_sgd", "pl_sgd",
     "xirr", "simple_return", "options_pl_sgd",
+    "peak_car_sgd", "return_span_days", "return_pct", "return_verdict",
 }
 
 

--- a/tests/test_performance_live.py
+++ b/tests/test_performance_live.py
@@ -16,6 +16,7 @@ Skips cleanly when no Postgres answers — the normal state of a checkout that h
 
     PYTHONPATH=. .venv/bin/python -m pytest tests/test_performance_live.py -q
 """
+import datetime as dt
 import os
 import sys
 import unittest
@@ -25,8 +26,11 @@ import pytest
 from sqlalchemy import text
 from sqlalchemy.exc import SQLAlchemyError
 
+from portfolio.cost_annotations import annotation_map
 from portfolio.db import session_scope
-from portfolio.performance import compute, rollup
+from portfolio.options import contracts_by_ticker
+from portfolio.performance import (_accumulate_positions, _fx_and_price, cdp_cost, compute,
+                                   legs_by_ticker, rollup, ticker_car)
 
 # The ledger #148 was measured against: 548 txn rows / 73 positions. The totals below are
 # readings of THAT book and nothing else.
@@ -34,6 +38,36 @@ MEASURED_TXN_ROWS = 548
 MEASURED = {"units_in": 1_574_652, "costed": 1_521_274, "free": 545, "unknown": 52_833}
 MEASURED_CAVEAT = [("S51", 0.4), ("SET", 0.2786), ("Q01", 0.25), ("C38U", 0.0746)]
 MEASURED_REFUSAL = ["ASTREA6B"]
+
+# #143 §9's settled peak capital-at-risk, one row per name the spec pinned. The DATE a peak
+# falls on is a pure function of the ledger — every leg of these names is single-currency, so
+# latest FX scales the whole series and cannot re-rank it — which makes the date the durable
+# half of the reading, and it is asserted whatever the FX table says. The AMOUNT is a reading
+# of a rate as well as of a book, so the two USD names are gated on MEASURED_FX below the way
+# every other figure here is gated on the row count: pinned while the rate is the one they
+# were read at, skipped rather than loosened once it moves.
+#
+# O5RU is the one name whose settled AMOUNT this build does not reproduce, and it is recorded
+# rather than normalised. §9 rule 4 states the transfer-phantom correction takes it
+# "79,972.84 -> 55,137.42" and says the peak "moves off the artifact onto a real plateau";
+# 55,137.42 is what a dated replay produces, on 2023-07-03, where the cash leg holds 37,800
+# units costing 49,335.42 beside an SRS leg of 5,802.00. The settled table's 39,986.42 is the
+# series' value on 2019-12-28 — exactly the CDP cost pool, before a 5,000-unit buy in 2020 and
+# a 3,710-unit rights issue in 2023 — and is also exactly half the withdrawn phantom, which is
+# what halving the artifact gives rather than what recomputing the peak gives. The two
+# statements in §9 disagree; this follows rule 4's own paragraph.
+MEASURED_FX = {"USD": 1.281, "HKD": 0.1633}     # fx_rate's newest row when these were read
+MEASURED_PEAK_CAR = {
+    "PLTR": (218_495.04, dt.date(2024, 1, 2)),
+    "D05": (96_440.20, dt.date(2020, 3, 16)),
+    "TSLA": (94_473.75, dt.date(2026, 6, 11)),
+    "Q01": (33_461.35, dt.date(2020, 2, 27)),
+    "O5RU": (55_137.42, dt.date(2023, 7, 3)),
+    "S51": (1_767.92, dt.date(2021, 9, 22)),
+    "AAPL": (0.0, None),
+}
+MEASURED_IN_SGD = {"D05", "Q01", "O5RU", "S51", "AAPL"}      # rate-independent either way
+MEASURED_NO_CAPITAL = ["AAPL", "HMN"]
 
 
 def _rows_or_skip():
@@ -238,6 +272,105 @@ class TestLiveBook(unittest.TestCase):
                    if r["cost_known"] and r["cost_partition"]["unknown"] > 0)
         got = sum(v["unsplit_pl_sgd"] for v in rollup(self.rows, "bucket").values())
         self.assertAlmostEqual(got, want, delta=0.01)
+
+    def test_peak_capital_at_risk_reproduces_the_settled_figures(self):
+        """The question the spec says a build session needs to be able to ask: does the peak
+        come out where it was measured? All seven dates and six of the seven amounts reproduce
+        to the cent; the seventh is O5RU, recorded above."""
+        self._measured_book_or_skip()
+        at_measured_fx = _fx_or_none() == MEASURED_FX
+        car = _live_ticker_car()
+        for ticker, (peak, on) in MEASURED_PEAK_CAR.items():
+            got = car[ticker]
+            self.assertEqual(got["peak_car_date"], on, ticker)
+            if peak is not None and (at_measured_fx or ticker in MEASURED_IN_SGD):
+                self.assertAlmostEqual(got["peak_car_sgd"], peak, 2, ticker)
+        if not at_measured_fx:
+            raise unittest.SkipTest("fx_rate has moved since these amounts were read — the "
+                                    "dates and the SGD names were still asserted")
+
+    def test_peak_car_ships_as_a_measured_zero_and_the_verdict_gates_the_render(self):
+        """True of any book: the field is never null, so nothing downstream can mistake "no
+        capital was ever at risk" for "nobody computed it"."""
+        for r in self.rows:
+            self.assertIsNotNone(r["peak_car_sgd"], r["ticker"])
+            self.assertIn(r["return_verdict"], ("ok", "caveat", "no_capital"), r["ticker"])
+            if r["return_verdict"] == "no_capital":
+                self.assertEqual(r["peak_car_sgd"], 0.0, r["ticker"])
+                self.assertIsNone(r["return_pct"], r["ticker"])
+
+    def test_no_capital_fires_on_the_windfalls_and_not_on_the_gift_that_wrote_puts(self):
+        """The live counterexample proving the rule is peak CAR and not `cost_known`: AMZN's
+        entering units are 100% free and it still reads a real positive percentage, because
+        41,000 USD of put collateral was genuinely at risk behind them."""
+        self._measured_book_or_skip()
+        held = {r["ticker"]: r for r in self.rows}
+        fired = sorted(r["ticker"] for r in self.rows
+                       if r["return_verdict"] == "no_capital" and r["cost_partition"]["free"])
+        self.assertEqual(fired, MEASURED_NO_CAPITAL)
+        amzn = held["AMZN"]
+        self.assertEqual(amzn["cost_partition"]["free"], amzn["cost_partition"]["units_in"])
+        self.assertEqual(amzn["return_verdict"], "ok")
+        self.assertGreater(amzn["return_pct"], 0)
+
+    def test_the_percentage_is_net_over_peak_car_on_every_ticker(self):
+        """True of any book, and the one arithmetic claim the hero makes. Summed across a
+        ticker's legs, because the figure is whole-ticker: on the one name held in three
+        buckets a per-leg reading is a different number entirely (3.9% against 31.2%)."""
+        by_ticker = {}
+        for r in self.rows:
+            g = by_ticker.setdefault(r["ticker"], {"net": 0.0, "row": r})
+            # both nulls read as nothing-to-add, for different reasons: `options_pl_sgd` is
+            # absent on a never-optioned name (#149), `pl_sgd` refuses on a doubted leg.
+            g["net"] += (r["pl_sgd"] or 0.0) + (r["options_pl_sgd"] or 0.0)
+        for ticker, g in by_ticker.items():
+            r = g["row"]
+            if r["return_pct"] is None:
+                continue
+            self.assertAlmostEqual(r["return_pct"], round(g["net"] / r["peak_car_sgd"], 4), 4,
+                                   ticker)
+
+    def test_the_return_fields_agree_across_every_leg_of_a_ticker(self):
+        """They are whole-ticker figures riding on per-leg rows, so a consumer holding any one
+        leg has the whole-ticker answer — and the four must never disagree between legs."""
+        seen = {}
+        for r in self.rows:
+            got = {k: r[k] for k in ("peak_car_sgd", "return_span_days", "return_pct",
+                                     "return_verdict")}
+            self.assertEqual(seen.setdefault(r["ticker"], got), got, r["ticker"])
+
+
+def _fx_or_none():
+    """The newest fx_rate row as `{currency: rate}` — what "at latest FX" resolved to."""
+    with session_scope() as s:
+        return {c: float(r) for c, r in s.execute(text(
+            "SELECT currency, rate_to_sgd FROM fx_rate "
+            "WHERE date = (SELECT max(date) FROM fx_rate)")).all()}
+
+
+def _live_ticker_car():
+    """`ticker_car` over the live book, keyed by ticker — the peak DATE never reaches the wire
+    (#143 Further Notes), so reading it means going through the accumulators."""
+    today = dt.date.today()
+    with session_scope() as s:
+        fx, _ = _fx_and_price(s)
+        txns = [dict(r) for r in s.execute(text("""
+            SELECT t.account_id, a.name account, a.funding_bucket, t.security_id,
+                   sec.canonical_ticker, sec.name, sec.market, sec.asset_type, sec.currency,
+                   t.trade_date, t.action, t.qty_signed, t.price, t.gross_amount, t.fees
+            FROM txn t JOIN account a ON a.id=t.account_id
+            JOIN security sec ON sec.id=t.security_id""")).mappings().all()]
+        divs = [dict(r) for r in s.execute(text(
+            "SELECT account_id, security_id, pay_date, gross, currency FROM dividend"
+        )).mappings().all()]
+        cdp = cdp_cost(s)
+        corp = s.execute(text(
+            "SELECT from_ticker, to_ticker, type FROM corporate_action "
+            "WHERE type IN ('rename','split','consolidation','merger','switch')")).all()
+    pos, meta = _accumulate_positions(txns, divs, cdp, corp, today, annotation_map())
+    contracts = contracts_by_ticker()
+    return {tk: ticker_car(ls, contracts.get(tk, ()), fx, today)
+            for tk, ls in legs_by_ticker(pos, meta).items()}
 
 
 if __name__ == "__main__":

--- a/web/src/modules/portfolio/SecurityDetail.jsx
+++ b/web/src/modules/portfolio/SecurityDetail.jsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from "react";
-import { get, fmt, sgd, money, pct, cls } from "../../api.js";
+import { get, fmt, sgd, money, cls } from "../../api.js";
 import { Cards, RowCard, usePhone } from "../../cards.jsx";
 import { ContractCell } from "./contract.jsx";
 
@@ -47,7 +47,19 @@ export default function SecurityDetail({ ticker, bucket, onBack }) {
         <Tile lbl="Unrealised P/L" val={s.unrealised_pl_sgd == null ? "n/a" : sgd(s.unrealised_pl_sgd)} cls={cls(s.unrealised_pl_sgd)} />
         <Tile lbl="Dividends" val={sgd(divTotalSgd)} cls="pos" />
         {opts.length > 0 && <Tile lbl="Options P/L" val={sgd(optPlSgd)} cls={cls(optPlSgd)} />}
-        <Tile lbl="XIRR" val={s.xirr == null ? "—" : pct(s.xirr)} cls={cls(s.xirr)} />
+        {/* No XIRR tile, and nothing backfills its slot — no filler, no rebalanced grid (#143
+            §10). An annualised rate is not the same claim as a lifetime return and no label
+            reconciles them: across the 58 non-optioned legs carrying one, the two differ by a
+            median 20 points and up to 367, and on two names the tile read a NEGATIVE rate
+            beside a five-figure positive Net. The server now ships `return_pct` — a lifetime
+            total on peak capital-at-risk, with its span and its peak — which the hero states
+            instead, one tier up from here.
+
+            Page-local. `Holdings.jsx` keeps its XIRR column, because it pairs XIRR with a Net
+            column rather than with a lifetime hero percentage, and `Overview.jsx`'s
+            portfolio-wide annualised return is a different computation entirely (twr.py).
+            Trigger: if Holdings ever gains the hero percentage, its column falls under this
+            same argument. */}
       </div>
 
       <div className="card" style={{ marginBottom: 18 }}>


### PR DESCRIPTION
Closes #152. Spec #143 §9 and §10.

One return figure per name, and the denominator that earns it. `peak_car_sgd`,
`return_span_days`, `return_pct` and `return_verdict` ship server-computed on every position
row; the XIRR tile leaves the ticker detail page with nothing backfilled.

```
CAR(t) = costed stock basis at t
       + Σ strike × contracts × multiplier over short PUTS open at t,   at latest FX
peak_car_sgd = max CAR(t)   over first event → today (held) or last resolution (closed)
```

## The six rules, and the one that is not written where you would look for it

Each rule is gated independently against fabricated rows, one gate per rule, each shaped so the
wrong reading gives a *different number* rather than merely a wrong sign. 13 mutants of the six
rules, all 13 killed.

**The costed share is read at `t`, not over the whole history.** §9 writes the multiplier
undated, but the sentence above it says every term is replayed in date order, and the book
settles it: undated, Q01 reads 25,096 against its measured 33,461, because 17,000 unpriced units
re-entered in 2021 and the peak was set fourteen months earlier. A gift in 2021 cannot shrink
capital that was at risk in 2020. This is why `cost_partition` was restructured into
`_resolved_entries` — the three position-level resolutions become budgets spent earliest-first,
which is what gives every resolved unit a **date** as well as a condition. The partition's own
output is byte-identical to #148's.

**Rule 4 reaches the costed share too, not just the unit count.** A matched internal move's
arrival was still landing in the share's denominator, pulling it toward 1 on exactly the mixed
shape rule 4 exists for — 1,933.33 where 1,000 is right. Zero-instance live, gated anyway.

## The settled figures

Six of seven peaks reproduce to the cent and **all seven dates** do: PLTR 218,495.04
@2024-01-02, D05 96,440.20 @2020-03-16, TSLA 94,473.75 @2026-06-11, Q01 33,461.35 @2020-02-27,
S51 1,767.92 @2021-09-22, AAPL 0.00. Spans are exact at the spec's measurement window. The USD
amounts are guarded on `fx_rate` as well as the ledger size, so a moved rate skips rather than
lies.

**O5RU disagrees with the settled table, deliberately.** The table says 39,986.42; §9 rule 4's
own paragraph says the transfer fix takes it "79,972.84 → 55,137.42" and moves the peak "onto a
real plateau". 55,137.42 is what a dated replay gives, on 2023-07-03 (cash 49,335.42 + SRS
5,802.00). The table's figure is exactly the phantom halved, and is the series' value before a
2020 buy and a 2023 rights issue. Following the paragraph over the table, and recording the
disagreement in the live test rather than normalising it away.

## Degenerate cases and what the page does not get

`no_capital` lands on the two pure-windfall names (AAPL, HMN) and **not** on the gifted name
that also wrote puts (AMZN). `peak_car_sgd` ships as a measured `0`, never null — that is the
true answer to "how much was at risk" — and **the verdict, not the null, gates the render**.
No minimum span and no materiality floor: nothing annualises, so nothing explodes at a short
span, and O39's +264% and 5E2's +104.6% on peak capital of 1.54 are reported rather than
suppressed by an unargued threshold.

`peak_car_date` is computed and deliberately **absent from the wire**. The collateral-locked
options-inclusive XIRR named out of scope is not reachable by accident: nothing on this page
annualises anything.

## The XIRR removal

Median divergence 20 points, up to 367; two names show a negative rate beside a five-figure
positive Net. Holdings keeps its XIRR column — it pairs XIRR with a Net column, not a lifetime
hero percentage — and `/api/return`'s portfolio-wide `xirr_annualised` is untouched. The
page-local trigger for revisiting is recorded in `SecurityDetail.jsx`.

## Rebase onto #149

Stacked originally on #148; rebased onto `50b6aca` after #148 and #149 both merged. Three
conflicts in `performance.py`, all resolved toward main:

- **`cost_carried` → `carried_units`.** #149's dated bound is adopted inside the earliest-first
  budget. Verified by direct comparison that the merged code and main's own formula give an
  identical partition on all 73 legs.
- **`options_pl_sgd` now nulls on a never-optioned name.** Guarded. The two nulls mean opposite
  things and are commented as such: absent options contribute nothing and the name still gets a
  percentage, while a null `pl_sgd` is the stock stream *refusing* and forces `caveat` — the one
  thing that must never happen is a renderer reading `ok` and printing a null as a percentage.
- **Net is still built from `pl_sgd`**, not #149's `stock_pl_sgd + income_sgd`. Same sum wherever
  both exist, but the identity keeps a value on a refusing leg, so adopting it would have moved
  the four caveat names' percentages as a side effect of a rebase. That unification is #150's,
  and is noted there.

## Two tests are red on this branch and neither is from this work

`test_the_book_totals` and `test_the_caveat_set_and_the_refusal_set` fail identically on a clean
`origin/main` worktree against the same 548-row book. #149's dated carry bounds arrivals to
`day <= max(close_dates)`, and a switch's two legs are never same-day — `0P0001OOJG`'s
predecessor closes 2023-04-24, its `switch_in` arrives 2023-04-27, so the one arrival the carry
exists to cover is the one excluded. Filed as **#164**, not fixed here: the fix moves cost
partitions, and cost partitions are this PR's denominator.

## Verification

- `tests/test_peak_car.py` — 38 tier-1 gates, no DB, one per rule plus every percentage claim
- 564 passed / 2 failed (both #164, pre-existing on main); ruff clean
- Playwright 1500 passed / 477 skipped / 0 failed
- `compute()` 0.123 s for 73 rows

https://claude.ai/code/session_01VVWR65pnaYG6f6VRngEga7


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added peak capital-at-risk, return percentage, return span, and return verdict metrics to position data.
  - Added support for option collateral, stock costs, transfers, corporate actions, and unknown-cost caveats in return calculations.
  - Added live performance coverage for the new metrics.

- **Bug Fixes**
  - Corrected capital exposure calculations across dated transactions and option lifecycles.
  - Removed the XIRR summary from security detail views.

- **Documentation**
  - Documented metric formulas, data fields, calculation rules, and return terminology.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->